### PR TITLE
replace dead link flask subclassing page

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -2,7 +2,7 @@
 
 Dynaconf provides a drop in replacement for `app.config`.
 
-As Flask encourages the composition by overriding the `config_class` attribute this extension follows the [patterns of Flask](http://flask.pocoo.org/docs/0.12/patterns/subclassing/) and turns your Flask's `app.config` in to a `dynaconf` instance.
+As Flask encourages the composition by overriding the `config_class` attribute this extension follows the [patterns of Flask](https://flask.palletsprojects.com/en/2.3.x/patterns/subclassing/) and turns your Flask's `app.config` in to a `dynaconf` instance.
 
 ## Initialize the extension
 


### PR DESCRIPTION
The link http://flask.pocoo.org/docs/0.12/patterns/subclassing/ leads to a page not found. I replaced it with the current link.