### PR TITLE
Fix - Array entries duplicated when using Validator with default for computed value

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -864,6 +864,9 @@ class Settings:
                 key, value, loader_identifier=loader_identifier, tomlfy=tomlfy
             )
 
+        # Fix for #905
+        saved_value = value if loader_identifier == "setdefault" else None
+
         value = parse_conf_data(value, tomlfy=tomlfy, box_settings=self)
         key = upperfy(key.strip())
         existing = getattr(self, key, None)
@@ -896,9 +899,13 @@ class Settings:
             if merge:
                 value = object_merge(existing, value)
             else:
-                # `dynaconf_merge` may be used within the key structure
-                # Or merge_enabled is set to True
-                value = self._merge_before_set(existing, value)
+                # Fix for #905
+                if loader_identifier == "setdefault":
+                    value = saved_value
+                else:
+                    # `dynaconf_merge` may be used within the key structure
+                    # Or merge_enabled is set to True
+                    value = self._merge_before_set(existing, value)
 
         if isinstance(value, dict):
             value = DynaBox(value, box_settings=self)

--- a/tests_functional/issues/905_item_duplication_in_list/.env
+++ b/tests_functional/issues/905_item_duplication_in_list/.env
@@ -1,0 +1,3 @@
+DYNACONF_GROUP__TEST_LIST = ["'1'", "'2'"]   # double quotes to cast as string
+
+DYNACONF_GROUP__ANOTHER = 45

--- a/tests_functional/issues/905_item_duplication_in_list/README.md
+++ b/tests_functional/issues/905_item_duplication_in_list/README.md
@@ -1,0 +1,3 @@
+# [bug] array entries duplicated with Validator using default for computed value.
+
+https://github.com/dynaconf/dynaconf/issues/905

--- a/tests_functional/issues/905_item_duplication_in_list/app.py
+++ b/tests_functional/issues/905_item_duplication_in_list/app.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dynaconf import Dynaconf
+from dynaconf import Validator
+
+settings = Dynaconf(
+    envvar_prefix="DYNACONF",
+    settings_files=["settings.toml"],
+    environments=True,
+    load_dotenv=True,
+    merge_enabled=True,
+)
+
+
+settings.validators.register(
+    Validator("group.something_new", default=5),
+)
+
+settings.validators.validate()
+
+assert settings.group.test_list == ["'1'", "'2'"]
+assert settings.group.something_new == 5
+assert settings.group.another_setting == "ciao"

--- a/tests_functional/issues/905_item_duplication_in_list/settings.toml
+++ b/tests_functional/issues/905_item_duplication_in_list/settings.toml
@@ -1,0 +1,2 @@
+[default.group]
+another_setting = "ciao"


### PR DESCRIPTION
This fixes #905

---

Just for the records, I'll try to explain what I've understood about the problem, sorry if it is too confusing.

One of the key-point of the problem was that the process of setting the default for the Validator uses `tomlfy=True` and this causes some side-effect on the `default` field siblings.

In the last step of recording this value there is a `merge_before_set(new, old)` function. I would expect that the new data to be merged in the existing data would be only the `default` value provided in Validation, but all of it's siblings are used too (including list).

Before this merge, `parse_conf_data(data, tomlfy=True, ...)` is called with 'default' value and all of it's existing siblings, and this makes `new` and `old` data to have different version of `test_list`, one that is "tomlyfied" and the other that is not (the original one).