### PR TITLE
Fix code snippet in docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -83,7 +83,7 @@ from dynaconf.strategies.filtering import PrefixFilter
 
 settings = Dynaconf(
     settings_file="settings.toml",
-    environments=False
+    environments=False,
     filter_strategy=PrefixFilter("prefix")
 )
 ```


### PR DESCRIPTION
Fix syntax error, missing comma

```
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```