### PR TITLE
Fix link to configuration page

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -13,7 +13,7 @@ In addition to that Dynaconf offers some approaches you may want to **Optionally
 
 ## Environment variables
 
-You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](configuration/#custom-prefix)).
+You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](/configuration/#envvar_prefix)).
 
 !!! warning
     Dynaconf will only look for UPPERCASE prefixed envvars. This means envvar exported as `dynaconf_value` or `myprefix_value` won't be loaded, while `DYNACONF_VALUE` and `MYPREFIX_VALUE` (when proper set) will.


### PR DESCRIPTION
Discussion #1017 

I've decided to follow the already existing links style even though `mkdocs` writes messages like this:

```
INFO    -  Doc file 'envvars.md' contains an absolute link '/configuration/#envvar_prefix', it was left as is. Did you mean 'configuration.md#envvar_prefix'?
```