### PR TITLE
Fix AttributeError with integer keys (yaml) #919

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -666,12 +666,6 @@ pip install dynaconf[redis]
 
 Read more on [external loaders](/advanced/#creating-new-loaders)
 
-## Extensions
-
-Community extensions will be linked here (open for recommendations).
-
-- [pytest-dynaconf]() - Set your Dynaconf environment to testing when running pytest.
-
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -386,7 +386,7 @@ def parse_conf_data(data, tomlfy=False, box_settings=None):
         # recursively parse inner dict items
         _parsed = {}
         for k, v in data.items():
-            _parsed[k] = parse_conf_data(
+            _parsed[str(k)] = parse_conf_data(
                 v, tomlfy=tomlfy, box_settings=box_settings
             )
         return _parsed


### PR DESCRIPTION
I'm not sure why this was supported before `v3.1.12` (see #919), because I didn't find explicit support for integer keys.

Anyway, the `ruamel.yaml` parser doesn't cast key integers to string (as toml parser does, for example), and some part of the system assumes all keys are strings, which I guess is a sane choice.

I've considered two approaches, assuming all int keys should be strings internally:
- Casting keys to integers in the loader level. This would require hacking the yaml parser (I guess this is not customizable) or writing a pos-parser to cast keys to string (this would cause some overhead, as all data would need to be traversed again).
- Cast keys when parsing them internally (`Settings.set`, `Settings.parse_conf`, etc). This wouldn't add overhead because the data need to pass through anyway. That's what I choose.

### Additional changes

I've also removed `pytest-dynaconf` recommendation on the main page, as their pypi link is broken.
