### PR TITLE
Docs - Add faq and fix `includes` info

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,7 +233,7 @@ source, settings files will be read, envvars parsed and external loaders connect
 
 ### **includes**
 
-> type=`list`, default=`[]` </br>
+> type=`list | str`, default=`[]` </br>
 > env-var=`INCLUDES_FOR_DYNACONF`
 
 After loading the files specified in `settings_files` dynaconf will load all the files added to `includes` in a post-load process.
@@ -242,7 +242,8 @@ After loading the files specified in `settings_files` dynaconf will load all the
     Includes can also be added inside files itself, ex:
 
     ```toml
-    includes: ['otherfile.toml']
+    dynaconf_include: ['otherfile.toml'] # or
+    dynaconf_include: 'otherfile.toml'
     key: "value"
     ```
 
@@ -360,7 +361,7 @@ DATABASES = {
 
 ### **preload**
 
-> type=`list`, default=`[]` </br>
+> type=`list | str`, default=`[]` </br>
 > env-var=`PRELOAD_FOR_DYNACONF`
 
 Sometimes you might need to load some file before dynaconf starts looking for its `settings_files` or `includes`, you can have for example a `dynaconf.toml` to hold dynaconf's configuration.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,7 +73,7 @@ See more about [hooks](https://www.dynaconf.com/advanced/#hooks)
 
 Yes, you may add a custom converter for any functions you like. Refer [here](/django/#use-django-functions-inside-custom-settings) for a full example.
 
-### Default-override workflow
+## Default-override workflow
 
 > I'd like to use a base-file as default settings (like django settings.py) and a user-file settings where I would add my custom overrides more explicitly. Can this be done?
 
@@ -104,5 +104,29 @@ bucket=["a", "b", "c", "d"]
 bucket=["a", "b", "c", "d"]
 ```
 
-To control how you want to merge these structures, you may want to have a look at [merging](https://www.dynaconf.com/merging/)
-There are several ways you can merge data: settings the global option [merge_enabled](), using double dunder syntax or marking a whole file, a specific env, or just an option for merging. Choose what fits best for your case.
+To control how you want to merge these structures, you may want to have a look at [merging](/merging/)
+There are several ways you can merge data: settings the global option [merge_enabled](/configuration/#merge_enabled), using dunder syntax or marking a whole file, a specific env, or just an option for merging. Choose what fits best for your case.
+
+## Error with Pyinstaller executable
+
+> I had some trouble running an executable app that uses Dynaconf. What could it be?
+
+A [user reported](https://github.com/dynaconf/dynaconf/issues/770) this situation while using Pyinstaller. For his case, the fix was to package *dynaconf* and *python-dotenv[cli]* without compiling by using the `--collect-all` argument of pyinstaller.
+
+## Dynaconf instance from dict
+
+> I would like a Dynaconf object to be created from a python dict, while still being able to use validators on it. Is it possible?
+
+Yes, it is possible.
+
+Let's say you got a stringfied json directly from an API and you'd like to integrate it to a Dynaconf object using some validation. You could do this:
+
+```python
+data = get_data_as_dict()
+
+settings = Dynaconf()
+
+settings.validators.register(Validator("aws", "elasticsearch", must_exist=True))
+settings.update(data)
+settings.validators.validate()
+```

--- a/docs/settings_files.md
+++ b/docs/settings_files.md
@@ -122,8 +122,7 @@ or
 
 ```toml
 # in toml file
-dynaconf_includes = ["path/to/file.toml"]
-dynaconf_preload = ["path/to/file.toml"]
+dynaconf_include = ["path/to/file.toml"]
 key = value
 anotherkey = value
 ```

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1045,7 +1045,7 @@ class Settings:
 
     def load_includes(self, env, silent, key):
         """Do we have any nested includes we need to process?"""
-        includes = self.get("DYNACONF_INCLUDE", [])
+        includes = ensure_a_list(self.get("DYNACONF_INCLUDE"))
         includes.extend(ensure_a_list(self.get("INCLUDES_FOR_DYNACONF")))
         if includes:
             self.load_file(path=includes, env=env, silent=silent, key=key)

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -7,6 +7,7 @@ from json import JSONDecoder
 from typing import Any
 from typing import Iterator
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -290,7 +291,10 @@ def trimmed_split(
     return [s]  # raw un-splitted
 
 
-def ensure_a_list(data: Any) -> list[int] | list[str]:
+T = TypeVar("T")
+
+
+def ensure_a_list(data: T) -> list[T]:
     """Ensure data is a list or wrap it in a list"""
     if not data:
         return []


### PR DESCRIPTION
- Add faq about #712 and #792
- Fix wrong info as reported in #898
- Change `dynaconf_include` to accept `str` (like `includes_for_dynaconf`) as proposed [here](https://github.com/dynaconf/dynaconf/issues/898#issuecomment-1478428723).