### PR TITLE
chore: Fix misspelled variable name for misspell

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -90,13 +90,13 @@ class LazySettings(LazyObject):
         e.g: ROOT_PATH='/' is transformed into `ROOT_PATH_FOR_DYNACONF`
         """
 
-        mispells = {
+        misspells = {
             "settings_files": "settings_file",
             "SETTINGS_FILES": "SETTINGS_FILE",
             "environment": "environments",
             "ENVIRONMENT": "ENVIRONMENTS",
         }
-        for misspell, correct in mispells.items():
+        for misspell, correct in misspells.items():
             if misspell in kwargs:
                 kwargs[correct] = kwargs.pop(misspell)
 

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -78,10 +78,10 @@ ROOT_PATH_FOR_DYNACONF = get("ROOT_PATH_FOR_DYNACONF", None)
 # Default settings file
 SETTINGS_FILE_FOR_DYNACONF = get("SETTINGS_FILE_FOR_DYNACONF", [])
 
-# MISPELLS `FILES` when/if it happens
-mispelled_files = get("SETTINGS_FILES_FOR_DYNACONF", None)
-if not SETTINGS_FILE_FOR_DYNACONF and mispelled_files is not None:
-    SETTINGS_FILE_FOR_DYNACONF = mispelled_files
+# MISSPELLS `FILES` when/if it happens
+misspelled_files = get("SETTINGS_FILES_FOR_DYNACONF", None)
+if not SETTINGS_FILE_FOR_DYNACONF and misspelled_files is not None:
+    SETTINGS_FILE_FOR_DYNACONF = misspelled_files
 
 # # ENV SETTINGS
 # # In dynaconf 1.0.0 `NAMESPACE` got renamed to `ENV`


### PR DESCRIPTION
Fixed an issue where a portion of variable names was spelled as `mispell` instead of `misspell`.





