### PR TITLE
Inspect Review

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -113,7 +113,7 @@ foo: from_yaml
 $ python
 >>> from dynaconf import Dynaconf, inspect_settings
 >>> settings = Dynaconf()
->>> inspect_settings(settings, key_dotted_path="foo", output_format="yaml")
+>>> inspect_settings(settings, key_dotted_path="foo", dumper="yaml")
 header:
   filters:
     env: None
@@ -139,7 +139,7 @@ history:
 To save to a file use:
 
 ```python
-inspect_setting(setting, to_file="filename.json", output_format="json")
+inspect_setting(setting, to_file="filename.json", dumper="json")
 ```
 
 Dynaconf supports some builtin formats, but you can use a custom dumper too that

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,7 @@ Note that `-i`/`--instance` cannot be used with `init` as `-i` must point to an 
 
 Inspect and dump data's loading history about a specific key or environment.
 
-This command is also available as a utility function at `dynaconf.inspect_settings` ([learn more](/advanced#inspect_settings)).
+It is also available as a [utility function](/advanced#inspecting-history).
 
 ```
 Usage: dynaconf inspect [OPTIONS]
@@ -127,7 +127,9 @@ Options:
   -e, --env TEXT                  Filters result by environment.
   -f, --format [yaml|json|json-compact]
                                   The output format.
-  -d, --descending                Set history loading order to 'last-first'
+  -s, --old-first                 Invert history sorting to 'old-first'
+  -n, --limit INTEGER             Limits how many history entries are shown.
+  -a, --all                       Show dynaconf internal settings?
   --help                          Show this message and exit.
 ```
 
@@ -135,13 +137,14 @@ Options:
 Sample usage:
 
 ```yaml
-# dynaconf -i app.settings inspect -k foo -f yaml
+>>> dynaconf -i app.settings inspect -k foo -f yaml -n 2
 header:
-  filters:
-    env: None
-    key: foo
-    history_ordering: ascending
-  active_value: from_environ
+  env_filter: 'foo'
+  key_filter: None
+  new_first: 'True'
+  history_limit: None
+  include_internal: 'False'
+current: from_environ
 history:
 - loader: yaml
   identifier: file_a.yaml

--- a/dynaconf/__init__.py
+++ b/dynaconf/__init__.py
@@ -4,6 +4,7 @@ from dynaconf.base import LazySettings  # noqa
 from dynaconf.constants import DEFAULT_SETTINGS_FILES
 from dynaconf.contrib import DjangoDynaconf  # noqa
 from dynaconf.contrib import FlaskDynaconf  # noqa
+from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.parse_conf import add_converter  # noqa
 from dynaconf.utils.parse_conf import DynaconfFormatError  # noqa
@@ -35,6 +36,7 @@ __all__ = [
     "DjangoDynaconf",
     "add_converter",
     "inspect_settings",
+    "get_history",
     "DynaconfFormatError",
     "DynaconfParseError",
 ]

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -851,10 +851,10 @@ def inspect(key, env, format, descending, _all):  # pragma: no cover
     try:
         inspect_settings(
             settings,
-            key_dotted_path=key,
-            env=env,
+            key=key,
+            env=env or None,
             output_format=format,
-            ascending_order=(not descending),
+            new_first=(not descending),
             include_internal=_all,
         )
         click.echo()

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -866,7 +866,7 @@ def inspect(
             settings,
             key=key,
             env=env or None,
-            output_format=format,
+            dumper=format,
             new_first=new_first,
             include_internal=_all,
             history_limit=history_limit,

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -870,6 +870,7 @@ def inspect(
             new_first=new_first,
             include_internal=_all,
             history_limit=history_limit,
+            print_report=True,
         )
         click.echo()
     except (KeyNotFoundError, EnvNotFoundError, OutputFormatError) as err:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -819,7 +819,9 @@ INSPECT_FORMATS = list(builtin_dumpers.keys())
 
 @main.command()
 @click.option("--key", "-k", help="Filters result by key.")
-@click.option("--env", "-e", help="Filters result by environment.", default="")
+@click.option(
+    "--env", "-e", help="Filters result by environment.", default=None
+)
 @click.option(
     "--format",
     "-f",
@@ -828,11 +830,20 @@ INSPECT_FORMATS = list(builtin_dumpers.keys())
     type=click.Choice(INSPECT_FORMATS),
 )
 @click.option(
-    "--descending",
-    "-d",
-    help="Set history loading order to 'last-first'",
-    default=False,
+    "--old-first",
+    "new_first",
+    "-s",
+    help="Invert history sorting to 'old-first'",
+    default=True,
     is_flag=True,
+)
+@click.option(
+    "--limit",
+    "history_limit",
+    "-n",
+    default=None,
+    type=int,
+    help="Limits how many history entries are shown.",
 )
 @click.option(
     "--all",
@@ -840,9 +851,11 @@ INSPECT_FORMATS = list(builtin_dumpers.keys())
     "-a",
     default=False,
     is_flag=True,
-    help="show dynaconf internal settings?",
+    help="Show dynaconf internal settings?",
 )
-def inspect(key, env, format, descending, _all):  # pragma: no cover
+def inspect(
+    key, env, format, new_first, history_limit, _all
+):  # pragma: no cover
     """
     Inspect the loading history of the given settings instance.
 
@@ -854,8 +867,9 @@ def inspect(key, env, format, descending, _all):  # pragma: no cover
             key=key,
             env=env or None,
             output_format=format,
-            new_first=(not descending),
+            new_first=new_first,
             include_internal=_all,
+            history_limit=history_limit,
         )
         click.echo()
     except (KeyNotFoundError, EnvNotFoundError, OutputFormatError) as err:

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -167,6 +167,7 @@ def get_history(
         filter_src_metadata: takes SourceMetadata and returns a boolean
         include_internal: if True, include internal loaders (e.g. defaults)
                           This has effect only if key is not provided.
+        history_limit: limits how many entries are shown
 
     Example:
         >>> settings = Dynaconf(...)
@@ -265,6 +266,7 @@ def _get_data_by_key(
     """
     if not isinstance(data, DynaBox):
         data = DynaBox(data)  # DynaBox can handle insensitive keys
+
     if sep in key_dotted_path:
         key_dotted_path = key_dotted_path.replace(sep, ".")
 

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -39,7 +39,9 @@ DumperPreset = Union[Literal["yaml"], Literal["json"], Literal["json-compact"]]
 
 
 class DumperType(Protocol):
-    def __call__(self, data: dict, text_stream: TextIO) -> None:
+    def __call__(
+        self, data: dict, text_stream: TextIO
+    ) -> None:  # pragma: no cover
         ...
 
 
@@ -54,7 +56,7 @@ class ReportBuilderType(Protocol):
         history_limit: int | None,
         current: Any,
         history: list[dict] | None,
-    ) -> dict:
+    ) -> dict: # pragma: no cover
         ...
 
 

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -56,7 +56,7 @@ class ReportBuilderType(Protocol):
         history_limit: int | None,
         current: Any,
         history: list[dict] | None,
-    ) -> dict: # pragma: no cover
+    ) -> dict:  # pragma: no cover
         ...
 
 

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -136,7 +136,7 @@ def inspect_settings(
     history = get_history(
         original_settings,
         key=key,
-        filter_src_metadata=env_filter,
+        filter_callable=env_filter,
         include_internal=include_internal,
     )
 
@@ -199,7 +199,8 @@ def _default_report_builder(**kwargs) -> dict:
 def get_history(
     obj: Settings | LazySettings,
     key: str | None = None,
-    filter_src_metadata: Callable[[SourceMetadata], bool] | None = None,
+    *,
+    filter_callable: Callable[[SourceMetadata], bool] | None = None,
     include_internal: bool = False,
     history_limit: int | None = None,
 ) -> list[dict]:
@@ -212,7 +213,7 @@ def get_history(
 
     :param obj: Setting object which contain the data
     :param key: Key path to desired key. Use all if not provided
-    :param filter_src_metadata: Takes SourceMetadata and returns a boolean
+    :param filter_callable: Takes SourceMetadata and returns a boolean
     :param include_internal: If True, include internal loaders (e.g. defaults).
         This has effect only if key is not provided.
     history_limit: limits how many entries are shown
@@ -230,8 +231,8 @@ def get_history(
             ...
         ]
     """
-    if filter_src_metadata is None:
-        filter_src_metadata = lambda x: True  # noqa
+    if filter_callable is None:
+        filter_callable = lambda x: True  # noqa
 
     sep = obj.get("NESTED_SEPARATOR_FOR_DYNACONF", "__")
 
@@ -243,7 +244,7 @@ def get_history(
     result = []
     for source_metadata, data in obj._loaded_by_loaders.items():
         # filter by source_metadata
-        if filter_src_metadata(source_metadata) is False:
+        if filter_callable(source_metadata) is False:
             continue
 
         # filter by internal identifiers

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -76,8 +76,8 @@ def inspect_settings(
     env: str | None = None,
     *,
     new_first: bool = True,
-    include_internal: bool = False,
     history_limit: int | None = None,
+    include_internal: bool = False,
     to_file: str | PosixPath | None = None,
     print_report: bool = False,
     dumper: DumperPreset | DumperType | None = None,
@@ -89,12 +89,13 @@ def inspect_settings(
     Optional arguments must be provided as kwargs.
 
     :param settings: A Dynaconf instance
-
     :param key: String dotted path. E.g "path.to.key"
-    :param ascending_order: If True, newest to oldest loading order
+    :param env: Filter by this env
+
+    :param new_first: If True, uses newest to oldest loading order
+    :param history_limit: Limits how many entries are shown
     :param include_internal: If True, include internal loaders (e.g. defaults).
         This has effect only if key is not provided.
-    :param history_limit: Limits how many entries are shown
     :param to_file: If specified, write to this filename
     :param print_report: If true, prints the dumped report to stdout
     :param dumper: Accepts preset strings (e.g. "yaml", "json") or custom
@@ -226,7 +227,7 @@ def get_history(
                 "loader": "yaml"
                 "identifier": "path/to/file.yml"
                 "env": "default"
-                "data": {"foo": 123, "spam": "eggs"
+                "data": {"foo": 123, "spam": "eggs"}
             },
             ...
         ]

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -131,7 +131,7 @@ def inspect_settings(
         def env_filter(src: SourceMetadata) -> bool:
             return src.env.lower() == env.lower()
 
-    history = _get_history(
+    history = get_history(
         original_settings,
         key=key,
         filter_src_metadata=env_filter,
@@ -192,7 +192,7 @@ def _default_report_builder(**kwargs) -> dict:
     }
 
 
-def _get_history(
+def get_history(
     obj: Settings | LazySettings,
     key: str | None = None,
     filter_src_metadata: Callable[[SourceMetadata], bool] | None = None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,16 +514,26 @@ def test_inspect_no_args(tmp_path):
     expected_header = """\
         {
           "header": {
-            "filters": {
-              "env": "None",
-              "key": "None",
-              "history_ordering": "ascending"
-            },
-            "active_value": {
-              "FOO": "from_environ_no_args"
-            }
+            "env_filter": "None",
+            "key_filter": "None",
+            "new_first": "True",
+            "history_limit": "None",
+            "include_internal": "False"
           },
-        """
+          "current": {
+            "FOO": "from_environ_no_args"
+          },
+          "history": [
+            {
+              "loader": "env_global",
+              "identifier": "unique",
+              "env": "global",
+              "merged": false,
+              "value": {
+                "FOO": "from_environ_no_args"
+              }
+            },
+            """
     assert result
     assert result.startswith(dedent(expected_header))
 
@@ -553,12 +563,20 @@ def test_inspect_yaml_format(tmp_path):
     result = run(cmd, env=environ)
     expected_header = """\
         header:
-          filters:
-            env: None
-            key: None
-            history_ordering: ascending
-          active_value:
-            BAR: from_file_yaml_format
+          env_filter: None
+          key_filter: None
+          new_first: 'True'
+          history_limit: None
+          include_internal: 'False'
+        current:
+          BAR: from_file_yaml_format
+          FOO: from_environ_yaml_format
+        history:
+        - loader: env_global
+          identifier: unique
+          env: global
+          merged: false
+          value:
             FOO: from_environ_yaml_format
         """
     assert result
@@ -595,13 +613,13 @@ def test_inspect_key_filter(tmp_path):
     expected_header = """\
         {
           "header": {
-            "filters": {
-              "env": "None",
-              "key": "bar",
-              "history_ordering": "ascending"
-            },
-            "active_value": "file_only"
+            "env_filter": "None",
+            "key_filter": "bar",
+            "new_first": "True",
+            "history_limit": "None",
+            "include_internal": "False"
           },
+          "current": "file_only",
         """
     assert result
     assert result.startswith(dedent(expected_header))
@@ -640,15 +658,15 @@ def test_inspect_env_filter(tmp_path):
     expected_header = """\
         {
           "header": {
-            "filters": {
-              "env": "prod",
-              "key": "None",
-              "history_ordering": "ascending"
-            },
-            "active_value": {
-              "FOO": "from_env_default",
-              "BAR": "prod_only_and_foo_default"
-            }
+            "env_filter": "prod",
+            "key_filter": "None",
+            "new_first": "True",
+            "history_limit": "None",
+            "include_internal": "False"
+          },
+          "current": {
+            "FOO": "from_env_default",
+            "BAR": "prod_only_and_foo_default"
           },
         """
     assert result
@@ -698,11 +716,12 @@ def test_inspect_all_args(tmp_path):
     result = run(cmd, env=environ)
     expected_result = f"""\
         header:
-          filters:
-            env: prod
-            key: bar
-            history_ordering: ascending
-          active_value: actual value but not in history
+          env_filter: prod
+          key_filter: bar
+          new_first: 'True'
+          history_limit: None
+          include_internal: 'False'
+        current: actual value but not in history
         history:
         - loader: toml
           identifier: {setting_file.as_posix()}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 from textwrap import dedent
+from unittest import mock
 
 import pytest
 
@@ -16,14 +17,14 @@ from dynaconf.cli import WRITERS
 from dynaconf.utils.files import read_file
 from dynaconf.vendor.click.testing import CliRunner
 
-
 settings = LazySettings(OPTION_FOR_TESTS=True, environments=True)
 
 
 def run(cmd, env=None, attr="output"):
-    runner = CliRunner()
-    result = runner.invoke(main, cmd, env=env, catch_exceptions=False)
-    return getattr(result, attr)
+    with mock.patch.dict(os.environ, {}):
+        runner = CliRunner()
+        result = runner.invoke(main, cmd, env=env, catch_exceptions=False)
+        return getattr(result, attr)
 
 
 def test_version():
@@ -486,15 +487,26 @@ def create_file(filename: str | Path, data: str):
     return filename
 
 
-def clear_dotenv(tmp_path):
-    Path(tmp_path / ".env").unlink()
+def get_current_test_name():
+    """
+    Utility to get the current test name.
+
+    Instance names should be unique for proper test isolation.
+    """
+    name = os.environ["PYTEST_CURRENT_TEST"]
+
+    # clean name to avoid issues with file creation:
+    # "this/test.py::"{testname}" (call)"
+    start = name.find("::") + 2
+    end = name.find(" (call")
+    name = name[start:end]
+    return name
 
 
 def test_inspect_no_args(tmp_path):
     """Inspect command with no arguments"""
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_no_args"
     setting_file = tmp_path / "a.toml"
     environ = {"DYNACONF_FOO": "from_environ_no_args"}
     cmd = ["-i", f"{instance_name}.settings", "inspect"]
@@ -540,9 +552,8 @@ def test_inspect_no_args(tmp_path):
 
 def test_inspect_yaml_format(tmp_path):
     """Inspect command with format argument"""
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_yaml_format"
     setting_file = tmp_path / "a.toml"
     environ = {
         "DYNACONF_FOO": "from_environ_yaml_format",
@@ -585,9 +596,8 @@ def test_inspect_yaml_format(tmp_path):
 
 def test_inspect_key_filter(tmp_path):
     """Inspect command with key filter argument"""
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_key_filter"
     setting_file = tmp_path / "a.toml"
     environ = {"DYNACONF_FOO": "from_environ_key_filter"}
     cmd = ["-i", f"{instance_name}.settings", "inspect", "-k", "bar"]
@@ -627,9 +637,8 @@ def test_inspect_key_filter(tmp_path):
 
 def test_inspect_env_filter(tmp_path):
     """Inspect command with env filter argument"""
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_env_filter"
     setting_file = tmp_path / "a.toml"
     environ = {}
     cmd = ["-i", f"{instance_name}.settings", "inspect", "-e", "prod"]
@@ -673,11 +682,73 @@ def test_inspect_env_filter(tmp_path):
     assert result.startswith(dedent(expected_header))
 
 
+def test_inspect_limit(tmp_path):
+    """
+    Inspect command with --limit.
+
+    Should include only the last history entry.
+    """
+    instance_name = get_current_test_name()
+
+    setting_file = tmp_path / "a.toml"
+    environ = {"DYNACONF_FOO": "from_environ"}
+    cmd = [
+        "-i",
+        f"{instance_name}.settings",
+        "inspect",
+        "--limit",
+        "1",
+    ]
+
+    create_file(
+        tmp_path / f"{instance_name}.py",
+        f"""\
+        from dynaconf import Dynaconf
+        settings = Dynaconf(
+            settings_file="{setting_file.as_posix()}",
+        )
+        """,
+    )
+
+    create_file(
+        setting_file,
+        "foo='from_file'",
+    )
+
+    result = run(cmd, env=environ)
+    expected_result = """\
+        {
+          "header": {
+            "env_filter": "None",
+            "key_filter": "None",
+            "new_first": "True",
+            "history_limit": "1",
+            "include_internal": "False"
+          },
+          "current": {
+            "FOO": "from_environ"
+          },
+          "history": [
+            {
+              "loader": "env_global",
+              "identifier": "unique",
+              "env": "global",
+              "merged": false,
+              "value": {
+                "FOO": "from_environ"
+              }
+            }
+          ]
+        }
+        """
+    assert result
+    assert result == dedent(expected_result)
+
+
 def test_inspect_all_args(tmp_path):
     """Inspect command with all arguments"""
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()  # should be unique for isolation
 
-    instance_name = "inspect_all_args"  # should be unique for isolation
     setting_file = tmp_path / "a.toml"
     environ = {"DYNACONF_BAR": "actual value but not in history"}
     cmd = [
@@ -734,9 +805,8 @@ def test_inspect_all_args(tmp_path):
 
 
 def test_inspect_invalid_key(tmp_path):
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_invalid_key"
     environ = {}
     cmd = [
         "-i",
@@ -759,9 +829,8 @@ def test_inspect_invalid_key(tmp_path):
 
 
 def test_inspect_invalid_env(tmp_path):
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_invalid_env"
     environ = {}
     cmd = [
         "-i",
@@ -784,9 +853,8 @@ def test_inspect_invalid_env(tmp_path):
 
 
 def test_inspect_invalid_format(tmp_path):
-    clear_dotenv(tmp_path)
+    instance_name = get_current_test_name()
 
-    instance_name = "inspect_invalid_format"
     environ = {}
     cmd = [
         "-i",

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -506,7 +506,7 @@ def test_get_history_env_filter(tmp_path):
     settings = Dynaconf(settings_file=[file_a, file_b], environments=True)
     settings.from_env("prod")  # CAVEAT: activate loading of prod
     history = get_history(
-        settings, filter_src_metadata=lambda x: x.env.lower() == "prod"
+        settings, filter_callable=lambda x: x.env.lower() == "prod"
     )
 
     assert len(history) == 2
@@ -552,7 +552,7 @@ def test_get_history_env_and_key_filter(tmp_path):
     history = get_history(
         settings,
         key="bar",
-        filter_src_metadata=lambda x: x.env.lower() == "prod",
+        filter_callable=lambda x: x.env.lower() == "prod",
     )
     assert len(history) == 2
     assert history[0]["value"] == "from_prod_a"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,7 +12,7 @@ import pytest
 from dynaconf import Dynaconf
 from dynaconf.utils.inspect import _ensure_serializable
 from dynaconf.utils.inspect import _get_data_by_key
-from dynaconf.utils.inspect import _get_history
+from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import EnvNotFoundError
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.inspect import KeyNotFoundError
@@ -113,7 +113,7 @@ def test_get_history_general(tmp_path):
         """,
     )
     settings = Dynaconf(settings_file=[file_a, file_b])
-    history = _get_history(settings)
+    history = get_history(settings)
 
     # metadata
     assert len(history) == 4
@@ -181,7 +181,7 @@ def test_get_history_env_false__file_plus_envvar(tmp_path):
     create_file(file_a, "foo: from_file")
 
     settings = Dynaconf(settings_file=file_a)
-    history = _get_history(settings)
+    history = get_history(settings)
 
     # metadata
     assert len(history) == 4
@@ -215,7 +215,7 @@ def test_get_history_env_false__val_default_plus_envvar():
     settings = Dynaconf(
         validators=[Validator("bar", default="from_val_default")]
     )
-    history = _get_history(settings)
+    history = get_history(settings)
 
     # metadata (validation_default runs after envvar loading)
     assert len(history) == 3
@@ -253,7 +253,7 @@ def test_get_history_env_false__merge_marks(tmp_path):
     create_file(file_c, "dynaconf_merge=true\nlisty=[7,8,9]")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = _get_history(settings)
+    history = get_history(settings)
 
     # metadata
     assert len(history) == 6
@@ -307,7 +307,7 @@ def test_get_history_env_true__file_plus_envvar(tmp_path):
     )
 
     settings = Dynaconf(settings_file=file_a, environments=True)
-    history = _get_history(settings)
+    history = get_history(settings)
 
     assert len(history) == 5
     assert history[2] == {
@@ -356,7 +356,7 @@ def test_get_history_env_true__val_default_plus_file(tmp_path):
         settings_file=file_a,
         environments=True,
     )
-    history = _get_history(settings)
+    history = get_history(settings)
 
     assert len(history) == 7
     assert history[2] == {
@@ -405,7 +405,7 @@ def test_get_history_env_true__merge_marks(tmp_path):
     create_file(file_c, "dynaconf_merge=true\nlisty=[7,8,9]")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = _get_history(settings)
+    history = get_history(settings)
 
     # metadata
     assert len(history) == 6
@@ -453,7 +453,7 @@ def test_get_history_key_filter(tmp_path):
     create_file(file_c, "a='cA'\nb='cB'\nc='cC'")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = _get_history(settings, key="a")
+    history = get_history(settings, key="a")
     assert history[0]["value"] == "aA"
     assert history[1]["value"] == "bA"
     assert history[2]["value"] == "cA"
@@ -469,7 +469,7 @@ def test_get_history_key_filter_nested(tmp_path):
     create_file(file_c, "a.b='cB'\na.c='cC'")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = _get_history(settings, key="a.c")
+    history = get_history(settings, key="a.c")
     assert len(history) == 3
     assert history[0]["value"] == "aC"
     assert history[1]["value"] == "bC"
@@ -505,7 +505,7 @@ def test_get_history_env_filter(tmp_path):
 
     settings = Dynaconf(settings_file=[file_a, file_b], environments=True)
     settings.from_env("prod")  # CAVEAT: activate loading of prod
-    history = _get_history(
+    history = get_history(
         settings, filter_src_metadata=lambda x: x.env.lower() == "prod"
     )
 
@@ -549,7 +549,7 @@ def test_get_history_env_and_key_filter(tmp_path):
 
     settings = Dynaconf(settings_file=[file_a, file_b], environments=True)
     settings.from_env("prod")  # CAVEAT: activate loading of prod
-    history = _get_history(
+    history = get_history(
         settings,
         key="bar",
         filter_src_metadata=lambda x: x.env.lower() == "prod",
@@ -586,7 +586,7 @@ def test_caveat__get_history_env_true(tmp_path):
     )
 
     settings = Dynaconf(settings_file=file_a, environments=True)
-    history = _get_history(settings)
+    history = get_history(settings)
     assert len(history) == 4
     assert history[2] == {
         "loader": "toml",
@@ -633,7 +633,7 @@ def test_caveat__get_history_env_true_workaround(tmp_path):
 
     settings = Dynaconf(settings_file=file_a, environments=True)
     settings.from_env("production")
-    history = _get_history(settings)
+    history = get_history(settings)
     assert len(history) == 6
     assert history[2] == {
         "loader": "toml",

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -13,7 +13,7 @@ from dynaconf import Dynaconf
 from dynaconf.utils.inspect import _ensure_serializable
 from dynaconf.utils.inspect import _get_data_by_key
 from dynaconf.utils.inspect import EnvNotFoundError
-from dynaconf.utils.inspect import get_history
+from dynaconf.utils.inspect import _get_history
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.inspect import KeyNotFoundError
 from dynaconf.utils.inspect import OutputFormatError
@@ -113,7 +113,7 @@ def test_get_history_general(tmp_path):
         """,
     )
     settings = Dynaconf(settings_file=[file_a, file_b])
-    history = get_history(settings)
+    history = _get_history(settings)
 
     # metadata
     assert len(history) == 4
@@ -181,7 +181,7 @@ def test_get_history_env_false__file_plus_envvar(tmp_path):
     create_file(file_a, "foo: from_file")
 
     settings = Dynaconf(settings_file=file_a)
-    history = get_history(settings)
+    history = _get_history(settings)
 
     # metadata
     assert len(history) == 4
@@ -215,7 +215,7 @@ def test_get_history_env_false__val_default_plus_envvar():
     settings = Dynaconf(
         validators=[Validator("bar", default="from_val_default")]
     )
-    history = get_history(settings)
+    history = _get_history(settings)
 
     # metadata (validation_default runs after envvar loading)
     assert len(history) == 3
@@ -253,7 +253,7 @@ def test_get_history_env_false__merge_marks(tmp_path):
     create_file(file_c, "dynaconf_merge=true\nlisty=[7,8,9]")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = get_history(settings)
+    history = _get_history(settings)
 
     # metadata
     assert len(history) == 6
@@ -307,7 +307,7 @@ def test_get_history_env_true__file_plus_envvar(tmp_path):
     )
 
     settings = Dynaconf(settings_file=file_a, environments=True)
-    history = get_history(settings)
+    history = _get_history(settings)
 
     assert len(history) == 5
     assert history[2] == {
@@ -356,7 +356,7 @@ def test_get_history_env_true__val_default_plus_file(tmp_path):
         settings_file=file_a,
         environments=True,
     )
-    history = get_history(settings)
+    history = _get_history(settings)
 
     assert len(history) == 7
     assert history[2] == {
@@ -405,7 +405,7 @@ def test_get_history_env_true__merge_marks(tmp_path):
     create_file(file_c, "dynaconf_merge=true\nlisty=[7,8,9]")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = get_history(settings)
+    history = _get_history(settings)
 
     # metadata
     assert len(history) == 6
@@ -453,7 +453,7 @@ def test_get_history_key_filter(tmp_path):
     create_file(file_c, "a='cA'\nb='cB'\nc='cC'")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = get_history(settings, key="a")
+    history = _get_history(settings, key="a")
     assert history[0]["value"] == "aA"
     assert history[1]["value"] == "bA"
     assert history[2]["value"] == "cA"
@@ -469,7 +469,7 @@ def test_get_history_key_filter_nested(tmp_path):
     create_file(file_c, "a.b='cB'\na.c='cC'")
 
     settings = Dynaconf(settings_file=[file_a, file_b, file_c])
-    history = get_history(settings, key="a.c")
+    history = _get_history(settings, key="a.c")
     assert len(history) == 3
     assert history[0]["value"] == "aC"
     assert history[1]["value"] == "bC"
@@ -505,7 +505,7 @@ def test_get_history_env_filter(tmp_path):
 
     settings = Dynaconf(settings_file=[file_a, file_b], environments=True)
     settings.from_env("prod")  # CAVEAT: activate loading of prod
-    history = get_history(
+    history = _get_history(
         settings, filter_src_metadata=lambda x: x.env.lower() == "prod"
     )
 
@@ -549,7 +549,7 @@ def test_get_history_env_and_key_filter(tmp_path):
 
     settings = Dynaconf(settings_file=[file_a, file_b], environments=True)
     settings.from_env("prod")  # CAVEAT: activate loading of prod
-    history = get_history(
+    history = _get_history(
         settings,
         key="bar",
         filter_src_metadata=lambda x: x.env.lower() == "prod",
@@ -586,7 +586,7 @@ def test_caveat__get_history_env_true(tmp_path):
     )
 
     settings = Dynaconf(settings_file=file_a, environments=True)
-    history = get_history(settings)
+    history = _get_history(settings)
     assert len(history) == 4
     assert history[2] == {
         "loader": "toml",
@@ -633,7 +633,7 @@ def test_caveat__get_history_env_true_workaround(tmp_path):
 
     settings = Dynaconf(settings_file=file_a, environments=True)
     settings.from_env("production")
-    history = get_history(settings)
+    history = _get_history(settings)
     assert len(history) == 6
     assert history[2] == {
         "loader": "toml",
@@ -665,7 +665,7 @@ def test_inspect_key_filter(tmp_path):
     filename = create_file(tmp_path / "a.yaml", "foo: from_yaml")
     settings = Dynaconf(settings_file=filename)
 
-    result = inspect_settings(settings, "foo", output_format="yaml")
+    result = inspect_settings(settings, key="foo", dumper="yaml")
 
     assert result["header"]["key_filter"] == "foo"
     assert result["current"] == "from_environ"
@@ -692,7 +692,7 @@ def test_inspect_no_filter(tmp_path):
     os.environ["DYNACONF_BAR"] = "environ_only"
     filename = create_file(tmp_path / "a.yaml", "foo: from_yaml")
     settings = Dynaconf(settings_file=filename)
-    result = inspect_settings(settings, output_format="yaml")
+    result = inspect_settings(settings, dumper="yaml")
 
     assert result["header"]["key_filter"] == "None"
     assert result["header"]["env_filter"] == "None"
@@ -732,7 +732,7 @@ def test_inspect_env_filter(tmp_path):
     )
 
     settings = Dynaconf(settings_file=filename, environments=True)
-    result = inspect_settings(settings, output_format="yaml", env="prod")
+    result = inspect_settings(settings, dumper="yaml", env="prod")
     assert result["header"]["env_filter"] == "prod"
     assert result["header"]["key_filter"] == "None"
     assert result["current"] == {"FOO": "from_env_default", "BAR": "prod_only"}
@@ -755,7 +755,7 @@ def test_inspect_to_file(tmp_path):
     settings = Dynaconf(settings_file=filename)
 
     file_out = tmp_path / "output.yml"
-    inspect_settings(settings, output_format="yaml", to_file=file_out)
+    inspect_settings(settings, dumper="yaml", to_file=file_out)
 
     # open created file
     assert file_out.read_text() == dedent(
@@ -820,4 +820,4 @@ def test_inspect_exception_env_not_found():
 def test_inspect_exception_invalid_format():
     settings = Dynaconf()
     with pytest.raises(OutputFormatError):
-        inspect_settings(settings, output_format="invalid_format")
+        inspect_settings(settings, dumper="invalid_format")

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,8 +12,8 @@ import pytest
 from dynaconf import Dynaconf
 from dynaconf.utils.inspect import _ensure_serializable
 from dynaconf.utils.inspect import _get_data_by_key
-from dynaconf.utils.inspect import EnvNotFoundError
 from dynaconf.utils.inspect import _get_history
+from dynaconf.utils.inspect import EnvNotFoundError
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.inspect import KeyNotFoundError
 from dynaconf.utils.inspect import OutputFormatError

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,8 +12,8 @@ import pytest
 from dynaconf import Dynaconf
 from dynaconf.utils.inspect import _ensure_serializable
 from dynaconf.utils.inspect import _get_data_by_key
-from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import EnvNotFoundError
+from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.inspect import KeyNotFoundError
 from dynaconf.utils.inspect import OutputFormatError

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -8,7 +8,7 @@ from dynaconf import LazySettings
 from dynaconf.loaders.redis_loader import delete
 from dynaconf.loaders.redis_loader import load
 from dynaconf.loaders.redis_loader import write
-from dynaconf.utils.inspect import _get_history
+from dynaconf.utils.inspect import get_history
 
 
 def custom_checker(ip_address, port):
@@ -117,7 +117,7 @@ def test_redis_has_proper_source_metadata(docker_redis):
     settings = LazySettings(environments=True)
     write(settings, {"SECRET": "redis_works_perfectly"})
     load(settings)
-    history = _get_history(
+    history = get_history(
         settings, filter_src_metadata=lambda s: s.loader == "redis"
     )
     assert history[0]["env"] == "development"  # default when environments=True

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -8,7 +8,7 @@ from dynaconf import LazySettings
 from dynaconf.loaders.redis_loader import delete
 from dynaconf.loaders.redis_loader import load
 from dynaconf.loaders.redis_loader import write
-from dynaconf.utils.inspect import get_history
+from dynaconf.utils.inspect import _get_history
 
 
 def custom_checker(ip_address, port):
@@ -117,7 +117,7 @@ def test_redis_has_proper_source_metadata(docker_redis):
     settings = LazySettings(environments=True)
     write(settings, {"SECRET": "redis_works_perfectly"})
     load(settings)
-    history = get_history(
+    history = _get_history(
         settings, filter_src_metadata=lambda s: s.loader == "redis"
     )
     assert history[0]["env"] == "development"  # default when environments=True

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -118,7 +118,7 @@ def test_redis_has_proper_source_metadata(docker_redis):
     write(settings, {"SECRET": "redis_works_perfectly"})
     load(settings)
     history = get_history(
-        settings, filter_src_metadata=lambda s: s.loader == "redis"
+        settings, filter_callable=lambda s: s.loader == "redis"
     )
     assert history[0]["env"] == "development"  # default when environments=True
     assert history[0]["value"]["SECRET"] == "redis_works_perfectly"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -9,7 +9,7 @@ from dynaconf import LazySettings
 from dynaconf.loaders.vault_loader import list_envs
 from dynaconf.loaders.vault_loader import load
 from dynaconf.loaders.vault_loader import write
-from dynaconf.utils.inspect import _get_history
+from dynaconf.utils.inspect import get_history
 
 
 def custom_checker(ip_address, port):
@@ -120,7 +120,7 @@ def test_vault_has_proper_source_metadata(docker_vault):
         with settings.using_env(env):
             write(settings, {"SECRET": f"vault_works_in_{env}"})
     load(settings)
-    history = _get_history(
+    history = get_history(
         settings, filter_src_metadata=lambda s: s.loader == "vault"
     )
     assert history[0]["env"] == "default"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -121,7 +121,7 @@ def test_vault_has_proper_source_metadata(docker_vault):
             write(settings, {"SECRET": f"vault_works_in_{env}"})
     load(settings)
     history = get_history(
-        settings, filter_src_metadata=lambda s: s.loader == "vault"
+        settings, filter_callable=lambda s: s.loader == "vault"
     )
     assert history[0]["env"] == "default"
     assert history[0]["value"]["SECRET"] == "vault_works_in_default"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -9,7 +9,7 @@ from dynaconf import LazySettings
 from dynaconf.loaders.vault_loader import list_envs
 from dynaconf.loaders.vault_loader import load
 from dynaconf.loaders.vault_loader import write
-from dynaconf.utils.inspect import get_history
+from dynaconf.utils.inspect import _get_history
 
 
 def custom_checker(ip_address, port):
@@ -120,7 +120,7 @@ def test_vault_has_proper_source_metadata(docker_vault):
         with settings.using_env(env):
             write(settings, {"SECRET": f"vault_works_in_{env}"})
     load(settings)
-    history = get_history(
+    history = _get_history(
         settings, filter_src_metadata=lambda s: s.loader == "vault"
     )
     assert history[0]["env"] == "default"

--- a/tests_functional/custom_loader/app.py
+++ b/tests_functional/custom_loader/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dynaconf import settings
-from dynaconf.utils.inspect import _get_history
+from dynaconf.utils.inspect import get_history
 
 with open(settings.find_file("settings.sff")) as settings_file:
     print("settings from sff file\n", settings_file.read())
@@ -15,6 +15,6 @@ print("Email is:", settings.EMAIL)
 print(settings.get_fresh("NAME"))
 
 # Assure new inspect/history works properly
-history = _get_history(settings, "NAME")
+history = get_history(settings, "NAME")
 assert history[0]["loader"] == "sff"
 assert history[0]["value"] == "Bruno Rocha"

--- a/tests_functional/custom_loader/app.py
+++ b/tests_functional/custom_loader/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dynaconf import settings
-from dynaconf.utils.inspect import get_history
+from dynaconf.utils.inspect import _get_history
 
 with open(settings.find_file("settings.sff")) as settings_file:
     print("settings from sff file\n", settings_file.read())
@@ -15,6 +15,6 @@ print("Email is:", settings.EMAIL)
 print(settings.get_fresh("NAME"))
 
 # Assure new inspect/history works properly
-history = get_history(settings, "NAME")
+history = _get_history(settings, "NAME")
 assert history[0]["loader"] == "sff"
 assert history[0]["value"] == "Bruno Rocha"


### PR DESCRIPTION
This is a review PR for the Inspect feature #939 

## Proposals

(I'm actively updating this section)

### Bug Fixes

- [x] CLI "django app detected" message breaks the output format (e.g. `dynaconf inspect | jq`)
- [x] `pre_load` and `dynaconf_hooks` identifiers are not preserved in history.
- [x] Compatibility break when defining `loader_identifier` with `str` (because of the new `SourceMetadata`)

### API changes in `dynaconf.utils.inspect`

- [x] rename `key_dotted_path`:
from `inspect_settings(key_dotted_path: str, ...)` to `inspect_settings(key: str, ...)`
from `get_history(key_dotted_path: str, ...)` to `get_history(key: str, ...)`

Justification: Explicit names are usually good, but in the context of Dynaconf `key` is used as dotted-path (as in `setting.get` for example), which makes it more consistent. Also, the docstring makes the usage clear and, if we support other path access (like `foo__bar`), `key` can accommodate that semantic.

- [x] merge/rename `custom_dumper` and `output_format` to `dumper: Callable | str (preset string)`
- [x] enforce the use of kwargs except for `settings`
- [x] add `report_builder` to customize the structure of the output report

### `Inspect` default report behavior

- [x] Change `inspect` output
  from `header.filter.history_order=ascdending | descending`
  to `header.chronological_sort=True | False` (more clear information)
- [x] Limit the number of history entries, similar to `git log -1` or `head -n 1`. Use 1 by default (users feedback)

### Clarify History Report behavior

The behavior of the history report may be counter-intuitive, specially with merge flag. It kinda snapshots the state of settings at the given source, but not exactly. This should be better explored, defined and documented.

Example, when source B merges data after A:
```python
# A loads [1, 2, 3], then: settings inspect -k LISTY:
A -> listy=[1, 2, 3]

# B loads listy=[4, "dynaconf_merge"], then: settings inspect -k LISTY:
B -> listy=[1, 2, 3, 4] # not listy=[4]
A -> listy=[1, 2, 3]
```
### Ideas
- Add `cli_inspect_options={...}` to `Dynaconf` instantiation to set custom default parameters (like limit and sort)

### General
- [ ] Add tests for new uncovered inspect-related code
- [x] Update documentation