### PR TITLE
Bump codecov action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
           check_name: Test Results (Python ${{ matrix.python-version }})
       - name: "Upload coverage to Codecov"
         if: ${{ matrix.python-version == '3.8' }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
 


### PR DESCRIPTION
Looks like the codecov action v1 is deprecated (see https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1). Bumping to the v3. 