### PR TITLE
feat: Add hookable functions

### DIFF
--- a/dynaconf/__init__.py
+++ b/dynaconf/__init__.py
@@ -4,6 +4,7 @@ from dynaconf.base import LazySettings  # noqa
 from dynaconf.constants import DEFAULT_SETTINGS_FILES
 from dynaconf.contrib import DjangoDynaconf  # noqa
 from dynaconf.contrib import FlaskDynaconf  # noqa
+from dynaconf.utils.parse_conf import FormattingError
 from dynaconf.validator import ValidationError  # noqa
 from dynaconf.validator import Validator  # noqa
 
@@ -28,4 +29,5 @@ __all__ = [
     "FlaskDynaconf",
     "ValidationError",
     "DjangoDynaconf",
+    "FormattingError",
 ]

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 from pathlib import Path
 
 from dynaconf import default_settings
+from dynaconf.hooking import hookable
 from dynaconf.loaders import default_loader
 from dynaconf.loaders import enable_external_loaders
 from dynaconf.loaders import env_loader
@@ -372,6 +373,7 @@ class Settings:
 
         return value
 
+    @hookable
     def as_dict(self, env=None, internal=False):
         """Returns a dictionary with set key and values.
 
@@ -415,6 +417,7 @@ class Settings:
             ".".join(keys), default=default, parent=result, cast=cast, **kwargs
         )
 
+    @hookable
     def get(
         self,
         key,
@@ -833,6 +836,7 @@ class Settings:
             )
         self.update(data=new_data, tomlfy=tomlfy, **kwargs)
 
+    @hookable
     def set(
         self,
         key,
@@ -917,6 +921,7 @@ class Settings:
             # a default value and goes away only when explicitly unset
             self._defaults[key] = value
 
+    @hookable
     def update(
         self,
         data=None,
@@ -1004,6 +1009,7 @@ class Settings:
         self.clean()
         self.execute_loaders(env, silent)
 
+    @hookable(name="loaders")
     def execute_loaders(
         self, env=None, silent=None, key=None, filename=None, loaders=None
     ):
@@ -1054,6 +1060,7 @@ class Settings:
             if last_loader and last_loader == env_loader:
                 last_loader.load(self, env, silent, key)
 
+    @hookable
     def load_file(self, path=None, env=None, silent=True, key=None):
         """Programmatically load files from ``path``.
 
@@ -1180,6 +1187,7 @@ class Settings:
             value = self.get_fresh(key)
             return value is True or value in true_values
 
