### PR TITLE
fix(cli): support for 'entrypoint-path' in FLASK_APP #946

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ dynaconf/vendor/source
 .tool-versions
 
 .DS_Store
+
+.helix

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -64,7 +64,8 @@ def set_settings(ctx, instance=None):
             from flask.cli import ScriptInfo  # noqa
             from dynaconf import FlaskDynaconf
 
-            flask_app = ScriptInfo().load_app()
+            app_import_path = os.environ["FLASK_APP"]
+            flask_app = ScriptInfo(app_import_path).load_app()
             settings = FlaskDynaconf(flask_app, **flask_app.config).settings
             if _echo_enabled:
                 click.echo(

--- a/tests_functional/issues/946_flask_cli/Makefile
+++ b/tests_functional/issues/946_flask_cli/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	FLASK_APP=myapp:app dynaconf list

--- a/tests_functional/issues/946_flask_cli/myapp.py
+++ b/tests_functional/issues/946_flask_cli/myapp.py
@@ -1,0 +1,13 @@
+"""
+CLI wouldnt recognize FLASK_APP "entrypoint" path (foo.bar:app)
+
+https://github.com/dynaconf/dynaconf/issues/946
+"""
+from __future__ import annotations
+
+from flask import Flask
+
+from dynaconf import FlaskDynaconf
+
+app = Flask(__name__)
+FlaskDynaconf(app)


### PR DESCRIPTION
Dynaconf CLI wouldn't recognize `FLASK_APP=<path>`, where `path` syntax is like `foo.bar:app` ('entrypoint-format').

This adds support for that by passing the FLASK_APP value to Flask itself to handle, as suggested in #946.

@COUR4G3 Thanks for the good notes about the problem.