### PR TITLE
Docs/clarify merging defaults

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -9,7 +9,7 @@ You can globally turn on the merging strategy by setting [merge_enable](https://
 
 ## Merging existing data structures
 
-If your settings has existing variables of types `list` or `dict` and you want to `merge` instead of `override` then 
+If your settings have existing variables of types `list` or `dict` and you want to `merge` instead of `override` then 
 the `dynaconf_merge` and `dynaconf_merge_unique` stanzas can mark that variable as a candidate for merging.
 
 For **dict** value:
@@ -77,7 +77,7 @@ So the above will result in
 DATABASE = {'password': 1234, 'user': 'admin', 'ARGS': {'timeout': 30, 'retries': 5}}
 ```
 
-> **IMPORTANT** lower case keys are respected only on *nix systems, unfortunately Windows environment variables are case insensitive and Python reads it as all upper cases, that means that if you are running on Windows the dictionary can have only upper case keys.
+> **IMPORTANT** lower case keys are respected only on *nix systems. Unfortunately, Windows environment variables are case insensitive and Python reads it as all upper cases, which means that if you are running on Windows the dictionary can have only upper case keys.
 
 You can also export a toml dictionary.
 
@@ -232,7 +232,7 @@ parameters = {enabled=false}
 password = 9999
 ```
 
-So with above the values will be:
+So with the above eg, the values will be:
 
 ```python
 settings.COLORS == ["pink"]
@@ -254,9 +254,9 @@ colors = ["pink"]
 parameters = {enabled=false}
 ```
 
-By adding `dynaconf_merge` to the top root of the file mark entire file to be merged.
+By adding `dynaconf_merge` to the top root of the file, the entire file will be marked for merge.
 
-And then the values will be updated in to existing data structures.
+And then the values will be updated into existing data structures.
 
 ```python
 settings.COLORS == ["pink", "green", "blue"]
@@ -283,9 +283,9 @@ colors = ["pink", "dynaconf_merge"]
 parameters = {enabled=false, dynaconf_merge=true}
 ```
 
-By adding `dynaconf_merge` to a `list` or `dict` marks it as a merge candidate.
+By adding `dynaconf_merge` to a `list` or `dict`, those will be marked as merge candidates.
 
-And then the values will be updated in to existing data structures.
+And then the values will be updated into existing data structures.
 
 ```python
 settings.COLORS == ["pink", "green", "blue"]
@@ -308,7 +308,7 @@ dynaconf_merge = {enabled=false}
 
 ### Dunder merging for nested structures
 
-For nested structures the recommendation is to use dunder merging because it it easier to read and also it has no limitations in terms of nesting levels.
+For nested structures, the recommendation is to use dunder merging because it is easier to read and also has no limitations in terms of nesting levels.
 
 ```ini
 # settings.local.yaml
@@ -325,7 +325,7 @@ The use of `__` to denote nested level will ensure the key is merged with existi
 > 
 > This is useful for `Django` settings.
 
-Lets say you have a configuration like this:
+Let's say you have a configuration like this:
 
 `settings.py`
 
@@ -349,7 +349,7 @@ So
 DATABASES['default']['ENGINE'] = 'other.module'
 ```
 
-Can be expressed as environment variables as:
+Can be expressed as environment variables:
 
 ```bash
 export DYNACONF_DATABASES__default__ENGINE=other.module
@@ -370,9 +370,9 @@ DATABASES = {
 ```
 
 !!! warning
-    lower case keys are respected only on *nix systems, unfortunately Windows environment variables are case insensitive and Python reads it as all upper cases, that means that if you are running on Windows the dictionary can have only upper case keys.
-    **Also** only first level keys are case insensitive, which means `DYNACONF_FOO__BAR=1` is different than `DYNACONF_FOO__bar=1`  
-    **in other words**, except by the first level key, you must follow strictly the case of the variable key.
+    lower case keys are respected only on *nix systems. Unfortunately, Windows environment variables are case insensitive and Python reads it as all upper cases, which means that if you are running on Windows the dictionary can have only upper case keys.
+    **Also** only first level keys are case insensitive, which means `DYNACONF_FOO__BAR=1` is different than `DYNACONF_FOO__bar=1`.</br>
+**In other words**, except by the first level key, you must follow strictly the case of the variable key.
 
 Now if you want to add a new item to `ARGS` key:
 
@@ -474,7 +474,7 @@ DATABASES = {
 
 > **New in 2.0.0**
 
-To merge exported variables there is the **dynaconf_merge** tokens, example:
+To merge exported variables there is the **dynaconf_merge** tokens. Example:
 
 Your main settings file (e.g `settings.toml`) has an existing `DATABASE` dict setting on `[default]` env.
 
@@ -529,7 +529,7 @@ settings.DATABASE == {'host': 'server.com', 'user': 'dev_user', 'password': 1234
 
 ## Known caveats
 
-The **dynaconf_merge** and **@merge** functionalities works only for the first level keys, it will not merge subdicts or nested lists (yet).
+The **dynaconf_merge** and **@merge** functionalities work only for the first level keys, it will not merge subdicts or nested lists (yet).
 
 
 ## More examples

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -1,3 +1,12 @@
+## Overview
+
+Dynaconf provides global and local tools to control if the value of conflicting settings (which have the same key) will be merged or will override one another.
+
+By default, nothing is merged. Also, only container types can be merged (`list` and `dict`). Non-container types, such as `str` and `int`, will always override the previous value (If you want to merge them, wrap them in a `list` or `dict`).
+
+You can globally turn on the merging strategy by setting [merge_enable](https://www.dynaconf.com/configuration/#merge_enabled) option to `True` (via instance settings or envvars).
+
+
 ## Merging existing data structures
 
 If your settings has existing variables of types `list` or `dict` and you want to `merge` instead of `override` then 
@@ -309,16 +318,8 @@ parameters__enabled = false
 
 The use of `__` to denote nested level will ensure the key is merged with existing values read more in [merging existing values](#merging-existing-values).
 
-### Global merge
 
-```bash
-export MERGE_ENABLED_FOR_DYNACONF=true
-```
-
-or put it in your `.env` file then Dynaconf will automatically merge all existing variables.
-
-
-### Nested keys in dictionaries via environment variables.
+## Nested keys in dictionaries via environment variables.
 
 > **New in 2.1.0**
 > 
@@ -469,7 +470,7 @@ DATABASES = {
 }
 ```
 
-### Using the `dynaconf_merge` mark on configuration files.
+## Using the `dynaconf_merge` mark on configuration files.
 
 > **New in 2.0.0**
 
@@ -526,7 +527,7 @@ settings.DATABASE == {'host': 'server.com', 'user': 'dev_user', 'password': 1234
 
 > **BEWARE**: Using `MERGE_ENABLED_FOR_DYNACONF` can lead to unexpected results because you do not have granular control of what is being merged or overwritten so the recommendation is to use other options.
 
-### Known caveats
+## Known caveats
 
 The **dynaconf_merge** and **@merge** functionalities works only for the first level keys, it will not merge subdicts or nested lists (yet).
 


### PR DESCRIPTION
- Add an Overview section to cover the defaults and an overview about merging.
- As I wrote about globals there, I removed the mini sections about globals in the middle.
- Also, changed headers hierarchy after "Local configuration files and merging to existing data", because the next headers seem to apply to general conflicts, not exclusively to local file conflicts. It is still not 100% clear about that, but I don't know how I could rewrite it, so this may be subject to another PR.