### PR TITLE
[Doc] Fix a small mistake of .env file in the document

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -116,7 +116,7 @@ and Dynaconf comes with `Python-Dotenv` support.
 You can put in the root of your application a file called **.env**
 
 ```bash
-PREFIX_USER=admin
+DYNACONF_USER=admin
 ```
 
 Then pass `load_dotenv=True` to your settings.


### PR DESCRIPTION
You are describing dot env files in ths section. The env name should be `DYNACONF_USER` rather than `PREFIX_USER`. If not, the program could not read the env correctly.