### PR TITLE
Add pytest plugin

### DIFF
--- a/pytest.py
+++ b/pytest.py
@@ -1,0 +1,5 @@
+from dynaconf import settings
+
+
+def pytest_configure(config):
+    settings.configure(FORCE_ENV_FOR_DYNACONF="testing")

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,12 @@ setup(
         "test": test_requirements,
     },
     python_requires=">=3.7",
-    entry_points={"console_scripts": ["dynaconf=dynaconf.cli:main"]},
+    entry_points={
+        "console_scripts": ["dynaconf=dynaconf.cli:main"],
+        "pytest11": [
+            "dynaconf = dynaconf.pytest",
+        ],
+    },
     setup_requires=["setuptools>=38.6.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I'm not sure if this is appropriate for this project, but I thought I would send a pull request just in case. When I run my automated tests with Pytest, one of the _first_ things I want to do is set the Dynaconf environment to "testing", _before_ I import code from my project being tested, since there could be logic in there that is dependent on which Dynaconf environment is active. Fortunately, [Pytest has a robust plugin system](https://docs.pytest.org/en/latest/how-to/writing_plugins.html), and we can write a Pytest plugin that does exactly that!

This plugin will be automatically picked up by Pytest: there's no installation necessary beyond installing Dynaconf. I don't know if that's the desired behavior or not; if not, we could always package this in a separate project, [like I just did in the `singingwolfboy/pytest-dynaconf` repo](https://github.com/singingwolfboy/pytest-dynaconf). But if the Dynaconf project is willing to accept this change, then I can archive that repo, since it's not useful anymore.