### PR TITLE
fix(env):allow underscore in env name #1011

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -812,8 +812,8 @@ class Settings:
         """
         env = env or self.ENV_FOR_DYNACONF
 
-        if not isinstance(env, str) or "_" in env or " " in env:
-            raise ValueError("env should be a string without _ or spaces")
+        if not isinstance(env, str) or " " in env:
+            raise ValueError("env should be a string without spaces")
 
         env = env.upper()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -210,9 +210,9 @@ def test_env_should_be_string(settings):
         settings.setenv(123456)
 
 
-def test_env_should_not_have_underline(settings):
-    with pytest.raises(ValueError):
-        settings.setenv("COOL_env")
+def test_env_should_allow_underline(settings):
+    settings.setenv("COOL_env")
+    assert settings.current_env == "COOL_ENV"
 
 
 def test_path_for(settings):

--- a/tests_functional/issues/1011_env_with_underline/app.py
+++ b/tests_functional/issues/1011_env_with_underline/app.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dynaconf import Dynaconf
+
+
+settings = Dynaconf(
+    settings_files=["settings.toml"],
+    environments=["unit_testing", "dev_coding", "prod_server"],
+)
+
+unit_settings = settings.from_env("unit_testing")
+dev_settings = settings.from_env("dev_coding")
+prod_settings = settings.from_env("prod_server")
+
+assert settings.name == "default"
+assert unit_settings.name == "unit"
+assert dev_settings.name == "dev"
+assert prod_settings.name == "prod"
+
+settings.setenv("prod_server")
+assert settings.name == "prod"

--- a/tests_functional/issues/1011_env_with_underline/settings.toml
+++ b/tests_functional/issues/1011_env_with_underline/settings.toml
@@ -1,0 +1,8 @@
+[default]
+name = "default"
+[unit_testing]
+name = "unit"
+[dev_coding]
+name = "dev"
+[prod_server]
+name = "prod"


### PR DESCRIPTION
Revert change added in #830, I was not able to find the reason for the change

The env name must allow `_` 

Fix #1011  