### PR TITLE
Handle all failures when pwd does not exist.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=79]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -29,7 +29,7 @@ from dynaconf.vendor import tomllib
 
 os.environ["PYTHONIOENCODING"] = "utf-8"
 
-CWD=None
+CWD = None
 try:
     CWD = Path.cwd()
 except FileNotFoundError:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -120,6 +120,8 @@ def import_settings(dotted_path):
         module = importlib.import_module(module)
     except ImportError as e:
         raise click.UsageError(e)
+    except FileNotFoundError:
+        return
     try:
         return getattr(module, name)
     except AttributeError as e:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -29,7 +29,11 @@ from dynaconf.vendor import tomllib
 
 os.environ["PYTHONIOENCODING"] = "utf-8"
 
-CWD = Path.cwd()
+CWD=None
+try:
+    CWD = Path.cwd()
+except FileNotFoundError:
+    pass
 EXTS = ["ini", "toml", "yaml", "json", "py", "env"]
 WRITERS = ["ini", "toml", "yaml", "json", "py", "redis", "vault", "env"]
 

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -6,10 +6,11 @@ from dynaconf.utils import missing
 from dynaconf.utils import upperfy
 from dynaconf.utils.parse_conf import parse_conf_data
 
-DOTENV_IMPORTED=False
+DOTENV_IMPORTED = False
 try:
     from dynaconf.vendor.dotenv import cli as dotenv_cli
-    DOTENV_IMPORTED=True
+
+    DOTENV_IMPORTED = True
 except ImportError:
     pass
 except FileNotFoundError:

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -5,7 +5,15 @@ from os import environ
 from dynaconf.utils import missing
 from dynaconf.utils import upperfy
 from dynaconf.utils.parse_conf import parse_conf_data
-from dynaconf.vendor.dotenv import cli as dotenv_cli
+
+DOTENV_IMPORTED=False
+try:
+    from dynaconf.vendor.dotenv import cli as dotenv_cli
+    DOTENV_IMPORTED=True
+except ImportError:
+    pass
+except FileNotFoundError:
+    pass
 
 
 IDENTIFIER = "env"

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -92,6 +92,8 @@ def load_from_env(
 
 def write(settings_path, settings_data, **kwargs):
     """Write data to .env file"""
+    if not DOTENV_IMPORTED:
+        return
     for key, value in settings_data.items():
         quote_mode = (
             isinstance(value, str)

--- a/dynaconf/utils/files.py
+++ b/dynaconf/utils/files.py
@@ -47,7 +47,10 @@ def find_file(filename=".env", project_root=None, skip_files=None, **kwargs):
     additional `./config` folder.
     """
     search_tree = []
-    work_dir = os.getcwd()
+    try:
+        work_dir = os.getcwd()
+    except FileNotFoundError:
+        return ""
     skip_files = skip_files or []
 
     # If filename is an absolute path and exists, just return it

--- a/tests_functional/missing_pwd/test.sh
+++ b/tests_functional/missing_pwd/test.sh
@@ -7,6 +7,6 @@ mkdir -p /tmp/foobar
 cd /tmp/foobar
 rm -rf /tmp/foobar
 
-dynaconf -i config.settings list 
+dynaconf -i config.settings list
 RC=$?
 exit $RC

--- a/tests_functional/missing_pwd/test.sh
+++ b/tests_functional/missing_pwd/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+rm -rf /tmp/foobar
+mkdir -p /tmp/foobar
+cd /tmp/foobar
+rm -rf /tmp/foobar
+
+dynaconf -i config.settings list 
+RC=$?
+exit $RC

--- a/tests_functional/runtests.py
+++ b/tests_functional/runtests.py
@@ -67,7 +67,6 @@ def execute_tests(path):
 
 
 def run_tests(show_list=False, test_filter=None):
-
     def filter_allowed(testpath):
         if not test_filter:
             return True
@@ -126,16 +125,16 @@ def run_tests(show_list=False, test_filter=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--list',
-        dest='show_list',
-        action='store_true',
-        help='List all available tests (do not execute)'
+        "--list",
+        dest="show_list",
+        action="store_true",
+        help="List all available tests (do not execute)",
     )
     parser.add_argument(
-        '--filter',
-        dest='test_filter',
-        action='append',
-        help='limt tests to those that contain a substring'
+        "--filter",
+        dest="test_filter",
+        action="append",
+        help="limt tests to those that contain a substring",
     )
     args = parser.parse_args()
     run_tests(show_list=args.show_list, test_filter=args.test_filter)

--- a/tests_functional/skipfile.toml
+++ b/tests_functional/skipfile.toml
@@ -18,4 +18,5 @@ nt = [
     "449_django_lazy_path",
     "685_disable_dotted_lookup",
     "741_envvars_ignored",
+    "missing_pwd",
 ]


### PR DESCRIPTION
Fixes https://github.com/dynaconf/dynaconf/issues/853

Reproducer:

```bash
#!/bin/bash

rm -rf /tmp/foobar
mkdir -p /tmp/foobar
cd /tmp/foobar
rm -rf /tmp/foobar


echo "PWD:$(pwd)"

dynaconf list
```