### PR TITLE
Fix - Infinite recursions in django app with lowercase_read=False #867

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -297,7 +297,7 @@ class Settings:
                     is False
                 ):
                     # only matches exact casing, first levels always upper
-                    return self._store.to_dict()[name]
+                    return self._store.__getattribute__(name)
                 # perform lookups for upper, and casefold
                 return self._store[name]
         # in case of RESERVED_ATTRS or KeyError above, keep default behaviour

--- a/tests_functional/issues/867_django_lowercase_recursion/manage.py
+++ b/tests_functional/issues/867_django_lowercase_recursion/manage.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myprj.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_functional/issues/867_django_lowercase_recursion/myprj/asgi.py
+++ b/tests_functional/issues/867_django_lowercase_recursion/myprj/asgi.py
@@ -1,0 +1,17 @@
+"""
+ASGI config for myprj project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
+"""
+from __future__ import annotations
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myprj.settings")
+
+application = get_asgi_application()

--- a/tests_functional/issues/867_django_lowercase_recursion/myprj/settings.py
+++ b/tests_functional/issues/867_django_lowercase_recursion/myprj/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
+
+import dynaconf
+
+PROJECT_ROOT = Path(__file__).parent.parent.resolve(strict=True).as_posix()
+
+settings = dynaconf.DjangoDynaconf(
+    __name__,
+    root_path=PROJECT_ROOT,
+    core_loaders=["TOML", "PY"],
+    settings_files=["settings.toml"],
+    lowercase_read=False,
+)
+
+
+# Behavior consistent with lowercase_read=False unit tests
+try:
+    settings.secret_key
+except AttributeError:
+    assert True  # should raise, because lowercase_read = False
+
+assert settings.Secret_key == "a"
+assert settings.SECRET_KEY == "a"

--- a/tests_functional/issues/867_django_lowercase_recursion/myprj/urls.py
+++ b/tests_functional/issues/867_django_lowercase_recursion/myprj/urls.py
@@ -1,0 +1,23 @@
+"""myprj URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/4.1/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+from __future__ import annotations
+
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/tests_functional/issues/867_django_lowercase_recursion/myprj/wsgi.py
+++ b/tests_functional/issues/867_django_lowercase_recursion/myprj/wsgi.py
@@ -1,0 +1,17 @@
+"""
+WSGI config for myprj project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.1/howto/deployment/wsgi/
+"""
+from __future__ import annotations
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myprj.settings")
+
+application = get_wsgi_application()

--- a/tests_functional/issues/867_django_lowercase_recursion/settings.toml
+++ b/tests_functional/issues/867_django_lowercase_recursion/settings.toml
@@ -1,0 +1,3 @@
+[default]
+secret_key = "a"
+test_value = "foo"


### PR DESCRIPTION
This fixes the special case that caused infinite recursion with the option `lowercase_read=False` in #867 .

[This solution](https://github.com/dynaconf/dynaconf/issues/867#issuecomment-1477129966) of some months ago was working at the time, but I misinterpreted the expected behavior for `lowercase_read=False`, which disallows only all lowercase characters (but permits other cases), as shown in those unit test: https://github.com/dynaconf/dynaconf/blob/c43c29e4cf96bb7174d4a582c644dccd1c3d31f0/tests/test_base.py#L47.

The solution consisted in replacing `_store.as_dict()[name]` with a more direct access method, which luckly avoided the recursive calls.
