### PR TITLE
[Doc] Fix the syntax errors of  the  doc  programming example.

### DIFF
--- a/docs/settings_files.md
+++ b/docs/settings_files.md
@@ -89,8 +89,8 @@ settings = Dynaconf(settings_files=["settings.toml", "*.yaml"])
 
 # using root_path
 settings = Dynaconf(
-    root_path="my/project/root"
-    settings_files=["settings.toml", "*.yaml"],
+    root_path="my/project/root",
+    settings_files=["settings.toml", "*.yaml"]
 )
 ```
 


### PR DESCRIPTION
The example's syntax have a mistake.   At the line end of "root_path" should have a ", " 