### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -221,7 +221,9 @@ class DynaconfConfig(Config):
 
         for object_reference in app.config[key]:
             # parse the entry point specification
-            entry_point = EntryPoint(name=None, group=None, value=object_reference)
+            entry_point = EntryPoint(
+                name=None, group=None, value=object_reference
+            )
             # dynamically resolve the entry point
             initializer = entry_point.load()
             # Invoke extension initializer

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover
 
 
 import dynaconf
-import pkg_resources
+from importlib.metadata import EntryPoint
 
 
 class FlaskDynaconf:
@@ -220,11 +220,9 @@ class DynaconfConfig(Config):
             return
 
         for object_reference in app.config[key]:
-            # add a placeholder `name` to create a valid entry point
-            entry_point_spec = f"__name = {object_reference}"
             # parse the entry point specification
-            entry_point = pkg_resources.EntryPoint.parse(entry_point_spec)
+            entry_point = EntryPoint(name=None, group=None, value=object_reference)
             # dynamically resolve the entry point
-            initializer = entry_point.resolve()
+            initializer = entry_point.load()
             # Invoke extension initializer
             initializer(app)


### PR DESCRIPTION
This PR removes the dependency on pkg_resources and relies on stdlib importlib.metadata instead. This fixes the problem described in issue #851.