### PR TITLE
Fix - Enable merge equal False

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -33,7 +33,7 @@ from dynaconf.utils import RENAMED_VARS
 from dynaconf.utils import upperfy
 from dynaconf.utils.boxing import DynaBox
 from dynaconf.utils.files import find_file
-from dynaconf.utils.functional import empty
+from dynaconf.utils.functional import Empty, empty
 from dynaconf.utils.functional import LazyObject
 from dynaconf.utils.parse_conf import apply_converter
 from dynaconf.utils.parse_conf import converters
@@ -886,7 +886,7 @@ class Settings:
         dotted_lookup=empty,
         is_secret="DeprecatedArgument",  # noqa
         validate=empty,
-        merge=False,
+        merge=empty,
     ):
         """Set a value storing references for the loader
 
@@ -934,6 +934,7 @@ class Settings:
             getattr(self, key, None) if not isinstance(value, Lazy) else None
         )
 
+
         if getattr(value, "_dynaconf_del", None):
             # just in case someone use a `@del` in a first level var.
             self.unset(key, force=True)
@@ -971,7 +972,7 @@ class Settings:
 
         if existing is not None and existing != value:
             # `dynaconf_merge` used in file root `merge=True`
-            if merge:
+            if merge and merge is not empty:
                 loader_identifier = (
                     loader_identifier._replace(merged=True)
                     if loader_identifier
@@ -989,7 +990,7 @@ class Settings:
                     # `dynaconf_merge` may be used within the key structure
                     # Or merge_enabled is set to True
                     value, updated_identifier = self._merge_before_set(
-                        existing, value, loader_identifier
+                        existing, value, loader_identifier, context_merge=merge
                     )
                     loader_identifier = updated_identifier
 
@@ -1018,7 +1019,7 @@ class Settings:
         data=None,
         loader_identifier=None,
         tomlfy=False,
-        merge=False,
+        merge=empty,
         is_secret="DeprecatedArgument",  # noqa
         dotted_lookup=empty,
         validate=empty,
@@ -1070,13 +1071,19 @@ class Settings:
             self.validators.validate_all()
 
     def _merge_before_set(
-        self, existing, value, identifier: SourceMetadata | None = None
+        self, existing, value, identifier: SourceMetadata | None = None, context_merge=empty
     ):
         """
         Merge the new value being set with the existing value before set
         Returns the merged value and the updated identifier (for inspecting).
         """
-        global_merge = getattr(self, "MERGE_ENABLED_FOR_DYNACONF", False)
+        # if identifier and identifier.loader == "toml":
+        #     breakpoint()
+
+        # context_merge may come from file_scope or env_scope
+        if context_merge is empty:
+            context_merge = self.get("MERGE_ENABLED_FOR_DYNACONF")
+
         if isinstance(value, dict):
             local_merge = value.pop(
                 "dynaconf_merge", value.pop("dynaconf_merge_unique", None)
@@ -1085,25 +1092,25 @@ class Settings:
                 # In case `dynaconf_merge:` holds value not boolean - ref #241
                 value = local_merge
 
-            if global_merge or local_merge:
+            if local_merge or (context_merge and local_merge is not False):
                 identifier = (
                     identifier._replace(merged=True) if identifier else None
                 )
                 value = object_merge(existing, value)
 
         if isinstance(value, (list, tuple)):
-            local_merge = (
-                "dynaconf_merge" in value or "dynaconf_merge_unique" in value
-            )
-            if global_merge or local_merge:
-                value = list(value)
-                unique = False
-                if local_merge:
-                    try:
-                        value.remove("dynaconf_merge")
-                    except ValueError:  # EAFP
-                        value.remove("dynaconf_merge_unique")
-                        unique = True
+            value = list(value)
+            local_merge = None
+            unique = False
+            if "dynaconf_merge" in value:
+                value.remove("dynaconf_merge")
+                local_merge = True
+            elif "dynaconf_merge_unique" in value:
+                value.remove("dynaconf_merge_unique")
+                local_merge = True
+                unique = True
+
+            if local_merge or (context_merge and local_merge is not False):
                 identifier = (
                     identifier._replace(merged=True) if identifier else None
                 )

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -33,7 +33,8 @@ from dynaconf.utils import RENAMED_VARS
 from dynaconf.utils import upperfy
 from dynaconf.utils.boxing import DynaBox
 from dynaconf.utils.files import find_file
-from dynaconf.utils.functional import Empty, empty
+from dynaconf.utils.functional import Empty
+from dynaconf.utils.functional import empty
 from dynaconf.utils.functional import LazyObject
 from dynaconf.utils.parse_conf import apply_converter
 from dynaconf.utils.parse_conf import converters
@@ -934,7 +935,6 @@ class Settings:
             getattr(self, key, None) if not isinstance(value, Lazy) else None
         )
 
-
         if getattr(value, "_dynaconf_del", None):
             # just in case someone use a `@del` in a first level var.
             self.unset(key, force=True)
@@ -1071,13 +1071,17 @@ class Settings:
             self.validators.validate_all()
 
     def _merge_before_set(
-        self, existing, value, identifier: SourceMetadata | None = None, context_merge=empty
+        self,
+        existing,
+        value,
+        identifier: SourceMetadata | None = None,
+        context_merge=empty,
     ):
         """
         Merge the new value being set with the existing value before set
         Returns the merged value and the updated identifier (for inspecting).
         """
-        # if identifier and identifier.loader == "toml":
+        # if identifier and identifier.loader == "py":
         #     breakpoint()
 
         # context_merge may come from file_scope or env_scope

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -33,7 +33,6 @@ from dynaconf.utils import RENAMED_VARS
 from dynaconf.utils import upperfy
 from dynaconf.utils.boxing import DynaBox
 from dynaconf.utils.files import find_file
-from dynaconf.utils.functional import Empty
 from dynaconf.utils.functional import empty
 from dynaconf.utils.functional import LazyObject
 from dynaconf.utils.parse_conf import apply_converter
@@ -1081,9 +1080,6 @@ class Settings:
         Merge the new value being set with the existing value before set
         Returns the merged value and the updated identifier (for inspecting).
         """
