### PR TITLE
Fix - Order of variables break parsing (#869)

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -33,6 +33,7 @@ from dynaconf.utils.functional import empty
 from dynaconf.utils.functional import LazyObject
 from dynaconf.utils.parse_conf import converters
 from dynaconf.utils.parse_conf import get_converter
+from dynaconf.utils.parse_conf import Lazy
 from dynaconf.utils.parse_conf import parse_conf_data
 from dynaconf.utils.parse_conf import true_values
 from dynaconf.validator import ValidationError
@@ -900,7 +901,11 @@ class Settings:
 
         value = parse_conf_data(value, tomlfy=tomlfy, box_settings=self)
         key = upperfy(key.strip())
-        existing = getattr(self, key, None)
+
+        # Fix for #869 - The call to getattr trigger early evaluation
+        existing = (
+            getattr(self, key, None) if not isinstance(value, Lazy) else None
+        )
 
         if getattr(value, "_dynaconf_del", None):
             # just in case someone use a `@del` in a first level var.

--- a/tests_functional/issues/869_order_break_parsing/.env
+++ b/tests_functional/issues/869_order_break_parsing/.env
@@ -1,0 +1,4 @@
+DYNACONF_ROOT="@jinja {{ this.root_rel | abspath }}"
+DYNACONF_SUBDIR="@format {this.root}/dotenv"
+DYNACONF_ROOT_REL=".."
+DYNACONF_MERGING=["@format {this.ROOT_REL}", "dynaconf_merge"]

--- a/tests_functional/issues/869_order_break_parsing/app.py
+++ b/tests_functional/issues/869_order_break_parsing/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from dynaconf import Dynaconf

--- a/tests_functional/issues/869_order_break_parsing/app.py
+++ b/tests_functional/issues/869_order_break_parsing/app.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from dynaconf import Dynaconf
+
+settings = Dynaconf(
+    settings_file="settings.yaml",
+    load_dotenv=True,
+)
+
+# issue example
+assert settings.as_dict()
+assert settings.ROOT == str(Path().absolute().parent)
+
+# possible merging side-effects related to workaround
+assert settings.MERGING[0] == settings.SUBDIR
+assert settings.MERGING[1] == settings.ROOT_REL

--- a/tests_functional/issues/869_order_break_parsing/settings.yaml
+++ b/tests_functional/issues/869_order_break_parsing/settings.yaml
@@ -1,0 +1,3 @@
+MERGING: ["@jinja {{ this.SUBDIR }}"]
+SUBDIR: "@jinja {{ this.ROOT }}/yaml"
+ROOT: "../.."


### PR DESCRIPTION
This is a workaround for this specific case (it is not exhaustive in assuring any order is allowed).

I think v4 may implement a more explicit dependency manager for variable substitution to assure it evaluates them in the right order and properly identifies/treat cycles (probably with a graph).