### PR TITLE
Set minimum HVAC version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ test_requirements = [
     "python-dotenv",
     "toml",
     "redis",
-    "hvac",
+    "hvac>=1.1.0",
     "configobj",
 ]
 


### PR DESCRIPTION
Dynaconf currently passes raise_on_deleted_version to HVAC's read_secret_version method. This is not supported in HVAC versions before 1.1.0.

Fixes #1009