### PR TITLE
Feature/detect casting comb token from converters

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -309,7 +309,7 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
     ):
         # Check combination token is used
         comb_token = re.match(
-            r"^@(str|int|float|bool|json) @(jinja|format)", data
+            f"^({'|'.join(converters.keys())}) @(jinja|format)", data,
         )
         if comb_token:
             tokens = comb_token.group(0)

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -309,7 +309,8 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
     ):
         # Check combination token is used
         comb_token = re.match(
-            f"^({'|'.join(converters.keys())}) @(jinja|format)", data,
+            f"^({'|'.join(converters.keys())}) @(jinja|format)",
+            data,
         )
         if comb_token:
             tokens = comb_token.group(0)

--- a/example/custom_cast_token/app.py
+++ b/example/custom_cast_token/app.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dynaconf import Dynaconf
+from dynaconf.utils import parse_conf
+
+settings = Dynaconf(
+    envvar_prefix="DYNACONF",
+    settings_files=["settings.toml"],
+    environments=True,
+)
+
+# Add a custom casting token casting string to pathlib.Path object
+parse_conf.converters["@path"] = (
+    lambda value: value.set_casting(Path)
+    if isinstance(value, parse_conf.Lazy)
+    else Path(value)
+)
+
+assert isinstance(settings.parent, Path)
+assert isinstance(settings.child, Path)
+assert str(settings.child).find("@format") == -1

--- a/example/custom_cast_token/settings.toml
+++ b/example/custom_cast_token/settings.toml
@@ -1,0 +1,3 @@
+[default]
+parent = "@path @format {env[HOME]}/parent"
+child = "@path @format {this.parent}/child"


### PR DESCRIPTION
Hi,

first of all: thanks for this amazing library. This makes life a lot easier.

## Main

I have a suggestion, but I can not see all the implications it has. What I suggest is to suggest to change the regex that detects whether two casting tokens are used in one variable definition. I think it would be nice if this regex is generated dynamically based on the values in the "converters" dict. What this allows is that a user could add a custom casting token. For instance, I wanted a casting token that would cast the string to a pathlib.Path object (see example/custom_cast_token):


```python
# app.py

from dynaconf.utils import parse_conf

parse_conf.converters["@path"] = (
    lambda value: value.set_casting(Path)
    if isinstance(value, parse_conf.Lazy)
    else Path(value)
)
```

```toml
#settings.toml

some_path = "@path /home/john/foo.txt"

```

This last thing would also work without changing the regex. But it becomes a problem when I would like to do something like:

```toml
# settings.toml

parent = "@path @format {env[HOME]}/parent"
child = "@path @format {this.parent}/child"
```

The regex as it is now does not pick up "@path @format" and therefore does not do the format step. This PR would solve that.

As as note. I also, found another solution that does not require changing Dynaconf:

```python
# app.py
parse_conf.converters["@path"] = lambda value: parse_conf.Lazy(value).set_casting(UPath)
```

with the following:

```toml
# settings.toml
parent = "@path @format {env[HOME]}/parent"
child = "@path @format {this.parent}/child"
```

but this feels slightly hacky and would not allow to have casting to path without also formatting (which the Lazy does).

## Tests
Before submitting this pull request I ran "make test_only" and that all passes. I also ran "make all", there I ran into some "maximum recursion depth reached" error. I already had this problem before making any changes though. I followed https://github.com/dynaconf/dynaconf/blob/master/CONTRIBUTING.md , but I must be doing something wrong. I have a similar (but not exactly the same) Traceback when I don't initialize settings like this:

```python
settings = Dynaconf(
    envvar_prefix="DYNACONF",
    settings_files=["settings.toml"],
    environments=True,
)
```

but import them like I see in the other examples:

```python
from dynaconf import settings
```





