### PR TITLE
Fix - Template substitution with variable update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       vault:
-        image: vault
+        image: hashicorp/vault:latest
         ports:
           - 8200:8200
         env:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -810,11 +810,11 @@ def validate(ctx, path):  # pragma: no cover
 
 
 from dynaconf.utils.inspect import (
-    KeyNotFound,
+    KeyNotFoundError,
     builtin_dumpers,
     inspect_settings,
-    EnvNotFound,
-    InvalidOutputFormat,
+    EnvNotFoundError,
+    OutputFormatError,
 )
 
 INSPECT_FORMATS = list(builtin_dumpers.keys())
@@ -854,7 +854,7 @@ def inspect(ctx, key, env, format, descending):  # pragma: no cover
             ascending_order=(not descending),
         )
         click.echo()
-    except (KeyNotFound, EnvNotFound, InvalidOutputFormat) as err:
+    except (KeyNotFoundError, EnvNotFoundError, OutputFormatError) as err:
         click.echo(err)
         sys.exit(1)
 

--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -32,7 +32,6 @@ def load(
     # setup SourceMetadata (for inspecting)
     loader_identifier = SourceMetadata(identifier, mod.__name__, "global")
 
-    # breakpoint()
     load_from_python_object(
         obj, mod, settings_module, key, loader_identifier, validate=validate
     )

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -70,7 +70,16 @@ def object_merge(
             if correct_case_key:
                 new[correct_case_key] = new.pop(new_key)
 
-        for old_key, value in old.items():
+        def safe_items(data):
+            """
+            Get items from DynaBox without triggering recursive evaluation
+            """
+            if data.__class__.__name__ == "DynaBox":
+                return data._safe_items()
+            else:
+                return data.items()
+
+        for old_key, value in safe_items(old):
 
             # This is for when the dict exists internally
             # but the new value on the end of full path is the same
@@ -412,7 +421,13 @@ def recursively_evaluate_lazy_format(
 
     For example: Evaluate values inside lists and dicts
     """
+    return _recursively_evaluate_lazy_format(value, settings)
 
+
+def _recursively_evaluate_lazy_format(
+    value: Any, settings: Settings | LazySettings
+) -> Any:
+    """Recursive implementation. Separate for easier debugging."""
     if getattr(value, "_dynaconf_lazy_format", None):
         value = value(settings)
 
@@ -420,7 +435,7 @@ def recursively_evaluate_lazy_format(
         # Keep the original type, can be a BoxList
         value = value.__class__(
             [
-                recursively_evaluate_lazy_format(item, settings)
+                _recursively_evaluate_lazy_format(item, settings)
                 for item in value
             ]
         )

--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -48,6 +48,14 @@ class DynaBox(Box):
             n_item = find_the_correct_casing(item, self) or item
             return super().__getitem__(n_item, *args, **kwargs)
 
+    def _safe_get(self, item, *args, **kwargs):
+        """Get item bypassing recursive evaluation"""
+        try:
+            return super().__getitem__(item, *args, **kwargs)
+        except (AttributeError, KeyError):
+            n_item = find_the_correct_casing(item, self) or item
+            return super().__getitem__(n_item, *args, **kwargs)
+
     def __copy__(self):
         return self.__class__(
             super(Box, self).copy(),

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -36,15 +36,15 @@ OutputFormat = Union[Literal["yaml"], Literal["json"], Literal["json-compact"]]
 DumperType = Callable[[dict, TextIO], None]
 
 
-class KeyNotFound(Exception):
+class KeyNotFoundError(Exception):
     pass
 
 
-class EnvNotFound(Exception):
+class EnvNotFoundError(Exception):
     pass
 
 
-class InvalidOutputFormat(Exception):
+class OutputFormatError(Exception):
     pass
 
 
@@ -78,7 +78,7 @@ def inspect_settings(
 
     setting_envs = {_env.env for _env in settings._loaded_by_loaders.keys()}
     if env and env.lower() not in setting_envs:
-        raise EnvNotFound(f"The requested env is not valid: {env!r}")
+        raise EnvNotFoundError(f"The requested env is not valid: {env!r}")
 
     def env_filter(src: SourceMetadata) -> bool:
         return src.env.lower() == env.lower() if env else True
@@ -89,7 +89,7 @@ def inspect_settings(
         filter_src_metadata=env_filter,
     )
     if key_dotted_path and not history:
-        raise KeyNotFound(
+        raise KeyNotFoundError(
             f"The requested key was not found: {key_dotted_path!r}"
         )
 
@@ -126,7 +126,7 @@ def inspect_settings(
     try:
         dumper = builtin_dumpers[output_format.lower()]
     except KeyError:
-        raise InvalidOutputFormat(
+        raise OutputFormatError(
             f"The desired format is not available: {output_format!r}"
         )
 

--- a/dynaconf/vendor/box/box.py
+++ b/dynaconf/vendor/box/box.py
@@ -261,6 +261,10 @@ class Box(dict):
     def items(self):
         return [(x, self[x]) for x in self.keys()]
 
+    def _safe_items(self):
+        """Get items list without triggering recursive evaluation"""
+        return [(x, self._safe_get(x)) for x in self.keys()]
+
     def __get_default(self, item):
         default_value = self._box_config['default_box_attr']
         if default_value in (self.__class__, dict):

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - 6379:6379
     vault:
-        image: vault
+        image: hashicorp/vault:latest
         ports:
             - 8200:8200
         environment:

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -14,11 +14,11 @@ import pytest
 from dynaconf import Dynaconf
 from dynaconf.utils.inspect import _ensure_serializable
 from dynaconf.utils.inspect import _get_data_by_key
-from dynaconf.utils.inspect import EnvNotFound
+from dynaconf.utils.inspect import EnvNotFoundError
 from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import inspect_settings
-from dynaconf.utils.inspect import InvalidOutputFormat
-from dynaconf.utils.inspect import KeyNotFound
+from dynaconf.utils.inspect import KeyNotFoundError
+from dynaconf.utils.inspect import OutputFormatError
 from dynaconf.validator import Validator
 from dynaconf.vendor.ruamel import yaml
 
@@ -761,7 +761,7 @@ def test_caveat__get_history_env_true_workaround(tmp_path):
 
 def test_inspect_exception_key_not_found():
     settings = Dynaconf()
-    with pytest.raises(KeyNotFound):
+    with pytest.raises(KeyNotFoundError):
         inspect_settings(settings, key_dotted_path="non_existant")
 
 
@@ -783,13 +783,13 @@ def test_inspect_empty_settings(capsys):
 
 def test_inspect_exception_env_not_found():
     settings = Dynaconf(environments=True)
-    with pytest.raises(EnvNotFound):
+    with pytest.raises(EnvNotFoundError):
         inspect_settings(settings, env="non_existant")
 
 
 def test_inspect_exception_invalid_format():
     settings = Dynaconf()
-    with pytest.raises(InvalidOutputFormat):
+    with pytest.raises(OutputFormatError):
         inspect_settings(
             settings, output_format="invalid_format"  # type: ignore
         )

--- a/tests_functional/issues/575_603_666_690__envvar_with_template_substitution/Makefile
+++ b/tests_functional/issues/575_603_666_690__envvar_with_template_substitution/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	pytest -v app_test.py

--- a/tests_functional/issues/575_603_666_690__envvar_with_template_substitution/app_test.py
+++ b/tests_functional/issues/575_603_666_690__envvar_with_template_substitution/app_test.py
@@ -1,0 +1,176 @@
+"""
+Given
+- some source is using template substitution '@format {variable}'
+- the template and the variable are inside some nested structure
+When
+- the variable referred to in the template is updated by another source
+Should
+- execute substitution with the updated/newest value
+Instead (before fix)
+- the old value (from original source) is used
+
+https://github.com/dynaconf/dynaconf/issues/575
+https://github.com/dynaconf/dynaconf/issues/603
+https://github.com/dynaconf/dynaconf/issues/690
+"""
+from __future__ import annotations
+
+import os
+from textwrap import dedent
+from unittest import mock
+
+import pytest
+
+from dynaconf import Dynaconf
+
+
+def create_file(filename: str, data: str):
+    """Utility to help create tmp files"""
+    with open(filename, "w") as f:
+        f.write(dedent(data))
+    return filename
+
+
+def test_envvar_override_without_nesting(tmp_path):
+    """Works without nesting structures"""
+    environ = {"DYNACONF_DB_PORT": "9999"}
+    filename = create_file(
+        filename=tmp_path / "s.toml",
+        data="""\
+        DB_PORT='1234'
+        DB_ADDRESS='@format 127.0.0.1:{this.db_port}'
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename)
+        assert settings.db_port == 9999  # unwanted casting, but not related
+        assert settings.db_address == "127.0.0.1:9999"
+
+
+def test_envvar_override_with_nesting(tmp_path):
+    environ = {"DYNACONF_DATABASE__DB_PORT": "9999"}
+    filename = create_file(
+        filename=tmp_path / "s.toml",
+        data="""\
+        [database]
+        DB_PORT='1234'
+        DB_ADDRESS='@format 127.0.0.1:{this.database.db_port}'
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename)
+        assert settings.database.db_address == "127.0.0.1:9999"
+
+
+def test_update_method_with_nesting(tmp_path):
+    environ = {}
+    filename = create_file(
+        filename=tmp_path / "s.toml",
+        data="""\
+        [database]
+        DB_PORT='1234'
+        DB_ADDRESS='@format 127.0.0.1:{this.database.db_port}'
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename)
+        settings.update({"database": {"db_port": "9999"}}, merge=True)
+        assert settings.database.db_port == "9999"
+        assert settings.database.db_address == "127.0.0.1:9999"
+
+
+def test_575_example(tmp_path):
+    environ = {"DYNACONF_INGEST__BASE_PATH": "/tmp/ingest"}
+    filename = create_file(
+        filename=tmp_path / "s.toml",
+        data="""\
+        INSTALL_DIR = "/opt/myapp"
+        LOGS_DIR = "@format {this.INSTALL_DIR}/logs"
+
+        [ingest]
+        BASE_PATH = "/opt/ingest"
+        LOGS_DIR = "@format {this.ingest.BASE_PATH}/logs"
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename)
+        assert settings.ingest.LOGS_DIR == "/tmp/ingest/logs"
+        assert settings.ingest.BASE_PATH == "/tmp/ingest"
+
+
+def test_690_example(tmp_path):
+    environ = {"MYAPP_SERVER__VERSION__RELEASE": "7.2"}
+    filename = create_file(
+        filename=tmp_path / "s.yaml",
+        data="""\
+        SERVER:
+          VERSION:
+            RELEASE: "6.10"
+            SNAP: 22
+          DEPLOY_WORKFLOW: "deploy-sat-jenkins"
+          DEPLOY_ARGUMENTS:
+            sat_version: "@format {this.server.version.release}"
+            snap_version: "@format {this.server.version.snap}"
+            rhel_version: '7'
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(
+            envvar_prefix="MYAPP",
+            core_loaders=["YAML"],
+            settings_file=filename,
+        )
+        assert settings.server.deploy_arguments.sat_version == "7.2"
+        assert settings.server.deploy_arguments.snap_version == "22"
+        assert settings.server.deploy_arguments.rhel_version == "7"
+
+
+def test_666_example(tmp_path):
+    environ = {
+        "MYAPP_SERVER__VERSION__RELEASE": "7.2",
+        "ENV_FOR_DYNACONF": "env1",
+    }
+    filename = create_file(
+        filename=tmp_path / "s.yaml",
+        data="""\
+        default:
+            a_level1:
+                prefix: default
+                level2:
+                    value: "@format {this.a_level1.prefix}-xxx"
+            b_level1:
+                prefix: default
+                level2:
+                    some_key: True
+                    value: "@format {this.b_level1.prefix}-xxx"
+        env1:
+            dynaconf_merge: True
+            a_level1:
+                prefix: env1
+
+            b_level1:
+                prefix: env1
+                level2:
+                    some_key: False
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename, environments=True)
+        assert settings.a_level1.level2.value == "env1-xxx"
+        assert settings.b_level1.level2.value == "env1-xxx"
+
+
+def test_603_example(tmp_path):
+    environ = {"DYNACONF_DATABASE__DB_PORT": "9999"}
+    filename = create_file(
+        filename=tmp_path / "s.toml",
+        data="""\
+        [default.database]
+        DB_HOST = "127.0.0.1"
+        DB_PORT = "5432"
+        DB_ADDRESS = "@format {this.database.DB_HOST}:{this.database.DB_PORT}"
+        """,
+    )
+    with mock.patch.dict(os.environ, environ):
+        settings = Dynaconf(settings_file=filename, environments=True)
+        assert settings.database.db_address == "127.0.0.1:9999"

--- a/tests_functional/issues/879_cli_validate_isinstance/pyrightconfig.json
+++ b/tests_functional/issues/879_cli_validate_isinstance/pyrightconfig.json
@@ -1,4 +1,0 @@
-{
-  "venvPath": "/home/pedro-psb/dev/projects/dynaconf-issues/879_cli_validate_isinstace",
-  "venv": "venv"
-}

--- a/tests_functional/test_vault.sh
+++ b/tests_functional/test_vault.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-docker run --rm --name dynaconf_with_vault -d -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -p 8200:8200 vault || true
+docker run --rm \
+    --name dynaconf_with_vault -d \
+    -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
+    -p 8200:8200 \
+    hashicorp/vault:latest \
+    || true
 sleep 5
 cd tests_functional/vault
 pwd

--- a/tests_functional/test_vault_userpass.sh
+++ b/tests_functional/test_vault_userpass.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-docker run --rm --name dynaconf_with_vault -d -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -p 8200:8200 vault || true
+docker run --rm \
+    --name dynaconf_with_vault -d \
+    -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
+    -p 8200:8200 \
+    hashicorp/vault:latest \
+    || true
 sleep 5
 cd tests_functional/vault_userpass
 pwd


### PR DESCRIPTION
This fixes the misbehavior of template substitution when the variable to be substituted gets updated by another source, as described in #575 #603 #666 and #690

**Main changes:**
- avoid replacement of `Lazy` objects by it's value inside `parse_conf_data`
- add `_safe_get` and `_safe_items` methods to `DynaBox`.
- small unrelated refactors

## Problem Overview

There were some points where earlier evaluation was called internally. Although those calls were unnecessary, they shouldn't have cause this bug by itself because evaluating a Lazy object means only asking it to return the final value (it doesn't replace itself with the value), so later on it should have used the correct value. Nevertheless, `parse_conf_data` was replacing the Lazy object with its early evaluation value, and that was the main cause of the problem.

## Additional Notes

Related to this, it would be nice to:
- solve previous related problems more cleanly (eg, #910 #933)
- track and remove unnecessary internal recursive evaluation calls (may improve performance).