### PR TITLE
Fix cli init command for flask (#705)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ test_examples:
 	cd example/issues/722_docs_example;pwd;python app.py
 	cd example/issues/729_use_default_when_setting_is_blank;pwd;python app.py
 	cd example/issues/741_envvars_ignored;pwd;sh recreate.sh
+	cd example/issues/705_flask_dynaconf_init;pwd;make test;make clean
 
 test_vault:
 	# @cd example/vault;pwd;python write.py

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -52,9 +52,10 @@ def set_settings(ctx, instance=None):
     elif "FLASK_APP" in os.environ:  # pragma: no cover
         with suppress(ImportError, click.UsageError):
             from flask.cli import ScriptInfo  # noqa
+            from dynaconf import FlaskDynaconf
 
             flask_app = ScriptInfo().load_app()
-            settings = flask_app.config
+            settings = FlaskDynaconf(flask_app, **flask_app.config).settings
             click.echo(
                 click.style(
                     "Flask app detected", fg="white", bg="bright_black"

--- a/example/issues/705_flask_dynaconf_init/Makefile
+++ b/example/issues/705_flask_dynaconf_init/Makefile
@@ -1,0 +1,12 @@
+.PHONY: test clean
+
+export FLASK_APP=app:create_app
+
+test: clean
+	dynaconf init -v test_var
+	grep '\[development\]' settings.toml
+
+clean:
+	rm -rf settings.toml
+	rm -rf .secrets.toml
+	rm -rf .gitignore

--- a/example/issues/705_flask_dynaconf_init/app.py
+++ b/example/issues/705_flask_dynaconf_init/app.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from flask import Blueprint
+from flask import Flask
+
+blueprint = Blueprint("default", __name__)
+
+
+@blueprint.route("/")
+def index():
+    return "Default route."
+
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["ENV"] = "development"
+    return app


### PR DESCRIPTION
Fixed the problem with the init cli command when the FLASK_APP variable is set. Now cli warps the app and app.config objects and pass settings object to the init call. 

Added also simple example how to reproduce this problem. 