### PR TITLE
Docs - `load_file` relative path resolution and `root_path` fallbacks #909

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -61,13 +61,31 @@ You can also set the merging individually for each settings variable as seen on
 
 ## Programmatically loading a settings file
 
+You can load files from within a python script.
+
+When using relative paths, it will use `root_path` as its basepath.
+Learn more about how `root_path` fallback works [here](/configuration#root_path).
+
 ```python
-from dynaconf import settings
-settings.load_file(path="/path/to/file.toml")  # list or `;/,` separated allowed
+from dynaconf import Dynaconf
+
+settings = Dynaconf()
+
+# single file
+settings.load_file(path="/path/to/file.toml")
+
+# list
+settings.load_file(path=["/path/to/file.toml", "/path/to/another-file.toml"])
+
+# separated by ; or ,
+settings.load_file(path="/path/to/file.toml;/path/to/another-file.toml")
 ```
 
-> **NOTE**: programmatically loaded file is not persisted, once `env` is changed via `setenv|using_env`, or a `reload` or `configure` is invoked it will be cleaned, to persist it needs to go to `INCLUDES_FOR_DYNACONF` variable or you need to load it programmatically again.
+Notice that data loaded by this method is not persisted.
 
+Once `env` is changed via `setenv|using_env`, `reload` or `configure` invocation, its loaded data
+will be cleaned. To persist consider using `INCLUDES_FOR_DYNACONF` variable or assuring it will
+be loaded programmatically again.
 
 ## Prefix filtering
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,6 +269,23 @@ source, settings files will be read, envvars parsed and external loaders connect
 > env-var=`INCLUDES_FOR_DYNACONF`
 
 After loading the files specified in `settings_files` dynaconf will load all the files added to `includes` in a post-load process.
+Note that:
+
+- Globs are allowed
+- When relative paths are given it will use [root_path](/configuration#root_path) as their basedir.
+- If `root_path` is not defined explicitly, will fallback to the directory of the last loaded setting or
+to the `cwd`. Eg:
+
+```python
+# will look for src/extra.yaml
+Dynaconf(root_path="src/", includes="extra.yaml")
+
+# will look for conf/extra.yaml
+Dynaconf(setings_files="conf/settings.yaml", includes="extra.yaml")
+
+# will look for $PWD/extra.yaml
+Dynaconf(includes="extra.yaml")
+```
 
 !!! tip
     Includes can also be added inside files itself, ex:
@@ -284,13 +301,6 @@ After loading the files specified in `settings_files` dynaconf will load all the
     ```bash
     export INCLUDES_FOR_DYNACONF="['otherfile.toml', 'path/*.yaml']"
     ```
-
-    **Includes allows the use of globs**
-
-!!! warning
-    includes are loaded relative to the first loaded file, so if you have a `settings_files=['conf/settings.toml']` and `includes=["*.yaml"]`
-    the yaml files will be loaded relative to the `conf` folder. Unless you specify the absolute path or pass `root_path` to the Dynaconf
-    initializer.
 
 ---
 
@@ -433,9 +443,19 @@ default = {
 > type=`str`, default=`None` </br>
 > env-var=`ROOT_PATH_FOR_DYNACONF`
 
-The working path for dynaconf to use as starting point when searching for files:
+The working path for dynaconf to use as the starting point when searching for files.
 
-Read more on [settings_files](/settings_files/#load)
+Note that:
+
+- For relative path, uses `cwd` as its basepath
+- When not explicitly set, the internal value for `root_path` will be set as follow:
+    - The place of the last loaded file, if any files were already loaded
+    - CWD
+
+Read more on [settings_files](/settings_files/#load).
+
+!!! note
+     The `cwd` is from where the python interpreter was called.
 
 ---
 

--- a/docs/settings_files.md
+++ b/docs/settings_files.md
@@ -77,9 +77,9 @@ settings.name == "Bruno"
 Dynaconf will start looking for each file defined in `settings_files` from the folder where your entry point python file is located (like `app.py`). Then, it will look at each parent down to the root of the system. For each visited folder, it will also try looking inside a `/config` folder.
 
 - If you define [root_path](/configuration/#root_path), it will look start looking from there, instead. Keep in mind that `root_path` is relative to `cwd`, which is from where the python interpreter was called.
-- For each file specified in `settings_files` dynaconf will also try to load an optional `name`**.local.**`extension`. Eg, `settings_file="settings.toml"` will look for `settings.local.toml` too.
 - Absolute paths are recognized and dynaconf will attempt to load them directly.
-- Blobs are accepted.
+- For each file specified in `settings_files` dynaconf will also try to load an optional `name`**.local.**`extension`. Eg, `settings_file="settings.toml"` will look for `settings.local.toml` too.
+- Globs are accepted.
 
 Define it in your settings instance or export the corresponding envvars.
 

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1115,10 +1115,16 @@ class Settings:
     ):
         """Programmatically load files from ``path``.
 
+        When using relative paths, the basedir fallbacks in this order:
+        - ROOT_PATH_FOR_DYNACONF
+        - Directory of the last loaded file
+        - CWD
+
         :param path: A single filename or a file list
         :param env: Which env to load from file (default current_env)
         :param silent: Should raise errors?
         :param key: Load a single key?
+        :param validate: Should trigger validation?
         """
         if validate is empty:
             validate = self.get("VALIDATE_ON_UPDATE_FOR_DYNACONF")


### PR DESCRIPTION
Clarification about:
- `load_file` relative path resolution, which relies on `root_path`.
- `root_path`implicit setting, when not explicit defined via `ROOT_PATH_FOR_DYNACONF`.

Also:
- Small docstring appends on `load_file`

ps:
I'll leave the idea of [dot expansion](https://github.com/dynaconf/dynaconf/issues/909#issuecomment-1511918263) to v4 ([proposal](https://github.com/dynaconf/dynaconf/issues/923))