+    @hookable
     def populate_obj(self, obj, keys=None, ignore=None):
         """Given the `obj` populate it using self.store items.
 

--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -27,6 +27,7 @@ import os
 import sys
 
 import dynaconf
+from dynaconf.hooking import HookableSettings
 
 try:  # pragma: no cover
     from django import conf
@@ -73,6 +74,7 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
     options.setdefault(
         "default_settings_paths", dynaconf.DEFAULT_SETTINGS_FILES
     )
+    options.setdefault("_wrapper_class", HookableSettings)
 
     class UserSettingsHolder(dynaconf.LazySettings):
         _django_override = True

--- a/dynaconf/hooking.py
+++ b/dynaconf/hooking.py
@@ -18,7 +18,11 @@ __all__ = [
 ]
 
 
-EMPTY_VALUE = object()
+class Empty:
+    ...
+
+
+EMPTY_VALUE = Empty()
 
 
 def hookable(function=None, name=None, before=True, after=True):
@@ -200,6 +204,30 @@ class HookValue:
             super().__setattr__(key, value)
         else:
             setattr(self.value, key, value)
+
+    def __add__(self, other):
+        return self.value + other
+
+    def __sub__(self, other):
+        return self.value - other
+
+    def __mul__(self, other):
+        return self.value * other
+
+    def __truediv__(self, other):
+        return self.value / other
+
+    def __floordiv__(self, other):
+        return self.value // other
+
+    def __mod__(self, other):
+        return self.value % other
+
+    def __divmod__(self, other):
+        return divmod(self.value, other)
+
+    def __pow__(self, power, modulo=None):
+        return pow(self.value, power, modulo)
 
     def __delattr__(self, item):
         delattr(self.value, item)

--- a/dynaconf/hooking.py
+++ b/dynaconf/hooking.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from enum import Enum
+from functools import wraps
+from typing import Any
+from typing import Callable
+
+__all__ = [
+    "hookable",
+    "EMPTY_VALUE",
+    "Hook",
+    "EagerValue",
+    "HookValue",
+    "MethodValue",
+    "Action",
+]
+
+
+EMPTY_VALUE = object()
+
+
+def hookable(function=None, name=None, before=True, after=True):
+    """Adds before and after hooks to any method.
+
+    :param function: function to be decorated
+    :param name: name of the method to be decorated (default to method name)
+    :param before: if before hooks should be executed
+    :param after: if after hooks should be executed
+    :return: decorated function
+
+    Usage: see tests/test_hooking.py for more examples.
+    """
+
+    if function and not callable(function):
+        raise TypeError("hookable must be applied with named arguments only")
+
+    def dispatch(fun, *args, **kwargs):
+        """calls the decorated function and its hooks"""
+        self, *args = args
+        # _registered_hooks = getattr(self, "_registered_hooks", None)
+        hooks_key, _registered_hooks = pop_hooks(self)
+        if not _registered_hooks:
+            return fun(self, *args, **kwargs)
+
+        def _hook(self, action, value, *args, **kwargs):
+            function_name = name or fun.__name__
+            hooks = _registered_hooks.get(f"{action}_{function_name}", [])
+            for hook in hooks:
+                value, args, kwargs = hook.function(
+                    self, value, *args, **kwargs
+                )
+                value = HookValue.new(value)
+            return value, args, kwargs
+
+        value = HookValue(EMPTY_VALUE)
+        if before:
+            value, args, kwargs = _hook(self, "before", value, *args, **kwargs)
+
+        if not isinstance(value, EagerValue):
+            value = HookValue.new(fun(self, *args, **kwargs))
+
+        if after:
+            value, args, kwargs = _hook(self, "after", value, *args, **kwargs)
+
+        # Put back registered hooks on self
+        put_hooks(self, _registered_hooks, hooks_key)
+
+        return value.value
+
+    if function:
+        # decorator applied without parameters e.g: @hookable
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return dispatch(function, *args, **kwargs)
+
+        # wrapper.function = function
+        return wrapper
+
+    def decorator(function):
+        # decorator applied with parameters e.g: @hookable(before=False)
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return dispatch(function, *args, **kwargs)
+
+        # wrapper.function = function
+        return wrapper
+
+    return decorator
+
+
+def pop_hooks(obj):
+    """Remove registered hooks from object"""
+    return_name = "_registered_hooks"
+    hooks = None
+    for key in [return_name, return_name.upper()]:
+        if hasattr(obj, key):
+            return_name = key
+            hooks = getattr(obj, key)
+        elif isinstance(obj, dict) and key in obj:
+            return_name = key
+            hooks = obj[key]
+        elif hasattr(obj, "_store") and key in obj._store:
+            return_name = key
+            hooks = obj._store[key]
+
+    with suppress(Exception):
+        delattr(obj, return_name)
+    with suppress(Exception):
+        del obj[return_name]
+    with suppress(Exception):
+        del obj._store[return_name]
+
+    return return_name, hooks
+
+
+def put_hooks(obj, hooks, key="_registered_hooks"):
+    """Put back registered hooks on object"""
+    if hasattr(obj, "_store"):
+        obj._store[key] = hooks
+    else:
+        setattr(obj, key, hooks)
+
+
+@dataclass
+class Hook:
+    """Hook to wrap a callable on _registered_hooks list.
+
+    :param callable: The callable to be wrapped
+
+    The callable must accept the following arguments:
+
+    - self: The instance of the class, e.g `settings`
+    - value: The value to be processed
+      (accumulated from previous hooks, last hook will receive the final value)
+    - *args: The args passed to the original method
+    - **kwargs: The kwargs passed to the original method
+
+    The callable must return a tuple with the following values:
+
+    - value: The processed value to be passed to the next hook
+    - *args: The args to be passed to the next hook
+    - **kwargs: The kwargs to be passed to the next hook
+    """
+
+    function: Callable
+
+
+@dataclass
+class HookValue:
+    """Base class for hook values.
+    Hooks must return a HookValue instance.
+    """
+
+    value: Any
+
+    @classmethod
+    def new(cls, value: Any) -> HookValue:
+        """Return a new HookValue instance with the given value."""
+        if isinstance(value, HookValue):
+            return value
+        return cls(value)
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __eq__(self, other) -> bool:
+        return self.value == other
+
+    def __ne__(self, other) -> bool:
+        return self.value != other
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __len__(self) -> int:
+        return len(self.value)
+
+    def __iter__(self):
+        return iter(self.value)
+
+    def __getitem__(self, item):
+        return self.value[item]
+
+    def __setitem__(self, key, value):
+        self.value[key] = value
+
+    def __delitem__(self, key):
+        del self.value[key]
+
+    def __contains__(self, item):
+        return item in self.value
+
+    def __getattr__(self, item):
+        return getattr(self.value, item)
+
+    def __setattr__(self, key, value):
+        if key == "value":
+            super().__setattr__(key, value)
+        else:
+            setattr(self.value, key, value)
+
+    def __delattr__(self, item):
+        delattr(self.value, item)
+
+    def __repr__(self) -> str:
+        return repr(self.value)
+
+
+@dataclass
+class MethodValue(HookValue):
+    """A value returned by a method
+    The main decorated method have its value wrapped in this class
+    """
+
+
+@dataclass
+class EagerValue(HookValue):
+    """Use this wrapper to return earlier from a hook.
+    Main function is bypassed and value is passed to after hooks."""
+
+
+class Action(str, Enum):
+    """All the hookable functions"""
+
+    AFTER_AS_DICT = "after_as_dict"
+    BEFORE_AS_DICT = "before_as_dict"
+    AFTER_GET = "after_get"
+    BEFORE_GET = "before_get"
+    AFTER_SET = "after_set"
+    BEFORE_SET = "before_set"
+    AFTER_UPDATE = "after_update"
+    BEFORE_UPDATE = "before_update"
+    AFTER_LOADERS = "after_loaders"
+    BEFORE_LOADERS = "before_loaders"
+    AFTER_LOAD_FILE = "after_load_file"
+    BEFORE_LOAD_FILE = "before_load_file"
+    AFTER_POPULATE_OBJ = "after_populate_obj"
+    BEFORE_POPULATE_OBJ = "before_populate_obj"

--- a/dynaconf/utils/functional.py
+++ b/dynaconf/utils/functional.py
@@ -43,7 +43,12 @@ class LazyObject:
     __getattr__ = new_method_proxy(getattr)
 
     def __setattr__(self, name, value):
-        if name in ["_wrapped", "_kwargs", "_warn_dynaconf_global_settings"]:
+        if name in [
+            "_wrapped",
+            "_kwargs",
+            "_warn_dynaconf_global_settings",
+            "_wrapper_class",
+        ]:
             # Assign to __dict__ to avoid infinite __setattr__ loops.
             self.__dict__[name] = value
         else:

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -137,13 +137,24 @@ class Merge(MetaValue):
         self.unique = unique
 
 
+class FormattingError(Exception):
+    """Error formatting a lazy variable"""
+
+
 class BaseFormatter:
     def __init__(self, function, token):
         self.function = function
         self.token = token
 
     def __call__(self, value, **context):
-        return self.function(value, **context)
+        try:
+            return self.function(value, **context)
+        except (KeyError, AttributeError) as exc:
+            # A template like {this.FOO} failed with AttributeError
+            # object has no attribute FOO. (or KeyError in case of env[...])
+            raise FormattingError(
+                f"dynaconf can't interpolate variable because {exc}"
+            ) from exc
 
     def __str__(self):
         return str(self.token)

--- a/tests/test_hooking.py
+++ b/tests/test_hooking.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+
+from dynaconf.hooking import Action
+from dynaconf.hooking import EagerValue
+from dynaconf.hooking import Hook
+from dynaconf.hooking import hookable
+from dynaconf.hooking import HookValue
+
+
+def test_hook_before_and_after_bypass_method():
+    """Method is never executed, before and after hooks are called"""
+
+    class HookedSettings:
+
+        _registered_hooks = {
+            # Accumulate all values
+            Action.BEFORE_GET: [
+                Hook(lambda s, v, *a, **kw: ("ba", a, kw)),
+                Hook(
+                    lambda s, v, *a, **kw: (EagerValue(f"{v.value}na"), a, kw)
+                ),
+                # EagerValue is a special value that bypasses the method
+                # and goes to the after hooks
+            ],
+            # After hooks makes the final value
+            Action.AFTER_GET: [
+                Hook(lambda s, v, *a, **kw: (f"{v.value}na", a, kw)),
+            ],
+        }
+
+        @hookable(name="get")
+        def get(self, key):
+            # 1st before hook will make value to be "ba"
+            # 2nd before hook will make value to be "bana"
+            # 1st after hook will make value to be "banana"
+            return "value"  # this will never be executed
+
+    settings = HookedSettings()
+    assert settings.get("key") == "banana"
+
+
+def test_hook_runs_after_method():
+    """After method the after hooks transforms value."""
+
+    DATABASE = {
+        "feature_enabled": True,
+    }
+
+    def try_to_get_from_database(self, value, key, *args, **kwargs):
+        print(self, value, key, args, kwargs)
+        return DATABASE.get(key, value.value), args, kwargs
+
+    class HookedSettings:
+
+        _registered_hooks = {
+            # After hooks makes the final value
+            Action.AFTER_GET: [
+                Hook(try_to_get_from_database),
+            ],
+        }
+
+        internal_data = {
+            "feature_enabled": False,
+            "something_not_in_database": "default value",
+        }
+
+        @hookable
+        def get(self, key):
+            return self.internal_data.get(key)
+
+    settings = HookedSettings()
+
+    # On the object feature is disabled
+    # but on the database it is enabled
+    assert settings.get("feature_enabled") is True
+
+    # This key is not in the database, so returns regular value
+    assert settings.get("something_not_in_database") == "default value"
+
+
+def test_hook_fail_with_wrong_parameters():
+    """Hookable decorator fails when called with wrong parameters."""
+
+    with pytest.raises(TypeError):
+
+        @hookable("not a function")
+        def foo():
+            pass
+
+
+def test_hook_values():
+    value = HookValue(1)
+    assert value == 1
+    assert value != 2
+    assert value == HookValue(1)
+    assert value != HookValue(2)
+    assert bool(value) is True
+    assert str(value) == "1"
+    assert repr(value) == repr(value.value)
+
+    value = HookValue([1, 2, 3])
+    assert value == [1, 2, 3]
+    assert value != [1, 2, 4]
+    assert value == HookValue([1, 2, 3])
+    assert value != HookValue([1, 2, 4])
+    assert bool(value) is True
+    assert str(value) == "[1, 2, 3]"
+    assert repr(value) == repr(value.value)
+    assert value[0] == 1
+    assert value[1] == 2
+    assert value[2] == 3
+    assert len(value) == 3
+    assert value[0:2] == [1, 2]
+    assert 2 in value
+    assert [x for x in value] == [1, 2, 3]
+
+    class Dummy:
+        pass
+
+    _value = Dummy()
+    value = HookValue(_value)
+    assert value == value.value
+    assert value != object()
+    assert value == HookValue(_value)
+    assert value != HookValue(object())
+    assert bool(value) is True
+    value.name = "dummy value"
+    assert value.name == "dummy value"
+    delattr(value, "name")
+    assert not hasattr(value, "name")
+
+    value = HookValue({})
+    assert value == {}
+    assert value != {"a": 1}
+    assert value == HookValue({})
+    value["a"] = 1
+    assert value == {"a": 1}
+    assert value["a"] == 1
+    del value["a"]
+    assert value == {}

--- a/tests/test_hooking.py
+++ b/tests/test_hooking.py
@@ -30,6 +30,9 @@ def test_hook_dynaconf_class_after():
 
 def test_hooked_dict():
     class HookedDict(dict):
+
+        _store = {}
+
         @hookable
         def get(self, key, default=None):
             return "to"
@@ -66,6 +69,8 @@ def test_hook_before_and_after_bypass_method():
 
     class HookedSettings:
 
+        _store = {}
+
         _registered_hooks = {
             # Accumulate all values
             Action.BEFORE_GET: [
@@ -101,10 +106,12 @@ def test_hook_runs_after_method():
     }
 
     def try_to_get_from_database(self, value, key, *args, **kwargs):
-        print(self, value, key, args, kwargs)
+        assert self.get("feature_enabled") is False
         return DATABASE.get(key, value.value), args, kwargs
 
     class HookedSettings:
+
+        _store = {}
 
         _registered_hooks = {
             # After hooks makes the final value

--- a/tests_functional/format/app.py
+++ b/tests_functional/format/app.py
@@ -7,6 +7,7 @@ from dynaconf import Dynaconf
 settings = Dynaconf(
     settings_files=["settings.toml"], environments=True, load_dotenv=True
 )
+from dynaconf import settings
 
 assert settings.get("FORMAT_USERNAME") is None
 assert settings.DATABASE_NAME == "my_database.db"

--- a/tests_functional/format/app.py
+++ b/tests_functional/format/app.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import os
 
-from dynaconf import settings
+from dynaconf import Dynaconf
+
+settings = Dynaconf(
+    settings_files=["settings.toml"], environments=True, load_dotenv=True
+)
 
 assert settings.get("FORMAT_USERNAME") is None
 assert settings.DATABASE_NAME == "my_database.db"

--- a/tests_functional/format/app.py
+++ b/tests_functional/format/app.py
@@ -2,11 +2,6 @@ from __future__ import annotations
 
 import os
 
-from dynaconf import Dynaconf
-
-settings = Dynaconf(
-    settings_files=["settings.toml"], environments=True, load_dotenv=True
-)
 from dynaconf import settings
 
 assert settings.get("FORMAT_USERNAME") is None


### PR DESCRIPTION
Allows to add AFTER and BEFORE hooks to some dynaconf methods

```python
from dynaconf import Dynaconf
from dynaconf.hooking import Action, Hook, HookableSettings

settings = Dynaconf(_wrapper_class=HookableSettings)

def lookup_for_key_in_cache_or_database(settings, value,  key, default):
    print(f"doing things to lookup key {key!r} on cache or db")
    new_value = find_in_cache(key) or query_db(key) or value 
    return new_value

settings.dynaconf.add_hook(Action.AFTER_GET, lookup_for_key_in_cache_or_database)
```

Then in any part of code

```python
>>> from config import settings
>>> settings.MY_AWESOME_KEY
"doing things to lookup key 'MY_AWESOME_KEY' on cache or db"
```