### PR TITLE
CI - Test docker-compose pyyaml issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,8 @@ git push -u origin HEAD
 ### Run integration tests
 
 * "make all" do not run integration tests for Redis and Vault.
-* If you want to run integration tests, make sure you have docker installed
+* If you want to run integration tests, make sure you have docker and docker-compose
+installed.
 
 ```bash
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ citest:
 	make coverage-report
 
 ciinstall:
+	curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
 	python -m pip install --upgrade pip
 	python -m pip install -r requirements_dev.txt
 

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -46,7 +46,7 @@ from dynaconf.vendor.box.box_list import BoxList
 
 
 class LazySettings(LazyObject):
-    """Loads settings lazily from multiple sources::
+    """Loads settings lazily from multiple sources:
 
         settings = Dynaconf(
             settings_files=["settings.toml"],  # path/glob

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,8 +16,6 @@ pytest
 pytest-cov
 pytest-mock
 commentjson
-pyyaml==6.0.1
-docker-compose
 lovely-pytest-docker
 tox
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,6 +16,7 @@ pytest
 pytest-cov
 pytest-mock
 commentjson
+pyyaml==6.0.1
 docker-compose
 lovely-pytest-docker
 tox


### PR DESCRIPTION
**problem**: `docker-compose` [from pypi ](https://pypi.org/project/docker-compose/1.29.2/)does not seem maintained (the last release is from 2021). The last version from pypi (`1.29.2`) depends on `pyyaml<=6`, which has a deprecated config that is causing the CI failure.

- [ ] ~~bump pyyaml to v6 (which doesnt have deprecated config)~~ the last docker-compose requires pyyaml<6
- [x] replace pip install `docker-compose` with newer [standalone binaries](https://docs.docker.com/compose/install/standalone/) releases. As it will not be installed by pip anymore, devs will need to assure `docker-compose` is available for local integration tests.

