### PR TITLE
fix #876 - avoid failure on deleted cwd

### DIFF
--- a/dynaconf/utils/files.py
+++ b/dynaconf/utils/files.py
@@ -46,18 +46,18 @@ def find_file(filename=".env", project_root=None, skip_files=None, **kwargs):
     For each path in the `search_tree` it will also look for an
     additional `./config` folder.
     """
+    # If filename is an absolute path and exists, just return it
+    # if the absolute path does not exist, return empty string so
+    # that it can be joined and avoid IoError
+    if os.path.isabs(filename):
+        return filename if os.path.exists(filename) else ""
+
     search_tree = []
     try:
         work_dir = os.getcwd()
     except FileNotFoundError:
         return ""
     skip_files = skip_files or []
-
-    # If filename is an absolute path and exists, just return it
-    # if the absolute path does not exist, return empty string so
-    # that it can be joined and avoid IoError
-    if os.path.isabs(filename):
-        return filename if os.path.exists(filename) else ""
 
     if project_root is not None:
         search_tree.extend(_walk_to_root(project_root, break_at=work_dir))

--- a/tests_functional/issues/876_deleted_cwd/app.py
+++ b/tests_functional/issues/876_deleted_cwd/app.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+from dynaconf import Dynaconf
+
+print(os.getenv("SETTINGS_FILE_FOR_DYNACONF"))
+settings = Dynaconf()
+
+print(settings.offset)
+assert settings.offset == 24
+
+settings.validators.validate()
+
+print(type(settings.offset))
+assert isinstance(settings.offset, int)

--- a/tests_functional/issues/876_deleted_cwd/test.sh
+++ b/tests_functional/issues/876_deleted_cwd/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
-export SETTINGS_FILE_FOR_DYNACONF=$(mktemp --suffix .yaml)
+export SETTINGS_FILE_FOR_DYNACONF=$(mktemp -t dynaconf.XXXXX.yaml)
 echo "offset: 24" > $SETTINGS_FILE_FOR_DYNACONF
 PARENT=$(readlink -f .)
 mkdir nonexistent_dir

--- a/tests_functional/issues/876_deleted_cwd/test.sh
+++ b/tests_functional/issues/876_deleted_cwd/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+export SETTINGS_FILE_FOR_DYNACONF=$(mktemp --suffix .yaml)
+echo "offset: 24" > $SETTINGS_FILE_FOR_DYNACONF
+PARENT=$(realpath .)
+mkdir nonexistent_dir
+cd nonexistent_dir
+rm -r ../nonexistent_dir
+ls ../
+python $PARENT/app.py
+cat $SETTINGS_FILE_FOR_DYNACONF
+rm -r $SETTINGS_FILE_FOR_DYNACONF

--- a/tests_functional/issues/876_deleted_cwd/test.sh
+++ b/tests_functional/issues/876_deleted_cwd/test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/bash -x
 export SETTINGS_FILE_FOR_DYNACONF=$(mktemp --suffix .yaml)
 echo "offset: 24" > $SETTINGS_FILE_FOR_DYNACONF
-PARENT=$(realpath .)
+PARENT=$(readlink -f .)
 mkdir nonexistent_dir
 cd nonexistent_dir
 rm -r ../nonexistent_dir

--- a/tests_functional/skipfile.toml
+++ b/tests_functional/skipfile.toml
@@ -21,6 +21,3 @@ nt = [
     "missing_pwd",
     "876_deleted_cwd",
 ]
-darwin = [
-    "876_deleted_cwd",
-]

--- a/tests_functional/skipfile.toml
+++ b/tests_functional/skipfile.toml
@@ -19,4 +19,8 @@ nt = [
     "685_disable_dotted_lookup",
     "741_envvars_ignored",
     "missing_pwd",
+    "876_deleted_cwd",
+]
+darwin = [
+    "876_deleted_cwd",
 ]


### PR DESCRIPTION
When the settings_file is provided as an absolute path dynaconf will not error even if cwd doesn't exist.

The fix was to check for absolute path first.

For relative paths the cwd is still required.