### PR TITLE
CI - Prevent running when just doc changes are made

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,16 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ master ]
+    branches: [master]
+    # will run when at least one file matches something else than those
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
       redis:
         image: redis
         ports:
-           - 6379:6379
+          - 6379:6379
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -218,7 +218,7 @@ jobs:
       vault:
         image: vault
         ports:
-           - 8200:8200
+          - 8200:8200
         env:
           VAULT_DEV_ROOT_TOKEN_ID: myroot
 


### PR DESCRIPTION
According to the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), this would trigger the CI if at least one file that is not specified in the `path-ignore` is modified.

Also, the Netlify workflow should trigger just when some changes are made to docs, right?
Assuming mkdocs currently doesn't rely on code to generate text, like using docstrings from code or something.

I did not include this change because the Netlify action file is not present in the `.github/` folder. Maybe it is editable from the GH web interface.