### PR TITLE
fix: envvars.md get `HOME` environment variable

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -140,7 +140,7 @@ Dynaconf support 2 types of lazy values `format` and `jinja` which allows
 template substitutions.
 
 ```bash
-export PREFIX_PATH='@format {env{"HOME"}/.config/{this.DB_NAME}'
+export PREFIX_PATH='@format {env[HOME]}/.config/{this.DB_NAME}'
 export PREFIX_PATH='@jinja {{env.HOME}}/.config/{{this.DB_NAME}} | abspath'
 ```
 


### PR DESCRIPTION
Old:

`export PREFIX_PATH='@format {env{"HOME"}/.config/{this.DB_NAME}'`

Error:
ValueError: unexpected '{' in field name

Fixed:

`export PREFIX_PATH='@format {env[HOME]}/.config/{this.DB_NAME}'`