### PR TITLE
Fix #979 - validators must not parse with toml

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -396,7 +396,7 @@ class Settings:
                 item,
                 default,
                 loader_identifier=loader_identifier,
-                tomlfy=True,
+                tomlfy=False,
             )
             return default
 

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -262,7 +262,8 @@ class Validator:
                 and self.is_type_of is str
             ):
                 # avoid TOML from parsing "+-1" as integer
-                default_value = f"'{default_value}'"
+                # by forcing casting to str
+                default_value = f"@str {default_value}"
 
             value = settings.setdefault(
                 name,

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -745,13 +745,13 @@ def test_toml_should_not_change_validator_type_with_is_type_set():
 
 def test_toml_should_not_change_validator_type_with_is_type_not_set_int():
     settings = Dynaconf(
-        validators=[Validator("TEST", default="+172800")]
+        validators=[Validator("TEST", default=-172800)]
         # The ways to force a string is
         # passing is_type_of=str
-        # or default="@str +172800" or default="'+172800'"
+        # or default="@str +172800" or default="+172800"
     )
 
-    assert settings.test == +172800
+    assert settings.test == -172800
 
 
 def test_toml_should_not_change_validator_type_using_at_sign():

--- a/tests_functional/issues/905_item_duplication_in_list/.env
+++ b/tests_functional/issues/905_item_duplication_in_list/.env
@@ -1,3 +1,3 @@
-DYNACONF_GROUP__TEST_LIST = ["'1'", "'2'"]   # double quotes to cast as string
+DYNACONF_GROUP__TEST_LIST="['1', '2']"
 
 DYNACONF_GROUP__ANOTHER = 45

--- a/tests_functional/issues/905_item_duplication_in_list/app.py
+++ b/tests_functional/issues/905_item_duplication_in_list/app.py
@@ -11,7 +11,6 @@ settings = Dynaconf(
     merge_enabled=True,
 )
 
-
 settings.validators.register(
     Validator("group.something_new", default=5),
 )


### PR DESCRIPTION
#979 #905
3 years ago I made the wrong decision to pass validators defaults to TOML parser.

Validator object is created at Python level, or at YAML level where there is no need to use toml as parser.

TOML parser must ideally be used only on environment variables where there is no type system available.

That said, this PR ensures toml will keep parsing values coming from envvars, but setdefault method will stop passing `tomlfy=True` so the type informed on the validator will be the type set as default value.

The only possible breaking change on this is if someone is setting defaults relying on TOML to parse the data, in that case, user will need to manually call `parse_with_toml` on default data.

I think that is not a common case, if someone reports it as a broken change, we can provide a new argument `parse_default_with_toml` on the Validator object later.