### PR TITLE
Docs - Django functions in settings file and misc

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -2,7 +2,7 @@
 
 > **New in 2.0.0**
 
-Dynaconf extensions for Django works by patching the `settings.py` file with dynaconf loading hooks, the change is done on a single file and then in your whole project every time you call `django.conf.settings` you will have access to `dynaconf` attributes and methods.
+Dynaconf extension for Django works by patching the `settings.py` file with dynaconf loading hooks, the change is done on a single file and then in your whole project. Every time you call `django.conf.settings` you will have access to `dynaconf` attributes and methods.
 
 Ensure dynaconf is installed on your env `pip install dynaconf[yaml]`
 
@@ -52,11 +52,11 @@ export DJANGO_HELLO="Hello"  # django.conf.settings.get('HELLO')
 
 </br>
 
-You can also set nested dictionary values, for example lets say you have a configuration like this:
-
-`settings.py`
+You can also set nested dictionary values. For example, let's say you have a configuration like this:
 
 ```py
+# settings.py
+
 ...
 DATABASES = {
     'default': {
@@ -107,7 +107,7 @@ in development mode or `DJANGO_ENV=production` to switch to production.
 If you don't want to manually create your config files take a look at the [CLI](/cli/)
 
 !!! tip
-    **.yaml** is the recommended format for Django applications because it allows complex data structures in easy way, but feel free to choose any format you are familiar with.
+    **.yaml** is the recommended format for Django applications because it allows easily writing complex data structures. Nevertheless, feel free to choose any format you are familiar with.
 
 !!! warning "Important"
     To use `$ dynaconf` CLI the `DJANGO_SETTINGS_MODULE` environment variable must be defined.
@@ -149,19 +149,19 @@ settings = dynaconf.DjangoDynaconf(
 
  Variables on environment can be set/override using `PROJECTNAME_` prefix e.g: `export PROJECTNAME_DEBUG=true`.
 
-Working environment can now be switched using `export PROJECTNAME_ENV=production` it defaults to `development`.
+The working environment can now be switched using `export PROJECTNAME_ENV=production` it defaults to `development`.
 
 Your settings are now read from `/etc/projectname/settings.toml` (dynaconf will not perform search for all the settings formats). This settings location can be changed via envvar using `export PROJECTNAME_SETTINGS=/other/path/to/settings.py{yaml,toml,json,ini}`
 
 You can have additional settings read from `/etc/projectname/plugins/*` any supported file from this folder will be loaded.
 
-You can set more options, take a look on [configuration](/configuration/)
+You can set more options, take a look at [configuration](/configuration/)
 
-### Use django function inside custom settings
+### Use Django functions inside custom settings
 
-If you need to use django function inside your settings, you can register custom converters.
+If you need to use django functions inside your settings, you can register custom converters.
 
-Example: if you need to user `reverse_lazy`, you might do this:
+Example: if you need to use `reverse_lazy`, you might do this:
 
 ```python
 # settings.py
@@ -203,11 +203,11 @@ default:
 
 The recommended way to create standalone scripts is by creating `management commands` inside your Django applications or plugins.
 
-Examples below assumes you have `DJANGO_SETTINGS_MODULE` environment variable set, either by `exporting` it to your env or by explicitly adding it to `os.environ` dictionary.
+The examples below assume you have `DJANGO_SETTINGS_MODULE` environment variable set, either by `exporting` it to your env or by explicitly adding it to `os.environ` dictionary.
 
 !!! tip "Important"
     If you need the script to be available out of your Django Application Scope, prefer using `settings.DYNACONF.configure()` instead of the common `settings.configure()` provided by Django. The latter would cause dynaconf to be disabled.</br></br>
-    Afterall, you probably don't need to call it, as you have `DJANGO_SETTINGS_MODULE` exported.
+    After all, you probably don't need to call it, as you have `DJANGO_SETTINGS_MODULE` exported.
 
 ### Common case
 
@@ -272,7 +272,7 @@ Django testing must work out of the box!
 
 But in some cases when you `mock` stuff and need to add `environment variables` to `os.environ` on demand for test cases it may be needed to `reload` the `dynaconf`.
 
-To do that write up on your test case setup part:
+To do that, write up your test case setup part:
 
 ```py
 import os
@@ -307,9 +307,9 @@ def set_test_settings():
 
 ## Explicit mode
 
-Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the common way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`.
+Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the usual way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`.
 
-Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings is managed by Django normally.
+Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings are managed by Django normally.
 
 ```py
 # settings.py
@@ -335,7 +335,7 @@ settings.populate_obj(sys.modules[__name__], ignore=locals())
 You can still change env with `export DJANGO_ENV=production` and also can export variables like `export DJANGO_DEBUG=true`
 
 !!! note
-    Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exists in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
+    Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exist in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
 
 ## Known Caveats
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -32,7 +32,8 @@ $ dynaconf init --django yourapp/settings.py
 
 Dynaconf will append its extension loading code to the bottom of your `yourapp/settings.py` file and will create `settings.toml` and `.secrets.toml` in the current folder (the same where `manage.py` is located).
 
-> **TIP** Take a look at [tests_functional/django_example](https://github.com/dynaconf/dynaconf/tree/master/tests_functional/django_example)
+!!! tip
+    Take a look at [tests_functional/django_example](https://github.com/dynaconf/dynaconf/tree/master/tests_functional/django_example)
 
 ## Using `DJANGO_` environment variables
 
@@ -46,7 +47,10 @@ export DJANGO_INTVALUE=1     # django.conf.settings['INTVALUE']
 export DJANGO_HELLO="Hello"  # django.conf.settings.get('HELLO')
 ```
 
-> **TIP**: If you don't want to use `DJANGO_` as prefix for envvars you can customize by passing a new name e.g: `dynaconf.DjangoDynaconf(__name__, ENVVAR_PREFIX_FOR_DYNACONF="FOO")` then `export FOO_DEBUG=true`
+!!! tip
+    If you don't want to use `DJANGO_` as prefix for envvars you can customize by passing a new name e.g: `dynaconf.DjangoDynaconf(__name__, ENVVAR_PREFIX_FOR_DYNACONF="FOO")` then `export FOO_DEBUG=true`
+
+</br>
 
 You can also set nested dictionary values, for example lets say you have a configuration like this:
 
@@ -93,16 +97,20 @@ Read more on [environment variables](https://www.dynaconf.com/merging/#nested-ke
 
 ## Settings files
 
-You can also have settings files for your Django app, in the root directory (the same where `manage.py` is located) put your `settings.{yaml, toml, ini, json, py}` and `.secrets.{yaml, toml, ini, json, py}` files and then define your environments `[default]`, `[development]` and `[production]`.
+You can also have settings files for your Django app.
 
-> NOTE: **.yaml** is the recommended format for Django applications because it allows complex data structures in easy way, but feel free to choose any format you are familiar with.
+In the root directory (the same where `manage.py` is located) put your `settings.{yaml, toml, ini, json, py}` and `.secrets.{yaml, toml, ini, json, py}` files and then define your environments `[default]`, `[development]` and `[production]`.
 
 To switch the working environment the `DJANGO_ENV` variable can be used, so `DJANGO_ENV=development` to work
 in development mode or `DJANGO_ENV=production` to switch to production.
 
-> **IMPORTANT**: To use `$ dynaconf` CLI the `DJANGO_SETTINGS_MODULE` environment variable must be defined.
+If you don't want to manually create your config files take a look at the [CLI](/cli/)
 
-IF you don't want to manually create your config files take a look at the [CLI](/cli/)
+!!! tip
+    **.yaml** is the recommended format for Django applications because it allows complex data structures in easy way, but feel free to choose any format you are familiar with.
+
+!!! warning "Important"
+    To use `$ dynaconf` CLI the `DJANGO_SETTINGS_MODULE` environment variable must be defined.
 
 ## Customizations
 
@@ -147,28 +155,28 @@ You can set more options, take a look on [configuration](/configuration/)
 
 ## Reading Settings on Standalone Scripts
 
-> **NOTE**: The recommended way to create standalone scripts is by creating `management commands` inside your Django applications or plugins.
-
-> **IMPORTANT** If you need that script to be out of your Django Application Scope, it is also possible and **if needed** you can use `settings.DYNACONF.configure()` instead of the common `settings.configure()` provided by Django.
-
-### Examples:
+The recommended way to create standalone scripts is by creating `management commands` inside your Django applications or plugins.
 
 Examples below assumes you have `DJANGO_SETTINGS_MODULE` environment variable set, either by `exporting` it to your env or by explicitly adding it to `os.environ` dictionary.
 
-> **IMPORTANT**: If you call `settings.configure()` directly dynaconf will be disabled. As you have `DJANGO_SETTINGS_MODULE` exported you don't need to call it, but if you need please use: `settings.DYNACONF.configure()`.
+!!! tip "Important"
+    If you need the script to be available out of your Django Application Scope, prefer using `settings.DYNACONF.configure()` instead of the common `settings.configure()` provided by Django. The latter would cause dynaconf to be disabled.</br></br>
+    Afterall, you probably don't need to call it, as you have `DJANGO_SETTINGS_MODULE` exported.
 
-#### Common case
+### Common case
 
-/etc/my_script.py
 ```python
+# /etc/my_script.py
+
 from django.conf import settings
 print(settings.DATABASES)
 ```
 
-#### Explicitly adding the setting module
+### Explicitly adding the setting module
 
-/etc/my_script.py
 ```python
+# /etc/my_script.py
+
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'foo.settings'
 
@@ -176,29 +184,34 @@ from django.conf import settings
 print(settings.DATABASES)
 ```
 
-#### When you need the `configure`
+### When you need the `configure`
 
-> Calling `DYNACONF.configure()` is needed when you want to access dynaconf special methods like `using_env`, `get`, `get_fresh` etc...
+Calling `DYNACONF.configure()` is needed when you want to access dynaconf special methods like `using_env`, `get`, `get_fresh` etc...
 
-/etc/my_script.py
 ```python
+# /etc/my_script.py
+
 from django.conf import settings
 settings.DYNACONF.configure()
 print(settings.get('DATABASES'))
 ```
 
-#### Importing settings directly (recommended for the above case)
+### Importing settings directly
 
-/etc/my_script.py
+This is recommended for the above case.
+
 ```python
+# /etc/my_script.py
+
 from foo.settings import settings
 print(settings.get('DATABASES'))
 ```
 
-#### Importing settings via importlib
+### Importing settings via importlib
 
-/etc/my_script.py
 ```python
+# /etc/my_script.py
+
 import os
 import importlib
 settings = importlib.import_module(os.environ['DJANGO_SETTINGS_MODULE'])
@@ -248,14 +261,13 @@ def set_test_settings():
 
 ## Explicit mode
 
-Some users have the preference to explicitly load each setting variable inside the `settings.py` and then let django manage it in the common way, it is possible.
+Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the common way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`.
 
-> **NOTE** Doing this way misses the ability to use dynaconf methods like `using_env`, `get` etc on your django applications code, you can use it only inside settings.py
+Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings is managed by Django normally.
 
-Dynaconf will be available only on `settings.py` scope, on the rest of your application settings is managed by Django normally.
-
-`settings.py`
 ```py
+# settings.py
+
 import sys
 from dynaconf import LazySettings
 
@@ -274,9 +286,10 @@ DATABASES = settings.get('DATABASES', {
 settings.populate_obj(sys.modules[__name__], ignore=locals())
 ```
 
-> **NOTE**: Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exists in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
-
 You can still change env with `export DJANGO_ENV=production` and also can export variables like `export DJANGO_DEBUG=true`
+
+!!! note
+    Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exists in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
 
 ## Known Caveats
 
@@ -284,4 +297,4 @@ You can still change env with `export DJANGO_ENV=production` and also can export
 
 ## Deprecation note
 
-On old dynaconf releases the solution was to add `dynaconf.contrib.django_dynaconf` to `INSTALLED_APPS` as the first item, this still works but has some limitations so it is not recommended anymore.
+On old dynaconf releases the solution was to add `dynaconf.contrib.django_dynaconf` to `INSTALLED_APPS` as the first item. This still works but has some limitations so it is not recommended anymore.

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -13,13 +13,14 @@ In addition to that Dynaconf offers some approaches you may want to **Optionally
 
 ## Environment variables
 
-You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](configuration/#custom-prefix))
+You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](configuration/#custom-prefix)).
+
+!!! warning
+    Dynaconf will only look for UPPERCASE prefixed envvars. This means envvar exported as `dynaconf_value` or `myprefix_value` won't be loaded, while `DYNACONF_VALUE` and `MYPREFIX_VALUE` (when proper set) will.
 
 ### Example
 
-!!! info
-    When loading environment variables, dynaconf will parse the value using `toml` language
-    so it will try to automatically convert to the proper data type.
+Notice that when loading environment variables, dynaconf will parse the value using `toml` language so it will try to automatically convert to the proper data type.
 
 ```bash
 export DYNACONF_NAME=Bruno                                   # str: "Bruno"
@@ -31,16 +32,6 @@ export DYNACONF_PERSON="{name='Bruno', email='foo@bar.com'}" # dict: {"name": "B
 export DYNACONF_STRING_NUM="'76'"                            # str: "76"
 export DYNACONF_PERSON__IS_ADMIN=true                        # bool: True (nested)
 ```
-
-!!! warning
-    When exporting data structures such as `dict` and `list` you have to use one of:  
-    ```
-    export DYNACONF_TOML_DICT={key="value"}
-    export DYNACONF_TOML_LIST=["item"]
-    export DYNACONF_JSON_DICT='@json {"key": "value"}'
-    export DYNACONF_JSON_LIST='@json ["item"]'
-    ```
-    Those 2 ways are the only ways for dynaconf to load `dicts` and `lists` from envvars.
 
 
 With the above it is now possible to read the settings in your `program.py` using:
@@ -65,6 +56,16 @@ assert settings.STRING_NUM == "76"
     existing settings solution. You can access using `.notation`, `[item] indexing`, `.get method`
     and also it allows `.notation.nested` for data structures like dicts.
     **Also variable access is case insensitive for the first level key**
+
+!!! warning
+    When exporting data structures such as `dict` and `list` you have to use one of:  
+    ```
+    export DYNACONF_TOML_DICT={key="value"}
+    export DYNACONF_TOML_LIST=["item"]
+    export DYNACONF_JSON_DICT='@json {"key": "value"}'
+    export DYNACONF_JSON_LIST='@json ["item"]'
+    ```
+    Those 2 ways are the only ways for dynaconf to load `dicts` and `lists` from envvars.
 
 ## Custom Prefix
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,3 +66,9 @@ def post(settings: Dynaconf) -> dict:
 ```
 
 See more about [hooks](https://www.dynaconf.com/advanced/#hooks)
+
+## Django functions inside settings
+
+> I use some django utility functions in my django `settings.py`. Can I still use them if I choose to use `yaml` to manage my config?
+
+Yes, you may add a custom converter for any functions you like. Refer [here](/django/#use-django-function-inside-custom-settings) for a full example.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -41,6 +41,7 @@ pdbr[ipython]
 mkdocs>=1.1.2
 mkdocs-material>=5.3.2
 mkdocs-material-extensions>=1.0
+mkdocs-git-revision-date-plugin
 pymdown-extensions
 Jinja2>3.0.0
 


### PR DESCRIPTION
- The modification in the `requirements-dev.txt` triggered the CI. The mkdocs plugin I added was only present in the `requirements.txt` (which is intended for netlify only), so `make` would not install it automatically.
- The main modification (**django page** and **faq page**) refers to discussions #865 and #858 
- A small unrelated contribution (**envvar page**) to #860 
- General and small readability/styling tweaks and typo fixes



