### PR TITLE
feat: Add `@get` converter to alias existing keys

### DIFF
--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -130,3 +130,41 @@ MODEL_SETTINGS_DICT: "@json @jinja {{ this|attr(this.MODEL_TYPE) }}"
 # This returns the raw json string
 MODEL_SETTINGS_STR: "@jinja {{ this|attr(this.MODEL_TYPE) }}"
 ```
+
+
+## Name aliasing
+
+In certain cases you need to reuse some variable value respecting the exact 
+data type it is previously defined in another step of the settings load.
+
+Example:
+
+`config.py`
+```py
+from dynaconf import Dynaconf
+settings = Dynaconf(settings_files=["settings.toml", "other.toml"])  
+```
+
+`settings.toml`
+```toml 
+thing = "value"
+number = 42
+```
+
+`other.toml`
+```toml 
+other_thing = "@get thing"
+
+# providing default if thing is undefined
+other_thing = "@get thing 'default value'"
+
+## type casting
+# Ensure the aliased value is of type int
+other_number = "@get number @int"
+
+# Ensure type and provide default if number is undefined
+other_number = "@get number @int 12"
+```
+
+The `@get` is lazily evaluated and subject to `DynaconfFormatError` in case of
+malformed expression, it is recommended to add validators.

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -139,20 +139,17 @@ data type it is previously defined in another step of the settings load.
 
 Example:
 
-`config.py`
-```py
+```py title="config.py"
 from dynaconf import Dynaconf
 settings = Dynaconf(settings_files=["settings.toml", "other.toml"])  
 ```
 
-`settings.toml`
-```toml 
+```toml title="settings.toml"
 thing = "value"
 number = 42
 ```
 
-`other.toml`
-```toml 
+```toml title="other.toml"
 other_thing = "@get thing"
 
 # providing default if thing is undefined

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -432,6 +432,12 @@ class Settings:
         :param default: In case of not found it will be returned
         :param parent: Is there a pre-loaded parent in a nested data?
         """
+        # if parent is not traverseable raise error
+        if parent and not hasattr(parent, "get"):
+            raise AttributeError(
+                f"cannot lookup {dotted_key!r} from {type(parent).__name__!r}"
+            )
+
         split_key = dotted_key.split(".")
         name, keys = split_key[0], split_key[1:]
         result = self.get(name, default=default, parent=parent, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ import pytest
 from dynaconf import add_converter
 from dynaconf import default_settings
 from dynaconf import Dynaconf
+from dynaconf import DynaconfFormatError
 from dynaconf.loaders.json_loader import DynaconfEncoder
 from dynaconf.utils import build_env_list
 from dynaconf.utils import ensure_a_list
@@ -519,3 +520,21 @@ def test_boolean_fix():
     assert boolean_fix("TrueNotOnly") == "TrueNotOnly"
     assert boolean_fix("FalseNotOnly") == "FalseNotOnly"
     assert boolean_fix("NotOnlyFalse") == "NotOnlyFalse"
+
+
+def test_get_converter(settings):
+    """Ensure the work of @get converter"""
+    settings.set("FOO", 12)
+    settings.set("BAR", "@get FOO")
+    assert settings.BAR == settings.FOO == 12
+
+    settings.set("ZAZ", "@get RAZ @float 42")
+    assert settings.ZAZ == 42.0
+
+
+def test_get_converter_error_when_converting(settings):
+    """Malformed declaration errors"""
+    settings.set("BLA", "@get")
+
+    with pytest.raises(DynaconfFormatError):
+        settings.BLA


### PR DESCRIPTION
Fix #1038

https://deploy-preview-1040--dynaconf.netlify.app/dynamic/#name-aliasing 

## Name aliasing

In certain cases you need to reuse some variable value respecting the exact 
data type it is previously defined in another step of the settings load.

Example:

`config.py`
```py
from dynaconf import Dynaconf
settings = Dynaconf(settings_files=["settings.toml", "other.toml"])  
```

`settings.toml`
```toml 
thing = "value"
number = 42
```

`other.toml`
```toml 
other_thing = "@get thing"

# providing default if thing is undefined
other_thing = "@get thing 'default value'"

## type casting
# Ensure the aliased value is of type int
other_number = "@get number @int"

# Ensure type and provide default if number is undefined
other_number = "@get number @int 12"
```

The `@get` is lazily evaluated and subject to `DynaconfFormatError` in case of
malformed expression, it is recommended to add validators.
