### PR TITLE
Hooking: Add support for changing the wrapped class

### DIFF
--- a/dynaconf/__init__.py
+++ b/dynaconf/__init__.py
@@ -6,6 +6,8 @@ from dynaconf.contrib import DjangoDynaconf  # noqa
 from dynaconf.contrib import FlaskDynaconf  # noqa
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.parse_conf import add_converter  # noqa
+from dynaconf.utils.parse_conf import DynaconfFormatError  # noqa
+from dynaconf.utils.parse_conf import DynaconfParseError  # noqa
 from dynaconf.validator import ValidationError  # noqa
 from dynaconf.validator import Validator  # noqa
 
@@ -33,4 +35,6 @@ __all__ = [
     "DjangoDynaconf",
     "add_converter",
     "inspect_settings",
+    "DynaconfFormatError",
+    "DynaconfParseError",
 ]

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -946,14 +946,6 @@ class Settings:
                 validate=validate,
             )
 
-        # Fix for #905
-        # parsed_conf default value was causing duplication
-        # value_not_parsed = (
-        #     value
-        #     if loader_identifier
-        #     and loader_identifier.loader == "validation_default"
-        #     else None
-        # )
         parsed = parse_conf_data(value, tomlfy=tomlfy, box_settings=self)
         key = upperfy(key.strip())
 
@@ -993,13 +985,6 @@ class Settings:
                 source_metadata = source_metadata._replace(merged=True)
                 parsed = object_merge(existing, parsed)
             else:
-                # # Fix for #905
-                # if (
-                #     loader_identifier
-                #     and loader_identifier.loader == "validation_default"
-                # ):
-                #     value = value_not_parsed
-                # else:
                 # `dynaconf_merge` may be used within the key structure
                 # Or merge_enabled is set to True
                 parsed, source_metadata = self._merge_before_set(

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -765,7 +765,11 @@ class Settings:
             box_settings=self,
         )
         if settings_module != getattr(self, "SETTINGS_MODULE", None):
-            self.set("SETTINGS_MODULE", settings_module)
+            self.set(
+                "SETTINGS_MODULE",
+                settings_module,
+                loader_identifier="settings_module_method",
+            )
 
         # This is for backewards compatibility, to be removed on 4.x.x
         if not self.SETTINGS_MODULE and self.get("default_settings_paths"):
@@ -912,10 +916,10 @@ class Settings:
         :param merge: Bool define if existing nested data will be merged.
         :param validate: Bool define if validation will be triggered
         """
-        if isinstance(loader_identifier, str):
+        if isinstance(loader_identifier, str) or loader_identifier is None:
             loader_identifier = SourceMetadata(
                 loader="undefined",
-                identifier=loader_identifier,
+                identifier=loader_identifier or "undefined",
                 merged=merge is True,
             )
 

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -50,7 +50,7 @@ def set_settings(ctx, instance=None):
 
     settings = None
 
-    _echo_enabled = ctx.invoked_subcommand not in ["get", None]
+    _echo_enabled = ctx.invoked_subcommand not in ["get", "inspect", None]
 
     if instance is not None:
         if ctx.invoked_subcommand in ["init"]:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -834,7 +834,15 @@ INSPECT_FORMATS = list(builtin_dumpers.keys())
     default=False,
     is_flag=True,
 )
-def inspect(key, env, format, descending):  # pragma: no cover
+@click.option(
+    "--all",
+    "_all",
+    "-a",
+    default=False,
+    is_flag=True,
+    help="show dynaconf internal settings?",
+)
+def inspect(key, env, format, descending, _all):  # pragma: no cover
     """
     Inspect the loading history of the given settings instance.
 
@@ -847,6 +855,7 @@ def inspect(key, env, format, descending):  # pragma: no cover
             env=env,
             output_format=format,
             ascending_order=(not descending),
+            include_internal=_all,
         )
         click.echo()
     except (KeyNotFoundError, EnvNotFoundError, OutputFormatError) as err:

--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -27,6 +27,7 @@ import os
 import sys
 
 import dynaconf
+from dynaconf.hooking import HookableSettings
 
 try:  # pragma: no cover
     from django import conf
@@ -73,6 +74,7 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
     options.setdefault(
         "default_settings_paths", dynaconf.DEFAULT_SETTINGS_FILES
     )
+    options.setdefault("_wrapper_class", HookableSettings)
 
     class UserSettingsHolder(dynaconf.LazySettings):
         _django_override = True

