### PR TITLE
fix: include load with relative root path

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1256,14 +1256,10 @@ class Settings:
                     filepath = os.path.join(root_dir, str(_filename))
 
                 paths = [
-                    p
-                    for p in sorted(glob(filepath, root_dir=self._root_path))
-                    if ".local." not in p
+                    p for p in sorted(glob(filepath)) if ".local." not in p
                 ]
                 local_paths = [
-                    p
-                    for p in sorted(glob(filepath, root_dir=self._root_path))
-                    if ".local." in p
+                    p for p in sorted(glob(filepath)) if ".local." in p
                 ]
 
                 # Handle possible *.globs sorted alphanumeric

--- a/tests_functional/issues/1025_include-with-root-path/Makefile
+++ b/tests_functional/issues/1025_include-with-root-path/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	pytest -sv app.py

--- a/tests_functional/issues/1025_include-with-root-path/app.py
+++ b/tests_functional/issues/1025_include-with-root-path/app.py
@@ -1,0 +1,47 @@
+"""
+[bug] dynaconf 3.2.2 broke dynaconf_include when combined with root_path
+
+https://github.com/dynaconf/dynaconf/issues/1025
+"""
+from __future__ import annotations
+
+import os
+from textwrap import dedent
+
+from dynaconf import Dynaconf
+
+
+def create_file(name, data):
+    with open(name, "w") as file:
+        file.write(dedent(data))
+
+    return name
+
+
+def test_1025(tmp_path):
+    os.chdir(tmp_path)
+    basedir = tmp_path / "etc"
+    basedir.mkdir()
+    f1 = create_file(
+        basedir / "f1.toml",
+        """
+        dynaconf_include = [
+            "f2.toml",
+        ]
+
+        name = "peter"
+        """,
+    )
+    create_file(
+        basedir / "f2.toml",
+        """
+        age = 6
+        """,
+    )
+
+    settings = Dynaconf(
+        settings_file=str(f1.absolute()),
+        root_path=basedir.name,
+    )
+    assert settings.name
+    assert settings.age

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py38,py39,py310,py311
 whitelist_externals=make
 
 [testenv]
@@ -19,5 +19,5 @@ whitelist_externals=
     python
 commands =
     ; py.test -sv --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
-    py.test -m "not integration" -v -l --tb=short --maxfail=1 tests/
+    py.test -m "not integration" -v -l --tb=short --maxfail=1 tests/ {posargs}
     ; make test_functional


### PR DESCRIPTION
The include loader was not handling the relative `root_path` correctly.

Closes #1025 