### PR TITLE
New data key casing must adapt to existing key casing

### DIFF
--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import inspect
 from functools import wraps
 
+from dynaconf.utils import find_the_correct_casing
 from dynaconf.utils import recursively_evaluate_lazy_format
-from dynaconf.utils import upperfy
 from dynaconf.utils.functional import empty
 from dynaconf.vendor.box import Box
 
@@ -37,7 +37,7 @@ class DynaBox(Box):
         try:
             return super().__getattr__(item, *args, **kwargs)
         except (AttributeError, KeyError):
-            n_item = item.lower() if item.isupper() else upperfy(item)
+            n_item = find_the_correct_casing(item, self) or item
             return super().__getattr__(n_item, *args, **kwargs)
 
     @evaluate_lazy_format
@@ -45,7 +45,7 @@ class DynaBox(Box):
         try:
             return super().__getitem__(item, *args, **kwargs)
         except (AttributeError, KeyError):
-            n_item = item.lower() if item.isupper() else upperfy(item)
+            n_item = find_the_correct_casing(item, self) or item
             return super().__getitem__(n_item, *args, **kwargs)
 
     def __copy__(self):
@@ -60,22 +60,11 @@ class DynaBox(Box):
             box_settings=self._box_config.get("box_settings"),
         )
 
-    def _case_insensitive_get(self, item, default=None):
-        """adds a bit of overhead but allows case insensitive get
-        See issue: #486
-        """
-        lower_self = {k.casefold(): v for k, v in self.items()}
-        return lower_self.get(item.casefold(), default)
-
     @evaluate_lazy_format
     def get(self, item, default=None, *args, **kwargs):
-        if item not in self:  # toggle case
-            item = item.lower() if item.isupper() else upperfy(item)
-        value = super().get(item, empty, *args, **kwargs)
-        if value is empty:
-            # see Issue: #486
-            return self._case_insensitive_get(item, default)
-        return value
+        n_item = find_the_correct_casing(item, self) or item
+        value = super().get(n_item, empty, *args, **kwargs)
+        return value if value is not empty else default
 
     def __dir__(self):
         keys = list(self.keys())


### PR DESCRIPTION
existing data is

```yaml
level1:
    KeY4:
```

envvars is

```console
$ export DYNACONF_LEVEL1__KEY4=foo
```

Then

```
settings._store
# must have a `KeY4` = "foo"
# instead of KEY4 = "foo"
```

Fix #737