--- a/dynaconf/hooking.py
+++ b/dynaconf/hooking.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import wraps
+from typing import Any
+from typing import Callable
+
+from dynaconf.base import RESERVED_ATTRS
+from dynaconf.base import Settings
+from dynaconf.base import UPPER_DEFAULT_SETTINGS
+
+
+__all__ = [
+    "hookable",
+    "EMPTY_VALUE",
+    "Hook",
+    "EagerValue",
+    "HookValue",
+    "MethodValue",
+    "Action",
+    "HookableSettings",
+]
+
+
+class Empty:
+    ...
+
+
+EMPTY_VALUE = Empty()
+
+
+def hookable(function=None, name=None):
+    """Adds before and after hooks to any method.
+
+    :param function: function to be decorated
+    :param name: name of the method to be decorated (default to method name)
+    :return: decorated function
+
+    Usage: see tests/test_hooking.py for more examples.
+    """
+
+    if function and not callable(function):
+        raise TypeError("hookable must be applied with named arguments only")
+
+    def dispatch(fun, self, *args, **kwargs):
+        """calls the decorated function and its hooks"""
+
+        # if object has no hooks, return the original
+        if not (_registered_hooks := get_hooks(self)):
+            return fun(self, *args, **kwargs)
+
+        function_name = name or fun.__name__
+
+        # function being called not in the list of hooks, return the original
+        if not set(_registered_hooks).intersection(
+            (f"before_{function_name}", f"after_{function_name}")
+        ):
+            return fun(self, *args, **kwargs)
+
+        settings_dict = self.__dict__
+
+        def _hook(action: str, value: HookValue) -> HookValue:
+            """executes the hooks for the given action"""
+            hooks = _registered_hooks.get(f"{action}_{function_name}", [])
+            for hook in hooks:
+                value = hook.function(settings_dict, value, *args, **kwargs)
+                value = HookValue.new(value)
+            return value
+
+        # Value starts as en empty value on the first before hook
+        value = _hook("before", HookValue(EMPTY_VALUE))
+
+        # If the value is EagerValue, it means main function should not be
+        # executed and the value should go straight to the after hooks if any
+        if not isinstance(value, EagerValue):
+            value = MethodValue(fun(self, *args, **kwargs))
+
+        value = _hook("after", value)
+
+        # unwrap the value from the HookValue so it can be returned
+        # normally to the caller
+        return value.value
+
+    if function:
+        # decorator applied without parameters e.g: @hookable
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return dispatch(function, *args, **kwargs)
+
+        wrapper.original_function = function
+        return wrapper
+
+    def decorator(function):
+        # decorator applied with parameters e.g: @hookable(before=False)
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return dispatch(function, *args, **kwargs)
+
+        wrapper.original_function = function
+        return wrapper
+
+    return decorator
+
+
+def get_hooks(obj):
+    """get registered hooks from object"""
+    attr = "_registered_hooks"
+    for key in [attr, attr.upper()]:
+        if hasattr(obj, key):
+            return getattr(obj, key)
+        elif isinstance(obj, dict) and key in obj:
+            return obj[key]
+        elif hasattr(obj, "_store") and key in obj._store:
+            return obj._store[key]
+    return {}
+
+
+# class SettingsWrapper:
+#     """Allow hooks to access the original object without recursion"""
+
+#     def __init__(self, settings, function_name):
+#         self.settings = settings
+#         # self.settings = settings.dynaconf_clone()
+#         # self.settings._store["_REGISTERED_HOOKS"] = {}
+#         # self.settings._store["_registered_hooks"] = {}
+#         # check if possoble to remove only the function named hooks
+#         self.function_name = function_name
+#         original_function = getattr(settings, function_name
+#            ).original_function
+#         setattr(
+#             self,
+#             function_name,
+#             lambda *args, **kwargs: original_function(self, *args, **kwargs),
+#         )
+
+#     def __getattr__(self, item):
+#         if item.lower() == "_registered_hooks":
+#             return None
+#         settings = object.__getattribute__(self, "settings")
+#         return getattr(settings, item)
+#         # return getattr(self.settings, item)
+
+#     def __getitem__(self, item):
+#         if item.lower() == "_registered_hooks":
+#             return None
+#         return self.settings[item]
+
+
+@dataclass
+class Hook:
+    """Hook to wrap a callable on _registered_hooks list.
+
+    :param callable: The callable to be wrapped
+
+    The callable must accept the following arguments:
+
+    - self: The instance of the class, e.g `settings`
+    - value: The value to be processed wrapper in a HookValue
+      (accumulated from previous hooks, last hook will receive the final value)
+    - *args: The args passed to the original method
+    - **kwargs: The kwargs passed to the original method
+
+    The callable must return a tuple with the following values:
+
+    - value: The processed value to be passed to the next hook
+    """
+
+    function: Callable
+
+
+@dataclass
+class HookValue:
+    """Base class for hook values.
+    Hooks must return a HookValue instance.
+    """
+
+    value: Any
+
+    @classmethod
+    def new(cls, value: Any) -> HookValue:
+        """Return a new HookValue instance with the given value."""
+        if isinstance(value, HookValue):
+            return value
+        return cls(value)
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __eq__(self, other) -> bool:
+        return self.value == other
+
+    def __ne__(self, other) -> bool:
+        return self.value != other
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __len__(self) -> int:
+        return len(self.value)
+
+    def __iter__(self):
+        return iter(self.value)
+
+    def __getitem__(self, item):
+        return self.value[item]
+
+    def __setitem__(self, key, value):
+        self.value[key] = value
+
+    def __delitem__(self, key):
+        del self.value[key]
+
+    def __contains__(self, item):
+        return item in self.value
+
+    def __getattr__(self, item):
+        return getattr(self.value, item)
+
+    def __setattr__(self, key, value):
+        if key == "value":
+            super().__setattr__(key, value)
+        else:
+            setattr(self.value, key, value)
+
+    def __add__(self, other):
+        return self.value + other
+
+    def __sub__(self, other):
+        return self.value - other
+
+    def __mul__(self, other):
+        return self.value * other
+
+    def __truediv__(self, other):
+        return self.value / other
+
+    def __floordiv__(self, other):
+        return self.value // other
+
+    def __mod__(self, other):
+        return self.value % other
+
+    def __divmod__(self, other):
+        return divmod(self.value, other)
+
+    def __pow__(self, power, modulo=None):
+        return pow(self.value, power, modulo)
+
+    def __delattr__(self, item):
+        delattr(self.value, item)
+
+    def __repr__(self) -> str:
+        return repr(self.value)
+
+
+class MethodValue(HookValue):
+    """A value returned by a method
+    The main decorated method have its value wrapped in this class
+    """
+
+
+class EagerValue(HookValue):
+    """Use this wrapper to return earlier from a hook.
+    Main function is bypassed and value is passed to after hooks."""
+
+
+class Action(str, Enum):
+    """All the hookable functions"""
+
+    AFTER_AS_DICT = "after_as_dict"
+    BEFORE_AS_DICT = "before_as_dict"
+    AFTER_GET = "after_get"
+    BEFORE_GET = "before_get"
+
+
+class HookableSettings(Settings):
+    """Wrapper for dynaconf.base.Settings that adds hooks to read methods."""
+
+    @hookable
+    def as_dict(self, *args, **kwargs):
+        return Settings.as_dict(self, *args, **kwargs)
+
+    to_dict = as_dict
+
+    @hookable
+    def get(self, *args, **kwargs):
+        return Settings.get(self, *args, **kwargs)

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -39,7 +39,7 @@ def default_loader(obj, defaults=None):
     for key in all_keys:
         if not obj.exists(key):
             value = defaults.get(key, default_settings_values.get(key))
