### PR TITLE
Add python API reference with mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - Django: django.md
   - Advanced usage: advanced.md
   - FAQ: faq.md
+  - API Reference: reference/
 theme:
   features:
     - search.suggest
@@ -69,6 +70,13 @@ plugins:
   - search:
       lang: en
       prebuild_index: true
+  - gen-files:
+      scripts:
+      - scripts/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+  - mkdocstrings
 extra:
   disqus: dynaconf
   social:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,8 @@ mkdocs
 pymdown-extensions
 mkdocs-material
 mkdocs-git-revision-date-plugin
+mkdocs-gen-files
+mkdocs-literate-nav
+mkdocs-section-index
+mkdocstrings[python]
 Jinja2>3.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,6 +40,10 @@ mkdocs>=1.1.2
 mkdocs-material>=5.3.2
 mkdocs-material-extensions>=1.0
 mkdocs-git-revision-date-plugin
+mkdocstrings[python]
+mkdocs-gen-files
+mkdocs-literate-nav
+mkdocs-section-index
 pymdown-extensions
 Jinja2>3.0.0
 

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -43,7 +43,7 @@ for path in sorted(src.rglob("*.py")):
     # Followed the advice in the note in this section of the mkdocstrings
     # recipe: https://mkdocstrings.github.io/recipes/#generate-pages-on-the-fly
     # Not doing this resulted in a 404 error.
-    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)
 
 # Similar comment to above, needed to make sure the path was relative.
 with mkdocs_gen_files.open(

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -1,19 +1,26 @@
-"""Generate the code reference pages and navigation."""
+"""Generate the code reference pages and navigation.
 
+From the mkdocstrings recipe: https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
+"""
 from pathlib import Path
 
 import mkdocs_gen_files
 
 nav = mkdocs_gen_files.Nav()
 
+# The template for this script made the assumption that the package files lived in
+# a src/ folder, so some of the paths here needed to change.
 root = Path(__file__).parent.parent
 src = Path(__file__).parent.parent / "dynaconf"
-docs_folder = root / "docs"
 
 for path in sorted(src.rglob("*.py")):
+    # We get the paths relative to the project root, rather than the src.
     module_path = path.relative_to(root).with_suffix("")
     doc_path = path.relative_to(root).with_suffix(".md")
-    full_doc_path = Path(docs_folder, "reference", doc_path)
+    # Needed to make sure the path here is relative to this file because
+    # mkdocs_gen_files defaulted to creating things in the temp folder for some reason.
+    # Caused git errors because files were outside the repo.
+    full_doc_path = Path(root, "docs", "reference", doc_path)
 
     parts = tuple(module_path.parts)
 
@@ -30,7 +37,11 @@ for path in sorted(src.rglob("*.py")):
         identifier = ".".join(parts)
         print("::: " + identifier, file=fd)
 
+    # Followed the advice in the note in this section of the mkdocstrings recipe:
+    # https://mkdocstrings.github.io/recipes/#generate-pages-on-the-fly
+    # Not doing this resulted in a 404 error.
     mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
 
-with mkdocs_gen_files.open(Path(docs_folder, "reference/SUMMARY.md"), "w") as nav_file:
+# Similar comment to above, needed to make sure the path was relative.
+with mkdocs_gen_files.open(Path(root, "docs", "reference/SUMMARY.md"), "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -1,15 +1,18 @@
 """Generate the code reference pages and navigation.
 
-From the mkdocstrings recipe: https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
+From the mkdocstrings recipe:
+https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages
 """
+from __future__ import annotations
+
 from pathlib import Path
 
 import mkdocs_gen_files
 
 nav = mkdocs_gen_files.Nav()
 
-# The template for this script made the assumption that the package files lived in
-# a src/ folder, so some of the paths here needed to change.
+# The template for this script made the assumption that the package files lived
+# in a src/ folder, so some of the paths here needed to change.
 root = Path(__file__).parent.parent
 src = Path(__file__).parent.parent / "dynaconf"
 
@@ -18,8 +21,8 @@ for path in sorted(src.rglob("*.py")):
     module_path = path.relative_to(root).with_suffix("")
     doc_path = path.relative_to(root).with_suffix(".md")
     # Needed to make sure the path here is relative to this file because
-    # mkdocs_gen_files defaulted to creating things in the temp folder for some reason.
-    # Caused git errors because files were outside the repo.
+    # mkdocs_gen_files defaulted to creating things in the temp folder for some
+    # reason. Caused git errors because files were outside the repo.
     full_doc_path = Path(root, "docs", "reference", doc_path)
 
     parts = tuple(module_path.parts)
@@ -37,11 +40,13 @@ for path in sorted(src.rglob("*.py")):
         identifier = ".".join(parts)
         print("::: " + identifier, file=fd)
 
-    # Followed the advice in the note in this section of the mkdocstrings recipe:
-    # https://mkdocstrings.github.io/recipes/#generate-pages-on-the-fly
+    # Followed the advice in the note in this section of the mkdocstrings
+    # recipe: https://mkdocstrings.github.io/recipes/#generate-pages-on-the-fly
     # Not doing this resulted in a 404 error.
     mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
 
 # Similar comment to above, needed to make sure the path was relative.
-with mkdocs_gen_files.open(Path(root, "docs", "reference/SUMMARY.md"), "w") as nav_file:
+with mkdocs_gen_files.open(
+    Path(root, "docs", "reference/SUMMARY.md"), "w"
+) as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -1,0 +1,36 @@
+"""Generate the code reference pages and navigation."""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+root = Path(__file__).parent.parent
+src = Path(__file__).parent.parent / "dynaconf"
+docs_folder = root / "docs"
+
+for path in sorted(src.rglob("*.py")):
+    module_path = path.relative_to(root).with_suffix("")
+    doc_path = path.relative_to(root).with_suffix(".md")
+    full_doc_path = Path(docs_folder, "reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1] == "__main__":
+        continue
+
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        identifier = ".".join(parts)
+        print("::: " + identifier, file=fd)
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+
+with mkdocs_gen_files.open(Path(docs_folder, "reference/SUMMARY.md"), "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
--- This PR is in DRAFT ---

Introduces automatic generation of the API reference for `dyanconf` using `mkdocstrings` and [this recipe](https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages).

Adjustments were needed to the template script to get the paths working for a project that was at the root level, rather than inside a `src/` folder. Hopefully these adjustments are explained in the comments.

Building/serving the docs takes quite a bit longer with this automated API reference, around ~80 seconds on my machine. To try for yourselves, check out this branch and explore the served docs. Here's a screenshot of the results.
![image](https://github.com/dynaconf/dynaconf/assets/42358474/d807765b-87e9-4e78-bb1d-5c30ebfdfff5)

There is definitely a discussion to be had on what is included/excluded as part of the public API, and some adjustments can be made to the script to satisfy more fine-grained requirements. There may be a way to feed in what should/shouldn't be included via some sort of config file. Open to thoughts on this.

Resolves #997
