### PR TITLE
fix(doc): fix argument `env` in Validation at validation.md

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -520,7 +520,7 @@ settings = Dynaconf(
     environments=True,
     validators=[
         # Ensure some parameters exist for both envs
-        Validator('VERSION', 'NAME', 'SERVERS', envs=['development', 'production'], must_exist=True),
+        Validator('VERSION', 'NAME', 'SERVERS', env=['development', 'production'], must_exist=True),
 
         # Ensure some parameter validate certain condition in dev env
         Validator("SERVERS", env='development', cont='localhost'),


### PR DESCRIPTION
Validation has no argument `envs`, it is mentioned in the doc but it seems to be not correct as it gives:

```
AttributeError: module 'dynaconf.validator_conditions' has no attribute 'envs'
```