### PR TITLE
Provides new add_converter function for #858

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -171,11 +171,10 @@ Example: if you need to use `reverse_lazy`, you might do this:
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 
 import dynaconf
-from dynaconf.utils import parse_conf
 from django.urls import reverse_lazy
 
 # register custom converter
-parse_conf.converters["@reverse_lazy"] = lambda value: parse_conf.Lazy(value, casting=reverse_lazy)
+dynaconf.add_converter("reverse_lazy", reverse_lazy)
 
 # regular setup
 settings = dynaconf.DjangoDynaconf(__name__)
@@ -189,7 +188,8 @@ And then the following code would work:
 # settings.yaml
 
 default:
-    LOGIN_URL: "@reverse_lazy account_login"
+    ADMIN_NAMESPACE: admin
+    LOGIN_URL: "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
 ```
 
 !!! note

--- a/dynaconf/__init__.py
+++ b/dynaconf/__init__.py
@@ -4,6 +4,7 @@ from dynaconf.base import LazySettings  # noqa
 from dynaconf.constants import DEFAULT_SETTINGS_FILES
 from dynaconf.contrib import DjangoDynaconf  # noqa
 from dynaconf.contrib import FlaskDynaconf  # noqa
+from dynaconf.utils.parse_conf import add_converter  # noqa
 from dynaconf.validator import ValidationError  # noqa
 from dynaconf.validator import Validator  # noqa
 
@@ -28,4 +29,5 @@ __all__ = [
     "FlaskDynaconf",
     "ValidationError",
     "DjangoDynaconf",
+    "add_converter",
 ]

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -276,6 +276,20 @@ def get_converter(converter_key, value, box_settings):
     return converted_value
 
 
+def add_converter(converter_key, casting_callable):
+    global converters
+
+    def converter_callable(value, box_settings=None):
+        if isinstance(value, Lazy):
+            # value got here as a Lazy object, needs evaluation
+            return Lazy(value(box_settings), casting=casting_callable)
+        else:
+            # value is good to go
+            return Lazy(value, casting=casting_callable)
+
+    converters[f"@{converter_key}"] = converter_callable
+
+
 def parse_with_toml(data):
     """Uses TOML syntax to parse data"""
     try:  # try tomllib first

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -276,18 +276,20 @@ def get_converter(converter_key, value, box_settings):
     return converted_value
 
 
-def add_converter(converter_key, casting_callable):
-    global converters
+def add_converter(converter_key, func):
+    """Adds a new converter to the converters dict"""
+    if not converter_key.startswith("@"):
+        converter_key = f"@{converter_key}"
 
-    def converter_callable(value, box_settings=None):
-        if isinstance(value, Lazy):
-            # value got here as a Lazy object, needs evaluation
-            return Lazy(value(box_settings), casting=casting_callable)
-        else:
-            # value is good to go
-            return Lazy(value, casting=casting_callable)
-
-    converters[f"@{converter_key}"] = converter_callable
+    converters[converter_key] = wraps(func)(
+        lambda value: value.set_casting(func)
+        if isinstance(value, Lazy)
+        else Lazy(
+            value,
+            casting=func,
+            formatter=BaseFormatter(lambda x, **_: x, converter_key),
+        )
+    )
 
 
 def parse_with_toml(data):

--- a/tests_functional/django_example/foo/settings.py
+++ b/tests_functional/django_example/foo/settings.py
@@ -69,9 +69,7 @@ from django.urls import reverse_lazy  # noqa
 import dynaconf  # noqa
 from dynaconf.utils import parse_conf  # noqa
 
-parse_conf.converters["@reverse_lazy"] = lambda value: parse_conf.Lazy(
-    value, casting=reverse_lazy
-)
+parse_conf.add_converter("reverse_lazy", reverse_lazy)
 
 settings = dynaconf.DjangoDynaconf(
     __name__,

--- a/tests_functional/django_example/foo/settings.py
+++ b/tests_functional/django_example/foo/settings.py
@@ -65,7 +65,13 @@ sys.path.append(".")
 
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://www.dynaconf.com/django/
+from django.urls import reverse_lazy  # noqa
 import dynaconf  # noqa
+from dynaconf.utils import parse_conf  # noqa
+
+parse_conf.converters["@reverse_lazy"] = lambda value: parse_conf.Lazy(
+    value, casting=reverse_lazy
+)
 
 settings = dynaconf.DjangoDynaconf(
     __name__,

--- a/tests_functional/django_example/foo/settings.py
+++ b/tests_functional/django_example/foo/settings.py
@@ -67,9 +67,8 @@ sys.path.append(".")
 # Read more at https://www.dynaconf.com/django/
 from django.urls import reverse_lazy  # noqa
 import dynaconf  # noqa
-from dynaconf.utils import parse_conf  # noqa
 
-parse_conf.add_converter("reverse_lazy", reverse_lazy)
+dynaconf.add_converter("reverse_lazy", reverse_lazy)
 
 settings = dynaconf.DjangoDynaconf(
     __name__,

--- a/tests_functional/django_example/polls/tests.py
+++ b/tests_functional/django_example/polls/tests.py
@@ -52,6 +52,7 @@ class SettingsTest(TestCase):
         self.assertEqual(settings.PASSWORD, "My5up3r53c4et")
         self.assertEqual(settings.USERNAME, "admin_user_from_env")
         self.assertEqual(settings.FOO, "It overrides every other env")
+        self.assertEqual(settings.LOGIN_URL, "/admin/login/")
 
     def test_override_settings_context(self):
         self.assertEqual(settings.ISSUE, 596)

--- a/tests_functional/django_example/settings.yaml
+++ b/tests_functional/django_example/settings.yaml
@@ -8,6 +8,7 @@ default:
   SECRET_KEY: 1234
   STATIC_ROOT: .
   STATIC_URL: /static/
+  LOGIN_URL: "@reverse_lazy admin:login"
   ALLOWED_HOSTS:
     - '*'
   INSTALLED_APPS:

--- a/tests_functional/django_example/settings.yaml
+++ b/tests_functional/django_example/settings.yaml
@@ -8,7 +8,8 @@ default:
   SECRET_KEY: 1234
   STATIC_ROOT: .
   STATIC_URL: /static/
-  LOGIN_URL: "@reverse_lazy admin:login"
+  ADMIN_NAMESPACE: admin
+  LOGIN_URL: "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
   ALLOWED_HOSTS:
     - '*'
   INSTALLED_APPS:


### PR DESCRIPTION
Provides new add_converter function for cases of adding other converters, like Django's `reverse_lazy`. Wraps the converter up and enables converter chaining, e.g., with `@format`. Includes a functional test and update to docs.