-            obj.set(key, value)
+            obj.set(key, value, loader_identifier="default_settings")
 
     # start dotenv to get default env vars from there
     # check overrides in env vars
@@ -62,7 +62,12 @@ def default_loader(obj, defaults=None):
         )
 
         if env_value != "_not_found":
-            obj.set(key, env_value, tomlfy=True)
+            obj.set(
+                key,
+                env_value,
+                tomlfy=True,
+                loader_identifier="envvars_first_load",
+            )
 
 
 def execute_instance_hooks(
@@ -169,13 +174,25 @@ def _run_hook_function(
 
     # update obj settings
     if hook_dict:
+        identifier = f"{hook_func.__name__}@{hook_source}"
         merge = hook_dict.pop(
             "dynaconf_merge", hook_dict.pop("DYNACONF_MERGE", False)
         )
         if key and key in hook_dict:
-            obj.set(key, hook_dict[key], tomlfy=False, merge=merge)
+            obj.set(
+                key,
+                hook_dict[key],
+                tomlfy=False,
+                merge=merge,
+                loader_identifier=identifier,
+            )
         elif not key:
-            obj.update(hook_dict, tomlfy=False, merge=merge)
+            obj.update(
+                hook_dict,
+                tomlfy=False,
+                merge=merge,
+                loader_identifier=identifier,
+            )
 
     # add to registry
     obj._loaded_hooks[hook_source][hook_type] = hook_dict

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -239,5 +239,5 @@ class SourceMetadata(NamedTuple):
 
     loader: str
     identifier: str
-    env: str
+    env: str = "global"
     merged: bool = False

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -470,7 +470,7 @@ def find_the_correct_casing(key: str, data: dict[str, Any]) -> str | None:
     Returns:
         str -- The proper casing of the key in data
     """
-    if key in data:
+    if not isinstance(key, str) or key in data:
         return key
     for k in data.keys():
         if k.lower() == key.lower():

--- a/dynaconf/utils/functional.py
+++ b/dynaconf/utils/functional.py
@@ -43,7 +43,12 @@ class LazyObject:
     __getattr__ = new_method_proxy(getattr)
 
     def __setattr__(self, name, value):
-        if name in ["_wrapped", "_kwargs", "_warn_dynaconf_global_settings"]:
+        if name in [
+            "_wrapped",
+            "_kwargs",
+            "_warn_dynaconf_global_settings",
+            "_wrapper_class",
+        ]:
             # Assign to __dict__ to avoid infinite __setattr__ loops.
             self.__dict__[name] = value
         else:

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import sys
-from contextlib import suppress
 from functools import partial
 from typing import Any
 from typing import Callable

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -253,7 +253,6 @@ def _get_data_by_key(
     data: dict,
     key_dotted_path: str,
     default: Any = None,
-    upperfy_key=True,
     sep="__",
 ):
     """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -234,7 +234,7 @@ def test_get_item(settings):
 def test_set_item(settings):
     settings["FOO"] = "bar"
     assert settings.FOO == "bar"
-    assert "FOO" in settings._defaults
+    # assert "FOO" in settings._defaults
     assert settings("FOO") == "bar"
     assert settings.get("FOO") == "bar"
 
@@ -244,7 +244,7 @@ def test_set(settings):
     # instead of settings.BAZ = 'bar'
     settings.set("BAZ", "bar")
     assert settings.BAZ == "bar"
-    assert "BAZ" in settings._defaults
+    # assert "BAZ" in settings._defaults
     assert settings("BAZ") == "bar"
     assert settings.get("BAZ") == "bar"
 

--- a/tests/test_hooking.py
+++ b/tests/test_hooking.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import pytest
+
+from dynaconf import Dynaconf
+from dynaconf.base import Settings
+from dynaconf.hooking import Action
+from dynaconf.hooking import EagerValue
+from dynaconf.hooking import get_hooks
+from dynaconf.hooking import Hook
+from dynaconf.hooking import hookable
+from dynaconf.hooking import HookableSettings
+from dynaconf.hooking import HookValue
+from dynaconf.utils.boxing import DynaBox
+
+
+class BaseHookedSettings:
+    def __init__(self, **kwargs):
+        self._store = DynaBox(kwargs)
+
+    @property
+    def __dict__(self):
+        return self._store
+
+    @hookable
+    def get(self, key):
+        return self._store.get(key)
+
+
+def test_hook_dynaconf_class_get_templated():
+    settings = Dynaconf(
+        INTERNAL_VALUE=42,
+        TEMPLATED="@format {this[INTERNAL_VALUE]}abc",
+        TEMPLATED1="@int @format {this[INTERNAL_VALUE]}",
+        TEMPLATED2="@jinja {{this.INTERNAL_VALUE}}abcd",
+        TEMPLATED3="@int @jinja {{this.INTERNAL_VALUE}}",
+        _wrapper_class=HookableSettings,
+    )
+
+    def just_assert_values_after_get(s, v, key, *_, **__):
+        assert s["INTERNAL_VALUE"] == 42
+        if key == "INTERNAL_VALUE":
+            assert v == 99
+        return v
+
+    def set_internal_value_to_99_before_get(s, v, key, *_, **__):
+        if key == "INTERNAL_VALUE":
+            return EagerValue(99)
+        return v
+
+    settings["_registered_hooks"] = {
+        Action.BEFORE_GET: [Hook(set_internal_value_to_99_before_get)],
+        Action.AFTER_GET: [Hook(just_assert_values_after_get)],
+    }
+
+    assert settings.TEMPLATED == "99abc"
+    settings.set("FOOVALUE", 100)
+    assert settings.FOOVALUE == 100
+    assert settings["FOOVALUE"] == 100
+    assert settings.TEMPLATED1 == 99
+    assert settings.TEMPLATED2 == "99abcd"
+    assert settings.TEMPLATED3 == 99
+    assert settings.INTERNAL_VALUE == 99
+    assert settings.get("INTERNAL_VALUE") == 99
+
+
+def test_hook_dynaconf_class_after_get():
+    settings = Dynaconf(INTERNAL_VALUE=42, _wrapper_class=HookableSettings)
+    assert settings.internal_value == 42
+
+    def adds_one(s, v, *_, **__):
+        return v + 1
+
+    settings["_registered_hooks"] = {
+        Action.AFTER_GET: [Hook(adds_one)],
+    }
+    hooks = get_hooks(settings)
+    assert len(hooks) == 1
+    assert settings.INTERNAL_VALUE == 43
+    assert settings.get("INTERNAL_VALUE") == 43
+
+
+def test_hooked_dict():
+    class HookedDict(BaseHookedSettings, dict):
+
+        _store = {}
+
+        @hookable
+        def get(self, key, default=None):
+            return "to"
+
+    d = HookedDict()
+    d["_registered_hooks"] = {
+        Action.AFTER_GET: [
+            Hook(lambda s, v, *_, **__: f"{v}fu"),
+        ],
+    }
+    assert d.get("key") == "tofu"
+
+
+def test_hooked_dict_store():
+    class HookedDict(BaseHookedSettings, dict):
+        ...
+
+    d = HookedDict(
+        key="to",
+        _registered_hooks={
+            Action.AFTER_GET: [
+                Hook(lambda s, v, *_, **__: f"{v}fu"),
+            ],
+        },
+    )
+    assert d.get("key") == "tofu"
+
+
+def test_hook_before_and_after_bypass_method():
+    """Method is never executed, before and after hooks are called"""
+
+    class HookedSettings(BaseHookedSettings):
+
+        _store = {}
+
+        _registered_hooks = {
+            # Accumulate all values
+            Action.BEFORE_GET: [
+                Hook(lambda s, v, *_, **__: "ba"),
+                Hook(lambda s, v, *_, **__: EagerValue(f"{v.value}na")),
+                # EagerValue is a special value that bypasses the method
+                # and goes to the after hooks
+            ],
+            # After hooks makes the final value
+            Action.AFTER_GET: [
+                Hook(lambda s, v, *_, **__: f"{v.value}na"),
+            ],
+        }
+
+        @hookable(name="get")
+        def get(self, key):
+            # 1st before hook will make value to be "ba"
+            # 2nd before hook will make value to be "bana"
+            # 1st after hook will make value to be "banana"
+            return "value"  # this will never be executed
+
+    settings = HookedSettings()
+    assert settings.get("key") == "banana"
+
+
+def test_hook_runs_after_method():
+    """After method the after hooks transforms value."""
+
+    DATABASE = {
+        "feature_enabled": True,
+    }
+
+    def try_to_get_from_database(d, value, key, *_, **__):
+        assert d.get("feature_enabled") is False
+        return DATABASE.get(key, value.value)
+
+    class HookedSettings(BaseHookedSettings):
+        ...
+
+    settings = HookedSettings(
+        feature_enabled=False,
+        something_not_in_database="default value",
+        _registered_hooks={
+            Action.AFTER_GET: [
+                Hook(try_to_get_from_database),
+            ],
+        },
+    )
+
+    # On the object feature is disabled
+    # but on the database it is enabled
+    assert settings.get("feature_enabled") is True
+
+    # This key is not in the database, so returns regular value
+    assert settings.get("something_not_in_database") == "default value"
+
+
+def test_hook_fail_with_wrong_parameters():
+    """Hookable decorator fails when called with wrong parameters."""
+
+    with pytest.raises(TypeError):
+
+        @hookable("not a function")
+        def foo():
+            pass
+
+
+def test_hook_values():
+    value = HookValue(1)
+    assert value == 1
+    assert value != 2
+    assert value == HookValue(1)
+    assert value != HookValue(2)
+    assert bool(value) is True
+    assert str(value) == "1"
+    assert repr(value) == repr(value.value)
+    assert value + 1 == 2
+    assert value - 1 == 0
+    assert value * 2 == 2
+    assert value / 2 == 0.5
+    assert value // 2 == 0
+    assert value % 2 == 1
+    assert value**2 == 1
+    assert divmod(value, 2) == (0, 1)
+
+    value = HookValue([1, 2, 3])
+    assert value == [1, 2, 3]
+    assert value != [1, 2, 4]
+    assert value == HookValue([1, 2, 3])
+    assert value != HookValue([1, 2, 4])
+    assert bool(value) is True
+    assert str(value) == "[1, 2, 3]"
+    assert repr(value) == repr(value.value)
+    assert value[0] == 1
+    assert value[1] == 2
+    assert value[2] == 3
+    assert len(value) == 3
+    assert value[0:2] == [1, 2]
+    assert 2 in value
+    assert [x for x in value] == [1, 2, 3]
+
+    class Dummy:
+        pass
+
+    _value = Dummy()
+    value = HookValue(_value)
+    assert value == value.value
+    assert value != object()
+    assert value == HookValue(_value)
+    assert value != HookValue(object())
+    assert bool(value) is True
+    value.name = "dummy value"
+    assert value.name == "dummy value"
+    delattr(value, "name")
+    assert not hasattr(value, "name")
+
+    value = HookValue({})
+    assert value == {}
+    assert value != {"a": 1}
+    assert value == HookValue({})
+    value["a"] = 1
+    assert value == {"a": 1}
+    assert value["a"] == 1
+    del value["a"]
+    assert value == {}

--- a/tests/test_hooking.py
+++ b/tests/test_hooking.py
@@ -16,6 +16,7 @@ from dynaconf.utils.boxing import DynaBox
 class BaseHookedSettings:
     def __init__(self, **kwargs):
         self._store = DynaBox(kwargs)
+        self._loaded_by_loaders = {}
 
     @property
     def __dict__(self):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -117,9 +117,18 @@ def test_get_history_general(tmp_path):
     history = get_history(settings)
 
     # metadata
-    assert len(history) == 2
+    assert len(history) == 3
     assert is_dict_subset(
         history[0],
+        {
+            "loader": "undefined",
+            "identifier": "init_kwargs",
+            "env": "global",
+            "merged": False,
+        },
+    )
+    assert is_dict_subset(
+        history[1],
         {
             "loader": "yaml",
             "identifier": str(file_a),
@@ -128,7 +137,7 @@ def test_get_history_general(tmp_path):
         },
     )
     assert is_dict_subset(
-        history[1],
+        history[2],
         {
             "loader": "yaml",
             "identifier": str(file_b),
@@ -138,18 +147,19 @@ def test_get_history_general(tmp_path):
     )
 
     # data integrity
-    assert history[0]["value"]["DICTY"] == {
+    assert "SETTINGS_FILE_FOR_DYNACONF" in history[0]["value"]
+    assert history[1]["value"]["DICTY"] == {
         "a": "A",
         "b": [1, {"c": "C", "d": "D"}],
     }
-    assert history[1]["value"]["LISTY"] == [
+    assert history[2]["value"]["LISTY"] == [
         1,
         {"a": "A", "b": "B", "c": [1, 2]},
     ]
 
     # types has been normalized
-    assert history[0]["value"]["DICTY"].__class__ == dict
-    assert history[1]["value"]["LISTY"].__class__ == list
+    assert history[1]["value"]["DICTY"].__class__ == dict
+    assert history[2]["value"]["LISTY"].__class__ == list
 
 
 def test_get_history_env_false__file_plus_envvar(tmp_path):
@@ -165,9 +175,9 @@ def test_get_history_env_false__file_plus_envvar(tmp_path):
     history = get_history(settings)
 
     # metadata
-    assert len(history) == 2
+    assert len(history) == 3
     assert is_dict_subset(
-        history[0],
+        history[1],
         {
             "loader": "yaml",
             "identifier": str(file_a),
@@ -176,7 +186,7 @@ def test_get_history_env_false__file_plus_envvar(tmp_path):
         },
     )
     assert is_dict_subset(
-        history[1],
+        history[2],
         {
             "loader": "env_global",
             "identifier": "unique",
@@ -212,7 +222,7 @@ def test_get_history_env_false__val_default_plus_envvar():
     assert is_dict_subset(
         history[1],
         {
-            "loader": "validation_default",
+            "loader": "setdefault",
             "identifier": "unique",
             "env": "main",
             "merged": False,
@@ -237,29 +247,29 @@ def test_get_history_env_false__merge_marks(tmp_path):
     history = get_history(settings)
 
     # metadata
-    assert len(history) == 4
-    assert history[0] == {
+    assert len(history) == 5
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"LISTY": [1, 2, 3]},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_b),
         "env": "default",
         "merged": True,
         "value": {"LISTY": [1, 2, 3, 4, 5, 6]},
     }
-    assert history[2] == {
+    assert history[3] == {
         "loader": "toml",
         "identifier": str(file_c),
         "env": "default",
         "merged": True,
         "value": {"LISTY": [1, 2, 3, 4, 5, 6, 7, 8, 9]},
     }
-    assert history[3] == {
+    assert history[4] == {
         "loader": "env_global",
         "identifier": "unique",
         "env": "global",
@@ -286,22 +296,22 @@ def test_get_history_env_true__file_plus_envvar(tmp_path):
     settings = Dynaconf(settings_file=file_a, environments=True)
     history = get_history(settings)
 
-    assert len(history) == 3
-    assert history[0] == {
+    assert len(history) == 4
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"FOO": "from_default_env"},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "development",
         "merged": False,
         "value": {"FOO": "from_development_env"},
     }
-    assert history[2] == {
+    assert history[3] == {
         "loader": "env_global",
         "identifier": "unique",
         "env": "global",
@@ -323,7 +333,7 @@ def test_get_history_env_true__val_default_plus_file(tmp_path):
         development.foo="from_development_file"
         """,
     )
-    print()
+    # print()
     settings = Dynaconf(
         validators=[
             Validator("bar", default="from_val_default_current_env"),
@@ -336,30 +346,30 @@ def test_get_history_env_true__val_default_plus_file(tmp_path):
     )
     history = get_history(settings)
 
-    assert len(history) == 4
-    assert history[0] == {
+    assert len(history) == 5
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"FOO": "from_default_file"},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "development",
         "merged": False,
         "value": {"FOO": "from_development_file"},
     }
-    assert history[2] == {
-        "loader": "validation_default",
+    assert history[3] == {
+        "loader": "setdefault",
         "identifier": "unique",
         "env": "development",
         "merged": False,
         "value": {"BAR": "from_val_default_current_env"},
     }
-    assert history[3] == {
-        "loader": "validation_default",
+    assert history[4] == {
+        "loader": "setdefault",
         "identifier": "unique",
         "env": "production",
         "merged": False,
@@ -384,29 +394,29 @@ def test_get_history_env_true__merge_marks(tmp_path):
     history = get_history(settings)
 
     # metadata
-    assert len(history) == 4
-    assert history[0] == {
+    assert len(history) == 5
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"LISTY": [1, 2, 3]},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_b),
         "env": "default",
         "merged": True,
         "value": {"LISTY": [1, 2, 3, 4, 5, 6]},
     }
-    assert history[2] == {
+    assert history[3] == {
         "loader": "toml",
         "identifier": str(file_c),
         "env": "default",
         "merged": True,
         "value": {"LISTY": [1, 2, 3, 4, 5, 6, 7, 8, 9]},
     }
-    assert history[3] == {
+    assert history[4] == {
         "loader": "env_global",
         "identifier": "unique",
         "env": "global",
@@ -686,15 +696,15 @@ def test_caveat__get_history_env_true(tmp_path):
     settings = Dynaconf(settings_file=file_a, environments=True)
     history = get_history(settings)
 
-    assert len(history) == 2
-    assert history[0] == {
+    assert len(history) == 3
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"FOO": "from_default_env"},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "development",
@@ -703,7 +713,7 @@ def test_caveat__get_history_env_true(tmp_path):
     }
 
     with pytest.raises(IndexError):
-        assert history[2] == {
+        assert history[3] == {
             "loader": "toml",
             "identifier": str(file_a),
             "env": "production",
@@ -734,15 +744,15 @@ def test_caveat__get_history_env_true_workaround(tmp_path):
     settings.from_env("production")
     history = get_history(settings)
 
-    assert len(history) == 3
-    assert history[0] == {
+    assert len(history) == 4
+    assert history[1] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "default",
         "merged": False,
         "value": {"FOO": "from_default_env"},
     }
-    assert history[1] == {
+    assert history[2] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "development",
@@ -750,7 +760,7 @@ def test_caveat__get_history_env_true_workaround(tmp_path):
         "value": {"FOO": "from_development_env"},
     }
 
-    assert history[2] == {
+    assert history[3] == {
         "loader": "toml",
         "identifier": str(file_a),
         "env": "production",

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -73,11 +73,11 @@ def test_ensure_serializable():
 
 def test_get_data_by_key():
     data = {"a": "A", "b": [1, 2, 3, {"a": "A", "b": "B"}], "c": {"d": "D"}}
-    assert _get_data_by_key(data, "a", upperfy_key=False) == "A"
+    assert _get_data_by_key(data, "a") == "A"
     # 2 cases below are not supported dynaconf idiom yet
-    # assert _get_data_by_key(data, "b._1_", upperfy_key=False) == 2
-    # assert _get_data_by_key(data, "b._3_.b", upperfy_key=False) == "B"
-    assert _get_data_by_key(data, "c.d", upperfy_key=False) == "D"
+    # assert _get_data_by_key(data, "b._1_") == 2
+    # assert _get_data_by_key(data, "b._3_.b") == "B"
+    assert _get_data_by_key(data, "c.d") == "D"
     assert _get_data_by_key(data, "this.doesnt.exist", default="foo") == "foo"
 
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -122,7 +122,7 @@ def test_get_history_general(tmp_path):
     assert is_dict_subset(
         history[0],
         {
-            "loader": "undefined",
+            "loader": "set_method",
             "identifier": "init_kwargs",
             "env": "global",
             "merged": False,
@@ -131,7 +131,7 @@ def test_get_history_general(tmp_path):
     assert is_dict_subset(
         history[1],
         {
-            "loader": "undefined",
+            "loader": "set_method",
             "identifier": "settings_module_method",
             "env": "global",
             "merged": False,

--- a/tests_functional/django_example/Makefile
+++ b/tests_functional/django_example/Makefile
@@ -9,3 +9,4 @@ test:
 	PYTHONPATH=. DJANGO_SETTINGS_MODULE=foo.settings dynaconf list
 	PYTHONPATH=. DJANGO_SETTINGS_MODULE=foo.settings dynaconf get DEBUG
 	PYTHONPATH=. DJANGO_SETTINGS_MODULE=foo.settings dynaconf inspect
+	PYTHONPATH=. DJANGO_SETTINGS_MODULE=foo.settings dynaconf inspect -k BEST_BOSS

--- a/tests_functional/django_example/foo/a_plugin_folder/dynaconf_hooks.py
+++ b/tests_functional/django_example/foo/a_plugin_folder/dynaconf_hooks.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
+from dynaconf.hooking import Action
+from dynaconf.hooking import Hook
+
+
+def hook_best_boss(temp_settings, value, key, *args, **kwargs):
+    """The key BEST_BOSS is not defined anywhere
+    but will return what this function returns"""
+    if key == "BEST_BOSS":
+        return "Michael Scott"
+    return value
+
 
 def post(settings):
     data = {"dynaconf_merge": True}
     if settings.get("ADD_BEATLES") is True:
         data["BANDS"] = ["Beatles"]
+
+    data["_registered_hooks"] = {Action.AFTER_GET: [Hook(hook_best_boss)]}
     return data

--- a/tests_functional/django_example/foo/dynaconf_hooks.py
+++ b/tests_functional/django_example/foo/dynaconf_hooks.py
@@ -2,4 +2,6 @@ from __future__ import annotations
 
 
 def post(settings):
-    return {"HOOK_ON_DJANGO_APP": True}
+    return {
+        "HOOK_ON_DJANGO_APP": True,
+    }

--- a/tests_functional/django_example/polls/tests.py
+++ b/tests_functional/django_example/polls/tests.py
@@ -10,6 +10,9 @@ from django.test.utils import override_settings
 @override_settings(ISSUE=596)
 class SettingsTest(TestCase):
     def test_settings(self):
+        # hooks
+        self.assertEqual(settings.BEST_BOSS, "Michael Scott")
+
         self.assertEqual(settings.ISSUE, 596)
         self.assertEqual(settings.SERVER, "prodserver.com")
         # self.assertEqual(
@@ -107,6 +110,7 @@ class TestHookExecutes(TestCase):
             ["Metallica", "Black Sabbath", "Iron Maiden", "Beatles"],
         )
         self.assertTrue(settings.HOOK_ON_DJANGO_APP)
+        self.assertEqual(settings.BEST_BOSS, "Michael Scott")
 
 
 class TestMerge(TestCase):

--- a/tests_functional/issues/905_item_duplication_in_list/app.py
+++ b/tests_functional/issues/905_item_duplication_in_list/app.py
@@ -21,3 +21,4 @@ settings.validators.validate()
 assert settings.group.test_list == ["1", "2"], settings.group
 assert settings.group.something_new == 5
 assert settings.group.another_setting == "ciao"
+assert settings.group.another == 45

--- a/tests_functional/issues/905_item_duplication_in_list/app.py
+++ b/tests_functional/issues/905_item_duplication_in_list/app.py
@@ -18,6 +18,6 @@ settings.validators.register(
 
 settings.validators.validate()
 
-assert settings.group.test_list == ["'1'", "'2'"]
+assert settings.group.test_list == ["1", "2"], settings.group
 assert settings.group.something_new == 5
 assert settings.group.another_setting == "ciao"

--- a/tests_functional/issues/969/app.py
+++ b/tests_functional/issues/969/app.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dynaconf import Dynaconf
+
+data = {1: 2}
+settings = Dynaconf()
+
+# __import__('ipdb').set_trace()
+settings.set("data", data)
+
+
+assert settings["data"][1] == 2


### PR DESCRIPTION
This PR allows changing the wrapped class with
a class that allows hooks on specific methods.

This will enable https://github.com/ansible/galaxy_ng/pull/1837

This PR also fixes: #969

This PR replaces #828 



Allows to add AFTER and BEFORE hooks to some dynaconf methods

```python
from dynaconf import Dynaconf
from dynaconf.hooking import Action, Hook, HookableSettings

settings = Dynaconf(_wrapper_class=HookableSettings)

def lookup_for_key_in_cache_or_database(settings, value,  key, default):
    print(f"doing things to lookup key {key!r} on cache or db")
    new_value = find_in_cache(key) or query_db(key) or value 
    return new_value

settings.register_hook(Action.AFTER_GET, lookup_for_key_in_cache_or_database)
```

Then in any part of code

```python
>>> from config import settings
>>> settings.MY_AWESOME_KEY
"doing things to lookup key 'MY_AWESOME_KEY' on cache or db"
```