### PR TITLE
Update vault and redis APIs as suggested in deprecation warnings. fix #950

### DIFF
--- a/dynaconf/loaders/redis_loader.py
+++ b/dynaconf/loaders/redis_loader.py
@@ -94,7 +94,7 @@ def write(obj, data=None, **kwargs):
     redis_data = {
         upperfy(key): unparse_conf_data(value) for key, value in data.items()
     }
-    client.hmset(holder.upper(), redis_data)
+    client.hset(holder.upper(), mapping=redis_data)
     load(obj)
 
 

--- a/dynaconf/loaders/vault_loader.py
+++ b/dynaconf/loaders/vault_loader.py
@@ -109,7 +109,9 @@ def load(obj, env=None, silent=None, key=None, validate=False):
         try:
             if obj.VAULT_KV_VERSION_FOR_DYNACONF == 2:
                 data = client.secrets.kv.v2.read_secret_version(
-                    path, mount_point=obj.VAULT_MOUNT_POINT_FOR_DYNACONF
+                    path,
+                    mount_point=obj.VAULT_MOUNT_POINT_FOR_DYNACONF,
+                    raise_on_deleted_version=True,  # keep default behavior
                 )
             else:
                 data = client.secrets.kv.read_secret(


### PR DESCRIPTION
### Vault

The [deprecation warning](https://github.com/dynaconf/dynaconf/issues/950) was quite straighfoward. Only the `kv2.read_secret_version` seems to be involved.

### Redis

[This](https://github.com/redis/redis-py/issues/1269) explain the redis deprecation warning and this shows that `hmset` can be replaced by `hset`. The use of `hset` here requires `redis` [v4](https://docs.redis.com/latest/rs/release-notes/legacy-release-notes/rlec-4-0-june-2015/) (2015) or higher. Should we add a fallback?