-        # if identifier and identifier.loader == "py":
-        #     breakpoint()
-
         # context_merge may come from file_scope or env_scope
         if context_merge is empty:
             context_merge = self.get("MERGE_ENABLED_FOR_DYNACONF")

--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -14,6 +14,7 @@ from dynaconf.utils import DynaconfDict
 from dynaconf.utils import object_merge
 from dynaconf.utils import upperfy
 from dynaconf.utils.files import find_file
+from dynaconf.utils.functional import empty
 
 
 def load(
@@ -24,7 +25,14 @@ def load(
     key=None,
     validate=False,
 ):
-    """Tries to import a python module"""
+    """
+    Tries to import a python module
+
+    Notes:
+        It doesn't handle environment namespaces explicitly. Eg
+            [default], [development], etc
+        See tests/test_nested_loading.py sample python file
+    """
     mod, loaded_from = get_module(obj, settings_module, silent)
     if not (mod and loaded_from):
         return
@@ -40,9 +48,10 @@ def load(
 def load_from_python_object(
     obj, mod, settings_module, key=None, identifier=None, validate=False
 ):
-    file_merge = getattr(mod, "dynaconf_merge", False) or getattr(
-        mod, "DYNACONF_MERGE", False
-    )
+    file_merge = getattr(mod, "dynaconf_merge", empty)
+    if file_merge is empty:
+        file_merge = getattr(mod, "DYNACONF_MERGE", empty)
+
     for setting in dir(mod):
         # A setting var in a Python file should start with upper case
         # valid: A_value=1, ABC_value=3 A_BBB__default=1

--- a/tests/test_nested_loading.py
+++ b/tests/test_nested_loading.py
@@ -154,6 +154,7 @@ port="@int 8080"
             ini="@int 5"
 """
 
+# this should have scoped envs DEFAULT, CUSTOM, etc
 PY_PLUGIN_TEXT = """
 DATABASE_URI = "py.example.com"
 PORT = 8080
@@ -265,7 +266,8 @@ def test_load_nested_different_types_with_merge(tmpdir):
     toml_plugin_file = tmpdir.join("plugin1.toml")
     toml_plugin_file.write(TOML_PLUGIN)
 
-    for ext in ["toml", "json", "yaml", "ini", "py"]:
+    # for ext in ["toml", "json", "yaml", "ini", "py"]:
+    for ext in ["toml", "json", "yaml", "ini"]:
         json_plugin_file = tmpdir.join(f"plugin2.{ext}")
         json_plugin_file.write(PLUGIN_TEXT[ext])
 
@@ -290,7 +292,8 @@ def test_load_nested_different_types_with_merge(tmpdir):
     assert settings.NESTED_1.nested_2.base == 2
     assert settings.NESTED_1.nested_2.nested_3.base == 3
     assert settings.NESTED_1.nested_2.nested_3.nested_4.base == 4
-    for ext in ["toml", "json", "yaml", "ini", "py"]:
+    # for ext in ["toml", "json", "yaml", "ini", "py"]:
+    for ext in ["toml", "json", "yaml", "ini"]:
         assert settings.NESTED_1.nested_2.nested_3.nested_4[ext] == 5
 
 

--- a/tests/test_nested_loading.py
+++ b/tests/test_nested_loading.py
@@ -154,7 +154,6 @@ port="@int 8080"
             ini="@int 5"
 """
 
-# this should have scoped envs DEFAULT, CUSTOM, etc
 PY_PLUGIN_TEXT = """
 DATABASE_URI = "py.example.com"
 PORT = 8080
@@ -266,8 +265,7 @@ def test_load_nested_different_types_with_merge(tmpdir):
     toml_plugin_file = tmpdir.join("plugin1.toml")
     toml_plugin_file.write(TOML_PLUGIN)
 
-    # for ext in ["toml", "json", "yaml", "ini", "py"]:
-    for ext in ["toml", "json", "yaml", "ini"]:
+    for ext in ["toml", "json", "yaml", "ini", "py"]:
         json_plugin_file = tmpdir.join(f"plugin2.{ext}")
         json_plugin_file.write(PLUGIN_TEXT[ext])
 
@@ -292,8 +290,7 @@ def test_load_nested_different_types_with_merge(tmpdir):
     assert settings.NESTED_1.nested_2.base == 2
     assert settings.NESTED_1.nested_2.nested_3.base == 3
     assert settings.NESTED_1.nested_2.nested_3.nested_4.base == 4
-    # for ext in ["toml", "json", "yaml", "ini", "py"]:
-    for ext in ["toml", "json", "yaml", "ini"]:
+    for ext in ["toml", "json", "yaml", "ini", "py"]:
         assert settings.NESTED_1.nested_2.nested_3.nested_4[ext] == 5
 
 

--- a/tests_functional/issues/835_926_enable-merge-equal-false/Makefile
+++ b/tests_functional/issues/835_926_enable-merge-equal-false/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	pytest app_test.py -sv
+

--- a/tests_functional/issues/835_926_enable-merge-equal-false/Makefile
+++ b/tests_functional/issues/835_926_enable-merge-equal-false/Makefile
@@ -2,4 +2,3 @@
 
 test:
 	pytest app_test.py -sv
-

--- a/tests_functional/issues/835_926_enable-merge-equal-false/app_test.py
+++ b/tests_functional/issues/835_926_enable-merge-equal-false/app_test.py
@@ -1,0 +1,344 @@
+from textwrap import dedent
+
+import pytest
+
+from dynaconf import Dynaconf
+from dynaconf.utils.inspect import get_history
+
+
+def create_file(filename: str, data: str) -> str:
+    """Utility to create files"""
+    with open(filename, "w") as file:
+        file.write(dedent(data))
+    return filename
+
+
+def test_case_835(tmp_path):
+    """
+    When using dynaconf_merge=False inside a structure
+    Should prevent merging of that structure
+    """
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        [general]
+        a = 1
+
+        [other]
+        a = 2
+        """,
+    )
+
+    file_b = create_file(
+        tmp_path / "b.toml",
+        """\
+        [general]
+        b = 1
+
+        [other]
+        dynaconf_merge = false
+        b = 2
+        """,
+    )
+    settings = Dynaconf(
+        settings_files=[file_a, file_b],
+        merge_enabled=True,
+    )
+
+    assert settings.other.b == 2
+    with pytest.raises(AttributeError):
+        settings.other.a
+
+
+def test_case_926_workaround(tmp_path):
+    """
+    The original example is not a bug because toplevel always merges.
+    But it can be achieved by explicitly deleting old keys.
+    """
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        [default]
+        DEBUG = true
+        [default.nested]
+        Name="Test"
+        """,
+    )
+
+    file_hooks = create_file(
+        tmp_path / "dynaconf_hooks.py",
+        """\
+        def post(settings):
+            data = {}
+            if settings.DEBUG:
+                data["database_url"] = "sqlite://"
+                data["name"] = "@del"
+            return data
+        """,
+    )
+    settings = Dynaconf(
+        environments=True,
+        settings_files=[file_a, file_hooks],
+    )
+
+    assert settings.database_url == "sqlite://"
+    with pytest.raises(AttributeError):
+        settings.name
+
+
+def test_case_926_local_scope_merge_marks(tmp_path):
+    """
+    When using merge=False on inner structure with global merge_enabled=True
+    Should prevent merging from that level (in dicts)
+    """
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        [default]
+        DEBUG = true
+        [default.nested]
+        Name="Test"
+        """,
+    )
+
+    file_hooks = create_file(
+        tmp_path / "dynaconf_hooks.py",
+        """\
+        def post(settings):
+            data = {}
+            if settings.DEBUG:
+                data["nested"] = {
+                    "database_url": "sqlite://",
+                    "dynaconf_merge": False
+                }
+            return data
+        """,
+    )
+    settings = Dynaconf(
+        environments=True,
+        settings_files=[file_a, file_hooks],
+    )
+
+    assert settings.nested.database_url == "sqlite://"
+    with pytest.raises(AttributeError):
+        settings.nested.name
+
+
+def test_case_926_file_scope_merge_mark(tmp_path):
+    """
+    When using merge=False on toplevel with global merge_enabled=True
+    Should propagate merge=False to nested structures
+    """
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        [default]
+        DEBUG = true
+        [default.nested]
+        Name="Test"
+        """,
+    )
+
+    file_hooks = create_file(
+        tmp_path / "dynaconf_hooks.py",
+        """\
+        def post(settings):
+            data = {"dynaconf_merge": False}
+            if settings.DEBUG:
+                data["nested"] = {"database_url": "sqlite://"}
+            return data
+        """,
+    )
+    settings = Dynaconf(
+        environments=True,
+        settings_files=[file_a, file_hooks],
+    )
+
+    assert settings.nested.database_url == "sqlite://"
+    with pytest.raises(AttributeError):
+        settings.nested.name
+
+
+def test_local_scope_merge_false():
+    """ """
+    settings = Dynaconf(
+        environments=True,
+        merge_enabled=True,
+    )
+    settings.set("dicty.name", "foo")
+    settings.set("listy", [1, 2, 3])
+    settings.update({"dicty": {"database_url": "sqlite://", "dynaconf_merge": False}})
+    settings.update({"listy": [9999]})
+
+    assert settings.dicty == {"database_url": "sqlite://"}
+    assert settings.listy == [1, 2, 3, 9999]
+
+
+def test_file_scope_merge_false(tmp_path):
+    """
+    Similar to when using a merge_enabled=true in the toplevel of a file,
+    using merge_enabled=false should prevent all structures of that scope from
+    merging (with the exception of the toplevel itself), even if global
+    merge_enabled=True.
+    """
+    # file-scope dynaconf_merge=True, merge_enabled=False
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        dicty={name="foo"}
+        listy=[1, 2, 3]
+        """,
+    )
+    file_b = create_file(
+        tmp_path / "b.toml",
+        """\
+        dynaconf_merge=true
+        dicty={database_url="sqlite://"}
+        listy=[9999]
+        """,
+    )
+    settings = Dynaconf(merge_enabled=False, settings_file=[file_a, file_b])
+    assert settings.dicty == {"database_url": "sqlite://", "name": "foo"}
+    assert settings.listy == [1, 2, 3, 9999]
+
+    # file-scope dynaconf_merge=False, merge_enabled=True
+    file_c = create_file(
+        tmp_path / "c.toml",
+        """\
+        dicty={name="foo"}
+        listy=[1, 2, 3]
+        """,
+    )
+    file_d = create_file(
+        tmp_path / "d.toml",
+        """\
+        dynaconf_merge=false
+        dicty={database_url="sqlite://"}
+        listy=[9999]
+        """,
+    )
+    settings = Dynaconf(merge_enabled=True, settings_file=[file_c, file_d])
+    assert settings.dicty == {"database_url": "sqlite://"}
+    assert settings.listy == [9999]
+
+
+def test_regression_expected_merge_on_toplevel_structure(tmp_path):
+    """
+    Top-level merges are implicitly always True.
+    It is expected that the merge_enabled flag and local merge marks don't
+    take effect on the top-level/root structure.
+    """
+    file_a = create_file(
+        tmp_path / "a.toml",
+        """\
+        [default]
+        from_a="foo"
+        """,
+    )
+
+    file_b = create_file(
+        tmp_path / "b.toml",
+        """\
+        [default]
+        from_b="bar"
+        """,
+    )
+
+    settings = Dynaconf(
+        environments=True, settings_files=[file_a, file_b], merge_enabled=False
+    )
+
+    assert settings.from_a == "foo"
+    assert settings.from_b == "bar"
+
+
+def test_regression_global_set_merge():
+    settings = Dynaconf()
+    settings.set("MERGE_ENABLED_FOR_DYNACONF", True)
+    settings.set("MERGE_KEY", {"items": [{"name": "item 1"}, {"name": "item 2"}]})
+    settings.set("MERGE_KEY", {"items": [{"name": "item 3"}, {"name": "item 4"}]})
+    assert settings.MERGE_KEY == {
+        "items": [
+            {"name": "item 1"},
+            {"name": "item 2"},
+            {"name": "item 3"},
+            {"name": "item 4"},
+        ]
+    }
+
+
+def test_regression_local_set_merge():
+    settings = Dynaconf()
+    settings.set("DATABASE", {"host": "localhost", "port": 666})
+    settings.set("DATABASE", {"host": "localhost", "port": 666})
+    assert settings.DATABASE == {"host": "localhost", "port": 666}
+
+    settings.set("DATABASE", {"host": "new", "user": "admin", "dynaconf_merge": True})
+    assert settings.DATABASE == {"host": "new", "port": 666, "user": "admin"}
+    assert settings.DATABASE.HOST == "new"
+    assert settings.DATABASE.user == "admin"
+
+
+def test_regression_dotted_merge_should_be_false_1(tmp_path):
+    filename = create_file(
+        tmp_path / "t.toml",
+        """\
+        [default]
+        foo='from_env_default'
+        [development]
+        foo='from_env_development'
+        [prod]
+        bar='prod_only'
+        spam='should_appear'
+        """,
+    )
+    settings = Dynaconf(settings_file=filename, environments=True)
+    settings.from_env("prod")
+    history = get_history(settings)
+    for record in history:
+        assert record["merged"] is False
+
+
+def test_regression_dotted_merge_should_be_false_2(tmp_path):
+    filename = create_file(
+        tmp_path / "t.toml",
+        """\
+        default.foo='from_env_default'
+        development.foo='from_env_development'
+        prod.bar='prod_only'
+        prod.spam='should_appear'
+        """,
+    )
+    settings = Dynaconf(settings_file=filename, environments=True)
+    settings.from_env("prod")
+    history = get_history(settings)
+    for record in history:
+        assert record["merged"] is False
+
+
+def test_regression_include(tmp_path):
+    include_file = create_file(
+        tmp_path / "foo.toml",
+        f"""\
+        [default]
+        key_b="bar"
+        dicty={{spam_b="eggs_b"}}
+        listy=[999]
+        """,
+    )
+    file_a = create_file(
+        tmp_path / "t.toml",
+        f"""\
+        [default]
+        key_a="foo"
+        dicty={{spam_a="eggs_a"}}
+        listy=[1,2,3]
+        dynaconf_include="{include_file}"
+        """,
+    )
+    settings = Dynaconf(settings_file=file_a, environments=True, merge_enabled=True)
+    assert settings.dicty.spam_a == "eggs_a"
+    assert settings.dicty.spam_b == "eggs_b"
+    assert settings.listy == [1,2,3,999]
+    assert settings.key_a == "foo"
+    assert settings.key_b == "bar"


### PR DESCRIPTION
Fix #835 and #926 

## Overview

The problem was that `False` was treated as a general fallback and would not be used even if located in a high override-priority position:
* local-scope marks
* file-scope marks
* global-flag

To solve it, I applied the same strategy used in some places of the codebase of using the `empty` sentinel for not-set values, thus making override priority relationships more explicit.