### PR TITLE
Feature - Allow system environment fallback in `get()` #742

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -474,6 +474,47 @@ skip_files=["path/to/ignored.toml"]
 
 ---
 
+### **sysenv_fallback**
+
+> type=`bool | list[str]`, default=`False` </br>
+> env-var=`SYSENV_FALLBACK_FOR_DYNACONF`
+
+Defines if dynaconf will try to load system environment variables (unprefixed)
+as a fallback when using `settings.get()`.
+
+Valid options are:
+
+- `False` (default): won't try to load system envvar
+- `True`: will try to load sys envvar for any name requested in `get()`
+- `list[str]`: will try to load sys envvar for the names provided in the list
+
+
+</br>
+
+This behaviour can also be defined on a per-call basis by providing
+the parameter `sysenv_fallback` to `settings.get()`
+
+Eg:
+
+```python
+from dynaconf import Dynaconf
+
+# will look for PATH (uppercase) in the system environment variables
+settings = Dynaconf(sysenv_fallback=True)
+settings.get("path")
+
+# can be set on a per-call basis
+settings = Dynaconf()
+settings.get("path", sysenv_fallback=True)
+
+# if a list is used, it filters what names are allowed.
+settings = Dynaconf(sysenv_fallback=["path"])
+settings.get("path")
+settings.get("user") # won't try loading unprefixed USER
+```
+
+---
+
 ### **validate_on_update**
 
 > type=`False | True | "all"`, default=`False` </br>

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -246,7 +246,12 @@ APPLY_DEFAULT_ON_NONE_FOR_DYNACONF = get(
     "APPLY_DEFAULT_ON_NONE_FOR_DYNACONF", None
 )
 
+# Auto trigger validation when Settings update methods are called directly
+# (set, update, load_file)
 VALIDATE_ON_UPDATE_FOR_DYNACONF = get("VALIDATE_ON_UPDATE_FOR_DYNACONF", False)
+
+# Use system environ as fallback when a setting was not set
+SYSENV_FALLBACK_FOR_DYNACONF = get("SYSENV_FALLBACK_FOR_DYNACONF", False)
 
 
 # Backwards compatibility with renamed variables

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1384,11 +1384,6 @@ def test_get_with_sysenv_fallback_global_as_true():
     assert settings.sysenv_fallback_for_dynaconf is True
     assert settings.get("test_key") == "TEST_VALUE"
 
-    # only support uppercase system envs
-    settings.environ["DIFFERENT_case"] = "CASE_VALUE"
-    assert not settings.get("different_case") == "CASE_VALUE"
-    assert not settings.get("DIFFERENT_case") == "CASE_VALUE"
-
 
 def test_get_with_sysenv_fallback_global_as_list():
     """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1372,6 +1372,7 @@ def test_get_with_sysenv_fallback_global_as_false():
     assert settings.sysenv_fallback_for_dynaconf is False
     assert not settings.get("test_key")
 
+
 def test_get_with_sysenv_fallback_global_as_true():
     """
     When sysenv_fallback is True
@@ -1402,6 +1403,7 @@ def test_get_with_sysenv_fallback_global_as_list():
     assert not settings.get("test_key")
     assert settings.get("foo_key") == "FOO_VALUE"
 
+
 def test_get_with_sysenv_fallback_local_overrides():
     """
     When there are local overrides
@@ -1415,7 +1417,9 @@ def test_get_with_sysenv_fallback_local_overrides():
     assert not settings.get("test_key")
     assert not settings.get("test_key", sysenv_fallback=["foo_key"])
     assert settings.get("test_key", sysenv_fallback=True) == "TEST_VALUE"
-    assert settings.get("test_key", sysenv_fallback=["test_key"]) == "TEST_VALUE"
+    assert (
+        settings.get("test_key", sysenv_fallback=["test_key"]) == "TEST_VALUE"
+    )
 
     # global is True
     settings = Dynaconf(sysenv_fallback=True)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1359,3 +1359,68 @@ def test_load_file__validate_on_update_is_str_all(tmpdir, valid, invalid):
     # should pass
     assert not settings.exists("value_a")
     settings.load_file(file_with_valid)
+
+
+def test_get_with_sysenv_fallback_global_as_false():
+    """
+    When global sysenv_fallback is False
+    Should not fallback to sys envvars (default)
+    """
+    settings = Dynaconf(sysenv_fallback=False)
+    settings.environ["TEST_KEY"] = "TEST_VALUE"
+
+    assert settings.sysenv_fallback_for_dynaconf is False
+    assert not settings.get("test_key")
+
+def test_get_with_sysenv_fallback_global_as_true():
+    """
+    When sysenv_fallback is True
+    Should fallback to sys envvars for uppercase envvar-names only
+    """
+    settings = Dynaconf(sysenv_fallback=True)
+    settings.environ["TEST_KEY"] = "TEST_VALUE"
+
+    assert settings.sysenv_fallback_for_dynaconf is True
+    assert settings.get("test_key") == "TEST_VALUE"
+
+    # only support uppercase system envs
+    settings.environ["DIFFERENT_case"] = "CASE_VALUE"
+    assert not settings.get("different_case") == "CASE_VALUE"
+    assert not settings.get("DIFFERENT_case") == "CASE_VALUE"
+
+
+def test_get_with_sysenv_fallback_global_as_list():
+    """
+    When sysenv_fallback is list
+    Should fallback to sys envvars only for listed names
+    """
+    settings = Dynaconf(sysenv_fallback=["FOO_KEY"])
+    settings.environ["TEST_KEY"] = "TEST_VALUE"
+    settings.environ["FOO_KEY"] = "FOO_VALUE"
+
+    assert isinstance(settings.sysenv_fallback_for_dynaconf, list)
+    assert not settings.get("test_key")
+    assert settings.get("foo_key") == "FOO_VALUE"
+
+def test_get_with_sysenv_fallback_local_overrides():
+    """
+    When there are local overrides
+    Should behave according to the overrides
+    """
+    # global is False
+    settings = Dynaconf(sysenv_fallback=False)
+    settings.environ["TEST_KEY"] = "TEST_VALUE"
+
+    assert settings.sysenv_fallback_for_dynaconf is False
+    assert not settings.get("test_key")
+    assert not settings.get("test_key", sysenv_fallback=["foo_key"])
+    assert settings.get("test_key", sysenv_fallback=True) == "TEST_VALUE"
+    assert settings.get("test_key", sysenv_fallback=["test_key"]) == "TEST_VALUE"
+
+    # global is True
+    settings = Dynaconf(sysenv_fallback=True)
+    settings.environ["ANOTHER_TEST"] = "ANOTHER_VALUE"
+
+    assert settings.sysenv_fallback_for_dynaconf is True
+    assert settings.get("another_test") == "ANOTHER_VALUE"
+    assert not settings.get("another_test", sysenv_fallback=False)


### PR DESCRIPTION
I've changed the proposed name in the original issue from `fallback_to_environ` to `sysenv_fallback` to stress that those are system environment variables, but it is totally fine to switch it back or to another name.

Also, I had some doubts on dealing with mixed casing, because windows seems to uppercase all environment variables and linux don't. To be safe, I chose to implement an uppercased-lookup of system variables, even though linux would support matching mixed-case.