### PR TITLE
docs: Fix mkdocs warnings for cleaner build output

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -79,7 +79,7 @@ settings = Dynaconf(post_hooks=hook_function)
 ```
 
 You can also set the merging individually for each settings variable as seen on
-[merging](/merging/) documentation.
+[merging](merging.md) documentation.
 
 ## Inspecting History
 
@@ -89,7 +89,7 @@ You can also set the merging individually for each settings variable as seen on
     This feature is in **tech preview** the usage interface and output format is
     subject to change.
 
-This feature purpose is to allow tracking any config-data loading history, that is, the loading steps that lead to a given final value. It can return a dict data report, print to `stdout` or write to a file, and is also available as a [CLI command](/cli#dynaconf-inspect-tech-preview).
+This feature purpose is to allow tracking any config-data loading history, that is, the loading steps that lead to a given final value. It can return a dict data report, print to `stdout` or write to a file, and is also available as a [CLI command](cli.md#dynaconf-inspect-tech-preview).
 
 It works by setting a *SourceMetadata* object to every ingested data, so it can be recovered and filtered to generate meaningful reports. The properties of this object are:
 
@@ -287,7 +287,7 @@ if __name__ == "__main__":
 You can load files from within a python script.
 
 When using relative paths, it will use `root_path` as its basepath.
-Learn more about how `root_path` fallback works [here](/configuration#root_path).
+Learn more about how `root_path` fallback works [here](configuration.md#root_path).
 
 ```python
 from dynaconf import Dynaconf
@@ -511,7 +511,7 @@ all_settings = settings.from_env('development', keep=True).from_env('other', kee
 
 The variables from [development] are loaded keeping pre-loaded values, then the variables from [other] are loaded keeping pre-loaded from [development] and overriding it.
 
-It is also possible to pass additional [configuration](/configuration/) variables to `from_env` method.
+It is also possible to pass additional [configuration](configuration.md) variables to `from_env` method.
 
 ```py
 new_settings = settings.from_env('production', keep=True, SETTINGS_FILE_FOR_DYNACONF='another_file_path.yaml')
@@ -590,7 +590,7 @@ assert obj.VALUE == 42.1  # AttributeError
 
 ## Exporting
 
-You can generate a file with current configs by calling `dynaconf list -o /path/to/file.ext` see more in [cli](/cli/)
+You can generate a file with current configs by calling `dynaconf list -o /path/to/file.ext` see more in [cli](cli.md)
 
 You can also do that programmatically with:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ Every command (except the init) will require the Instance can be set using `-i` 
 
 The `$ dynaconf -i config.settings` cli provides some useful commands
 
-> **IMPORTANT** if you are using [Flask Extension](/flask/) the env var `FLASK_APP` must be defined to use the CLI, and if using [Django Extension](/django/) the `DJANGO_SETTINGS_MODULE` must be defined.
+> **IMPORTANT** if you are using [Flask Extension](flask.md) the env var `FLASK_APP` must be defined to use the CLI, and if using [Django Extension](django.md) the `DJANGO_SETTINGS_MODULE` must be defined.
 
 ### dynaconf --help
 
@@ -66,7 +66,7 @@ as well as `.gitignore` file ignoring the generated `.secrets.toml`
 .secrets.*
 ```
 
-> For sensitive data in production is recommended using [Vault Server](/secrets/)
+> For sensitive data in production is recommended using [Vault Server](secrets.md)
 
 ```bash
 Usage: dynaconf init [OPTIONS]
@@ -113,7 +113,7 @@ Note that `-i`/`--instance` cannot be used with `init` as `-i` must point to an 
 
 Inspect and dump data's loading history about a specific key or environment.
 
-It is also available as a [utility function](/advanced#inspecting-history).
+It is also available as a [utility function](advanced.md#inspecting-history).
 
 ```
 Usage: dynaconf inspect [OPTIONS]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ other_value = "other value from dev"
 ...     default_env="my_default",
 ...     env="development", # this is the active env, by default
 ... )
- 
+
 >>> settings.other_value
 "other value from dev"
 
@@ -111,7 +111,7 @@ other_value = "other value from dev"
 ```
 
 !!! note
-		The `default_env` is not the environment that will be active on startup. For this, see [`env`](/configuration/#env).
+		The `default_env` is not the environment that will be active on startup. For this, see [`env`](configuration.md#env).
 
 
 ---
@@ -272,7 +272,7 @@ After loading the files specified in `settings_files` dynaconf will load all the
 Note that:
 
 - Globs are allowed
-- When relative paths are given it will use [root_path](/configuration#root_path) as their basedir.
+- When relative paths are given it will use [root_path](configuration.md#root_path) as their basedir.
 - If `root_path` is not defined explicitly, will fallback to the directory of the last loaded setting or
 to the `cwd`. Eg:
 
@@ -310,12 +310,12 @@ Dynaconf(includes="extra.yaml")
 > env-var=`LOADERS_FOR_DYNACONF`
 
 The list of loaders dynaconf will trigger after its core loaders, this list is useful to include
-[custom loaders](/advanced/#custom loaders) and also to control the loading of env vars as the last step.
+[custom loaders](advanced.md/#custom loaders) and also to control the loading of env vars as the last step.
 
 !!! warning
     By default the `env_loader` will be latest on this list, so it ensures environment variables has the priority following the Unix philosophy.
 
-Learn more about [loaders](/advanced/)
+Learn more about [loaders](advanced.md)
 
 ---
 
@@ -364,7 +364,7 @@ With `merge_enabled` the ending `settings.server` will be
 {"port": 8888, "address": "server.com"}
 ```
 
-Otherwise it will be only what is specified in the latest loaded file. read more about [merging strategies](/merging)
+Otherwise it will be only what is specified in the latest loaded file. read more about [merging strategies](merging.md)
 
 ---
 
@@ -373,7 +373,7 @@ Otherwise it will be only what is specified in the latest loaded file. read more
 > type=`str`, default=`"__"` (double underescore) </br>
 > env-var=`NESTED_SEPARATOR_FOR_DYNACONF`
 
-One of the [merging strategies](/merging) is the use of `__` to access nested level data structures. By default the separator is `__` (double underline), this variable allows you to change that.
+One of the [merging strategies](merging.md) is the use of `__` to access nested level data structures. By default the separator is `__` (double underline), this variable allows you to change that.
 
 ex:
 
@@ -452,7 +452,7 @@ Note that:
     - The place of the last loaded file, if any files were already loaded
     - CWD
 
-Read more on [settings_files](/settings_files/#load).
+Read more on [settings_files](settings_files.md#load).
 
 !!! note
      The `cwd` is from where the python interpreter was called.
@@ -508,7 +508,7 @@ export SETTINGS_FILE_FOR_DYNACONF="/etc/program/settings.toml"
 export SETTINGS_FILES_FOR_DYNACONF="/etc/program/settings.toml;/tmp/foo.yaml"
 ```
 
-Read more on [settings_files](/settings_files/) </br>
+Read more on [settings_files](settings_files.md) </br>
 
 ---
 
@@ -574,7 +574,7 @@ settings.get("user") # won't try loading unprefixed USER
 
 Defines if validation will be triggered when a Dynaconf instance
 is updated with the methods `update()`, `set()` or `load_file()`.
-Also defines which raising strategy will be used (see more on [Validation](/validation/#trigger-on-data-update)).
+Also defines which raising strategy will be used (see more on [Validation](validation.md#trigger-on-data-update)).
 
 Valid options are:
 
@@ -618,7 +618,7 @@ validators=[
 
 When `envs` is enabled, defines if validation will be performed only on `default` + `current_env` or if all envs will be validated (even if not activated).
 
-Setting this to `True` can be useful if you have validators that apply only to some `env`s, like requiring a setting in `production` but not in `development`. See [this section](/validation#validating-only-the-current_env) in the Validation page.
+Setting this to `True` can be useful if you have validators that apply only to some `env`s, like requiring a setting in `production` but not in `development`. See [this section](validation.md#validating-only-the-current_env) in the Validation page.
 
 ### **validate_only**
 
@@ -630,7 +630,7 @@ This setting only applies during `Dynaconf` instantiation. Further calls to `Dyn
 
 In practice, this forwards `validate_only` to the `only` kwarg during the validation step upon `Dynaconf` instantiation for all `Validator`s passed. Note that this setting has interaction with [`validate_exclude`](#validate_exclude).
 
-Read more about it in the [selective validation](/validation#selective-validation) section.
+Read more about it in the [selective validation](validation.md#selective-validation) section.
 
 ### **validate_exclude**
 
@@ -642,7 +642,7 @@ This setting only applies during `Dynaconf` instantiation. Further calls to `Dyn
 
 In practice, this forwards `validate_exclude` to the `exclude` kwarg during the validation step upon `Dynaconf` instantiation for all `Validator`s passed. Note that this setting has interaction with [`validate_only`](#validate_only).
 
-Read more about it in the [selective validation](/validation#selective-validation) section.
+Read more about it in the [selective validation](validation.md#selective-validation) section.
 
 ---
 
@@ -674,7 +674,7 @@ default = {
 }
 ```
 
-Read more on [Secrets](/secrets/)
+Read more on [Secrets](secrets.md)
 
 ---
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -104,7 +104,7 @@ In the root directory (the same where `manage.py` is located) put your `settings
 To switch the working environment the `DJANGO_ENV` variable can be used, so `DJANGO_ENV=development` to work
 in development mode or `DJANGO_ENV=production` to switch to production.
 
-If you don't want to manually create your config files take a look at the [CLI](/cli/)
+If you don't want to manually create your config files take a look at the [CLI](cli.md)
 
 !!! tip
     **.yaml** is the recommended format for Django applications because it allows easily writing complex data structures. Nevertheless, feel free to choose any format you are familiar with.
@@ -155,7 +155,7 @@ Your settings are now read from `/etc/projectname/settings.toml` (dynaconf will 
 
 You can have additional settings read from `/etc/projectname/plugins/*` any supported file from this folder will be loaded.
 
-You can set more options, take a look at [configuration](/configuration/)
+You can set more options, take a look at [configuration](configuration.md)
 
 ### Use Django functions inside custom settings
 
@@ -164,7 +164,7 @@ converters with the `add_converters` utility.
 
 When defining those in `settings.py`, there are some django functions that can't
 be imported directly in the module scope. Because of that, you may add them in
-a [hook](/advanced#hooks) that executes after loading.
+a [hook](advanced.md#hooks) that executes after loading.
 
 For example, if you need to use `reverse_lazy`, you might do this:
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -6,14 +6,14 @@ According to [12factorapp](https://12factor.net) it is a good practice to keep y
 
 In addition to that Dynaconf offers some approaches you may want to **Optionally** follow:
 
-- Add a list of validators to `validators=[Validator()]` on your dynaconf settings instance and provide [defaults and constraints](/validation/).
+- Add a list of validators to `validators=[Validator()]` on your dynaconf settings instance and provide [defaults and constraints](validation.md).
 - Enable `load_dotenv` and provide a `.env.example` or `.env` file with the default variables.
-- Write your variables in a [settings file](/settings_files) in the format of your choice.
-- Load your settings from [vault or redis](/secrets/)
+- Write your variables in a [settings file](settings_files.md) in the format of your choice.
+- Load your settings from [vault or redis](secrets.md)
 
 ## Environment variables
 
-You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](/configuration/#envvar_prefix)).
+You can override any setting key by exporting an environment variable prefixed by `DYNACONF_` (or by the [custom prefix](configuration.md/#envvar_prefix)).
 
 !!! warning
     Dynaconf will only look for UPPERCASE prefixed envvars. This means envvar exported as `dynaconf_value` or `myprefix_value` won't be loaded, while `DYNACONF_VALUE` and `MYPREFIX_VALUE` (when proper set) will.
@@ -33,9 +33,9 @@ export DYNACONF_STRING_NUM="'76'"                            # str: "76"
 export DYNACONF_PERSON__IS_ADMIN=true                        # bool: True (nested)
 ```
 
-!!! info 
+!!! info
     For envvars Dynaconf will automatically transform `True` and `False` to `true` and `false` respectively,
-    this transformation allows TOML to parse the value as a boolean.  
+    this transformation allows TOML to parse the value as a boolean.
     If you want to keep the original value in this case use `@str` or wrap it in quotes twice like `FOO='"True"'`
     Note that this applies only for strictly string equal to `True|False` doesn't apply to same string found
     inside toml data structures.
@@ -64,7 +64,7 @@ assert settings.STRING_NUM == "76"
     **Also variable access is case insensitive for the first level key**
 
 !!! warning
-    When exporting data structures such as `dict` and `list` you have to use one of:  
+    When exporting data structures such as `dict` and `list` you have to use one of:
     ```
     export DYNACONF_TOML_DICT={key="value"}
     export DYNACONF_TOML_LIST=["item"]
@@ -154,7 +154,7 @@ export PREFIX_PATH='@jinja {{env.HOME}}/.config/{{this.DB_NAME}} | abspath'
 ### Adding a Custom Casting Token
 
 If you would like to add a custom casting token, you can do so by adding a
-converter. For example, if we would like to cast strings to a pathlib.Path 
+converter. For example, if we would like to cast strings to a pathlib.Path
 object we can add in our python code:
 
 ```python

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,7 @@ See more about [hooks](https://www.dynaconf.com/advanced/#hooks)
 
 > I use some django utility functions in my django `settings.py`. Can I still use them if I choose to use `yaml` to manage my config?
 
-Yes, you may add a custom converter for any functions you like. Refer [here](/django/#use-django-functions-inside-custom-settings) for a full example.
+Yes, you may add a custom converter for any functions you like. Refer [here](django.md#use-django-functions-inside-custom-settings) for a full example.
 
 ## Default-override workflow
 
@@ -104,8 +104,8 @@ bucket=["a", "b", "c", "d"]
 bucket=["a", "b", "c", "d"]
 ```
 
-To control how you want to merge these structures, you may want to have a look at [merging](/merging/)
-There are several ways you can merge data: settings the global option [merge_enabled](/configuration/#merge_enabled), using dunder syntax or marking a whole file, a specific env, or just an option for merging. Choose what fits best for your case.
+To control how you want to merge these structures, you may want to have a look at [merging](merging.md)
+There are several ways you can merge data: settings the global option [merge_enabled](configuration.md/#merge_enabled), using dunder syntax or marking a whole file, a specific env, or just an option for merging. Choose what fits best for your case.
 
 ## Error with Pyinstaller executable
 

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -62,7 +62,7 @@ in development mode or `FLASK_ENV=production` to switch to production.
 
 > **IMPORTANT**: To use `$ dynaconf` CLI the `FLASK_APP` must be defined.
 
-IF you don't want to manually create your config files take a look at the [CLI](/cli/)
+IF you don't want to manually create your config files take a look at the [CLI](cli.md)
 
 ## Loading Flask Extensions Dynamically
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ pip install dynaconf
             settings_files=['settings.toml', '.secrets.toml'],
         )
         ```
-        More options are described on [Dynaconf Configuration](/configuration/)
+        More options are described on [Dynaconf Configuration](configuration.md)
 
     === "settings.toml"
         **Optionally** store settings in a file (or in multiple files)
@@ -108,7 +108,7 @@ pip install dynaconf
         [a_dict.nested]
         other_level = "nested value"
         ```
-        More details in [Settings Files](/settings_files/)
+        More details in [Settings Files](settings_files.md)
 
     === ".secrets.toml"
         **Optionally** store sensitive data in a local-only file `.secrets.toml`
@@ -125,7 +125,7 @@ pip install dynaconf
         .secrets.*
         ```
 
-        read more on [Secrets](/secrets/)
+        read more on [Secrets](secrets.md)
 
     === "env vars"
         **Optionally** override using prefixed environment variables. (`.env` files are also supported)
@@ -187,7 +187,7 @@ pip install dynaconf
 
         > ℹ️ On Flask, settings files are layered in multiple environments by default, you can disable it by passing `environments=False` to FlaskDynaconf extension.
 
-        More details in [Settings Files](/settings_files/)
+        More details in [Settings Files](settings_files.md)
 
     === ".secrets.toml"
         **Optionally** store sensitive data in a local-only file `.secrets.toml`
@@ -205,7 +205,7 @@ pip install dynaconf
         .secrets.*
         ```
 
-        read more on [Secrets](/secrets/)
+        read more on [Secrets](secrets.md)
 
     === "env vars"
         **Optionally** override any setting using `FLASK_` prefixed environment variables. (`.env` files are also supported)
@@ -218,7 +218,7 @@ pip install dynaconf
 
     ---
 
-    Dynaconf can also **load your Flask extensions** for you see more details in [Flask Extension](/flask/)
+    Dynaconf can also **load your Flask extensions** for you see more details in [Flask Extension](flask.md)
 
 
 ??? "Or using Django"
@@ -301,7 +301,7 @@ pip install dynaconf
 
         > ℹ️ On Django settings files are layered in multiple environments by default, you can disable it by passing `environments=False` to FlaskDynaconf extension.
 
-        More details in [Settings Files](/settings_files/)
+        More details in [Settings Files](settings_files.md)
 
     === ".secrets.yaml"
         **Optionally** store sensitive data in a local-only file `.secrets.toml`
@@ -319,7 +319,7 @@ pip install dynaconf
         .secrets.*
         ```
 
-        read more on [Secrets](/secrets/)
+        read more on [Secrets](secrets.md)
 
     === "env vars"
         **Optionally** override any setting using `DJANGO_` prefixed environment variables. (`.env` files are also supported)
@@ -346,21 +346,21 @@ pip install dynaconf
 
     ---
 
-    More details in [Django Extension](django/)
+    More details in [Django Extension](django.md)
 
 ---
 
 !!! tip
-    The `dynaconf` CLI has more useful commands such as `list | export`, `init`, `write` and `validate` read more on [CLI](/cli/)
+    The `dynaconf` CLI has more useful commands such as `list | export`, `init`, `write` and `validate` read more on [CLI](cli.md)
 
 ## Defining your settings variables
 
-Dynaconf prioritizes the use of [environment variables](/envvars/) and
-you can optionally store settings in [Settings Files](/settings_files/) using any of `toml|yaml|json|ini|py` extension.
+Dynaconf prioritizes the use of [environment variables](envvars.md) and
+you can optionally store settings in [Settings Files](settings_files.md) using any of `toml|yaml|json|ini|py` extension.
 
 ### On env vars
 
-[environment variables](/envvars/) are loaded by Dynaconf if prefixed either with
+[environment variables](envvars.md) are loaded by Dynaconf if prefixed either with
 `DYNACONF_` or a `CUSTOM_` name that you can customize on your settings instance, or
 `FLASK_` and `DJANGO_` respectively if you are using extensions.
 
@@ -386,7 +386,7 @@ export DYNACONF_NESTED__LEVEL__KEY=1         # Double underlines
                                              # }
 ```
 
-More details on [environment variables](/envvars/).
+More details on [environment variables](envvars.md).
 
 ### On files
 
@@ -411,7 +411,7 @@ The following are the currently supported formats:
 !!! tip
     Can't find the file format you need for your settings?
     You can create your custom loader and read any data source.
-    read more on [extending dynaconf](/advanced/)
+    read more on [extending dynaconf](advanced.md)
 
 #### Key types
 
@@ -548,7 +548,7 @@ You can for example name it `[testing]` or `[anything]`
     `env="development"` to `Dynaconf` class on instantiation.
 
 
-Read more on [Settings Files](/settings_files/)
+Read more on [Settings Files](settings_files.md)
 
 ## Reading settings variables
 
@@ -585,7 +585,7 @@ If the key has spaces it can be accessed by replacing the space with an undersco
 ROOT:
     MY KEY: "value"
 ```
-    
+
 ```python
 settings.root.my_key == "value"
 settings.root["my key"] == "value"
@@ -646,7 +646,7 @@ validate your settings in 2 ways.
     dynaconf -i config.settings validate
     ```
 
-Read more on [Validation](/validation/)
+Read more on [Validation](validation.md)
 
 ## Dependencies
 
@@ -672,7 +672,7 @@ pip install dynaconf[vault]
 pip install dynaconf[redis]
 ```
 
-Read more on [external loaders](/advanced/#creating-new-loaders)
+Read more on [external loaders](advanced.md#creating-new-loaders)
 
 ## License
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -9,7 +9,7 @@ You can globally turn on the merging strategy by setting [merge_enabled](https:/
 
 ## Merging existing data structures
 
-If your settings have existing variables of types `list` or `dict` and you want to `merge` instead of `override` then 
+If your settings have existing variables of types `list` or `dict` and you want to `merge` instead of `override` then
 the `dynaconf_merge` and `dynaconf_merge_unique` stanzas can mark that variable as a candidate for merging.
 
 For **dict** value:
@@ -69,7 +69,7 @@ export DYNACONF_DATABASE__ARGS__timeout=30
 export DYNACONF_DATABASE__ARGS__retries=5
 ```
 
-Each `__` is parsed as a level traversing thought dict keys. read more in [environment variables](/envvars/#nested-keys-in-dictionaries-via-environment-variables)
+Each `__` is parsed as a level traversing thought dict keys. read more in [environment variables](envvars.md#nested-keys-in-dictionaries-via-environment-variables)
 
 So the above will result in
 
@@ -323,7 +323,7 @@ The use of `__` to denote nested level will ensure the key is merged with existi
 ## Nested keys in dictionaries via environment variables.
 
 > **New in 2.1.0**
-> 
+>
 > This is useful for `Django` settings.
 
 Let's say you have a configuration like this:
@@ -344,7 +344,7 @@ And  now you want to change the values of `ENGINE` to `other.module`, via enviro
 
 Each `__` (dunder, a.k.a *double underline*) denotes access to nested elements in a dictionary.
 
-So 
+So
 
 ```py
 DATABASES['default']['ENGINE'] = 'other.module'

--- a/docs/pt-br/docs/cli.md
+++ b/docs/pt-br/docs/cli.md
@@ -8,7 +8,7 @@ Todo comando (com exceção do init) requer uma Instância que pode ser passada 
 
 O comando `$ dynaconf -i config.settings` do cli provê alguns comandos bem úteis
 
-> **IMPORTANTE** caso usem [Flask Extension](/flask/) a variável de ambiente `FLASK_APP` deve ser definda para usar o CLI, e caso usem [Django Extension](/django/) a variável `DJANGO_SETTINGS_MODULE` deve estar definida.
+> **IMPORTANTE** caso usem [Flask Extension](flask.md) a variável de ambiente `FLASK_APP` deve ser definda para usar o CLI, e caso usem [Django Extension](django.md) a variável `DJANGO_SETTINGS_MODULE` deve estar definida.
 
 ### dynaconf --help
 
@@ -64,7 +64,7 @@ Bem como incluirá no arquivo `.gitignore` para que seja ignorado o arquivo `.se
 .secrets.*
 ```
 
-> Reomenda-se que para dados sensíveis em produção use[Vault Server](/secrets/)
+> Reomenda-se que para dados sensíveis em produção use[Vault Server](secrets.md)
 
 ```
 Uso: dynaconf init [OPÇÕES]
@@ -74,10 +74,10 @@ Uso: dynaconf init [OPÇÕES]
 
   O formato dos arquivo pode ser alterado passando --format=yaml|json|ini|py.
 
-  Esse comando deve ser executado no diretório raiz do projeto o pode-se passar 
+  Esse comando deve ser executado no diretório raiz do projeto o pode-se passar
   --path=/myproject/root/folder.
 
-  O --env/-e está depreciado ( mantido por compatibilidade, mas deve evitar o uso) 
+  O --env/-e está depreciado ( mantido por compatibilidade, mas deve evitar o uso)
 
 Opções:
   -f, --format [ini|toml|yaml|json|py|env]
@@ -86,7 +86,7 @@ Opções:
   -v, --vars TEXT                 valores extras a serem gravados no arquivo de settings, ex.:
                                   `dynaconf init -v NAME=foo -v X=2
 
-  -s, --secrets TEXT              valores sensíveis a serem escritos no arquivo .secrets 
+  -s, --secrets TEXT              valores sensíveis a serem escritos no arquivo .secrets
                                   ex.: `dynaconf init -s TOKEN=kdslmflds
 
   --wg / --no-wg
@@ -128,7 +128,7 @@ Lista todos os parâmetros definidos e, opcionalmente, exporta para um arquivo J
 ```
 Uso: dynaconf list [OPÇÕES]
 
-  Lista todos os valores de configuração definidos pelo usuário e se `--all` for passado 
+  Lista todos os valores de configuração definidos pelo usuário e se `--all` for passado
   mostra, também, as variáveis internas do dynaconf.
 
 Opçẽos:
@@ -136,7 +136,7 @@ Opçẽos:
   -k, --key TEXT     Filtra por uma única chave (key)
   -m, --more         Pagina o resultado ao estilo mais|menos (more|less)
   -l, --loader TEXT  um identificador de conversor (loader) para filtar ex.: toml|yaml
-  -a, --all          Mostra as configurações internas do dynaconf? 
+  -a, --all          Mostra as configurações internas do dynaconf?
   -o, --output FILE  Filepath para gravar os valores listados num arquivo JSON
   --output-flat      O arquivo de saída é plano (flat) (i.e., não inclui o nome ambiente [env])
   --help             Mostra essa mensagem e sai.
@@ -148,7 +148,7 @@ Opçẽos:
 dynaconf list -o path/to/file.yaml
 ```
 
-O comando acima exportará todos os itens mostrados por `dynaconf list` para o format desejado o qual é inferido pela extensão do arquivo em `-o`, formatos suportados são: `yaml, toml, ini, json, py` 
+O comando acima exportará todos os itens mostrados por `dynaconf list` para o format desejado o qual é inferido pela extensão do arquivo em `-o`, formatos suportados são: `yaml, toml, ini, json, py`
 
 Quando se usa `py` pode-se querer uma saída plana (flat) (sem estar aninhada internamente pelo nome do ambiente (env))
 
@@ -164,7 +164,7 @@ Uso: dynaconf write [OPÇÕES] [ini|toml|yaml|json|py|redis|vault|env]
   Escreve os dados dem uma fonte específica
 
 Opções:
-  -v, --vars TEXT     Par chave=valor que será escrito no settings ex.: 
+  -v, --vars TEXT     Par chave=valor que será escrito no settings ex.:
                       `dynaconf write toml -e NAME=foo -e X=2
 
   -s, --secrets TEXT  Par chave=segredo que será escrito no .secrets ex:

--- a/docs/pt-br/docs/flask.md
+++ b/docs/pt-br/docs/flask.md
@@ -55,21 +55,21 @@ export PEANUT_MAIL_SERVER='host.com'  # app.config.get('MAIL_SERVER')
 
 ## Arquivos de Configuração
 
-Você também pode ter seus arquivos de configuração para a sua aplicação Flask. Coloque os arquivos `settings.toml` e `.secrets.toml`, no diretório raiz (mesmo lugar onde é executado `flask run`) e então os ambientes da aplicação `[default]`, `[development]` e `[production]`. 
+Você também pode ter seus arquivos de configuração para a sua aplicação Flask. Coloque os arquivos `settings.toml` e `.secrets.toml`, no diretório raiz (mesmo lugar onde é executado `flask run`) e então os ambientes da aplicação `[default]`, `[development]` e `[production]`.
 
 Use a variável `FLASK_ENV` para alternar entre os ambientes definidos no arquivo de configuração. Por exemplo, definir `FLASK_ENV=development` fará com que a aplicação opere com os valores definidos do ambiente de desenvolvimento, já `FLASK_ENV=production` substituirá para os
 valores definidos para o ambiente de produção.
 
 > **IMPORTANTE**: Para usar `$ dynaconf` CLI a varável `FLASK_APP` deve ser definida previamente.
 
-Se você não quer criar os seus arquivos de configuração manualmente considere dar uma olhada em [CLI](/cli/)
+Se você não quer criar os seus arquivos de configuração manualmente considere dar uma olhada em [CLI](cli.md)
 
 ## Carregando Extensões Flask Dinamicamente
 
 Você pode pedir ao Dynaconf para carregar suas extensões Flask dinamicamente, desde que elas sigam os padrões das extensões convencionada pelo Flask.
 
-O único requisito é que a extensão deva ser do tipo `callable` e deve receber o `app` como primeiro argumento (`flask_admin:Admin` ou `custom_extension.module:instance.init_app`),  e por fim a extensão deve ser 
- 
+O único requisito é que a extensão deva ser do tipo `callable` e deve receber o `app` como primeiro argumento (`flask_admin:Admin` ou `custom_extension.module:instance.init_app`),  e por fim a extensão deve ser
+
 The only requirement is that the extension must be a `callable` that accepts `app` as first argument. e.g: `flask_admin:Admin` or `custom_extension.module:instance.init_app` and of course the extension must be in Python namespace to be imported.
 
 Para que a extensão seja inicializada basta usar uma referência para o [*entry point*](https://packaging.python.org/specifications/entry-points/), por exemplo: "flask_admin:Admin" or "extension.module:instance.init_app".
@@ -134,8 +134,8 @@ EXTENSIONS = [
 
 ### Problemas Frequentes
 
-Caso você encontre um problema no momento do carregamento das variáveis do arquivo `.env` ou na importação do app, ou create_app, 
-é recomendado desativar o suporte do Flask para dotenv. 
+Caso você encontre um problema no momento do carregamento das variáveis do arquivo `.env` ou na importação do app, ou create_app,
+é recomendado desativar o suporte do Flask para dotenv.
 
 ```bash
 export FLASK_SKIP_DOTENV=1

--- a/docs/pt-br/docs/index.md
+++ b/docs/pt-br/docs/index.md
@@ -1,4 +1,4 @@
-# Início Rápido com Dynaconf 
+# Início Rápido com Dynaconf
 
 <p style="align-content: center">
   <a href="https://dynaconf.com"><img src="img/logo_400.svg?sanitize=true" alt="Dynaconf"></a>
@@ -37,7 +37,7 @@ pip install dynaconf
 
     #### Usando somente Python
 
-    No diretório raiz de seu projeto execute o comando `dynaconf init`    
+    No diretório raiz de seu projeto execute o comando `dynaconf init`
 
     ```bash hl_lines="2"
     cd path/to/your/project/
@@ -93,7 +93,7 @@ pip install dynaconf
             settings_files=['settings.toml', '.secrets.toml'],
         )
         ```
-        Mais opções são descritas em [Dynaconf Configuration](/configuration/)
+        Mais opções são descritas em [Dynaconf Configuration](configuration.md)
 
     === "settings.toml"
         **Opcionalmente** armazene as configurações em um arquivo (ou em múltiplos arquivos)
@@ -108,7 +108,7 @@ pip install dynaconf
         [a_dict.nested]
         other_level = "nested value"
         ```
-        Mais detalhes em [Settings Files](/settings_files/)
+        Mais detalhes em [Settings Files](settings_files.md)
 
     === ".secrets.toml"
         **Opcionalmente** armazene dados sensíveis em um único arquivo local chamado `.secrets.toml`
@@ -118,14 +118,14 @@ pip install dynaconf
         message = "This file doesn't go to your pub repo"
         ```
 
-        > ⚠️ O comando `dynaconf init` coloca o `.secrets.*` em seu `.gitignore` evitando que o mesmo seja exposto no repositório público mas é sua responsabilidade mantê-lo em seu ambiente local, também é recomendado que os ambientes de produção utilizem o suporte nativo para o serviço da Hashicorp Vault para senhas e tokens. 
+        > ⚠️ O comando `dynaconf init` coloca o `.secrets.*` em seu `.gitignore` evitando que o mesmo seja exposto no repositório público mas é sua responsabilidade mantê-lo em seu ambiente local, também é recomendado que os ambientes de produção utilizem o suporte nativo para o serviço da Hashicorp Vault para senhas e tokens.
 
         ```ini
         # Segredos não vão para o repositório público
         .secrets.*
         ```
 
-        Leia mais em [Secrets](/secrets/)
+        Leia mais em [Secrets](secrets.md)
 
     === "env vars"
         **Opcionalmente** use variáveis de ambiente com prefixos. (arquivos `.env` também são suportados)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -134,7 +134,7 @@ settings = Dynaconf(**options)
 
 and then in your program you do `from project.config import settings` instead of `from dynaconf import settings`.
 
-The `**options` are any of the [dynaconf config options](/configuration)
+The `**options` are any of the [dynaconf config options](configuration.md)
 
 ex:
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -249,4 +249,4 @@ print(settings.MYSQL_HOST)  # This data is being read from redis imediatelly!
 
 Do you want to store settings in other databases like NoSQL, Relational Databases or other services?
 
-Please see how to [extend dynaconf](/advanced/) to add your custom loaders.
+Please see how to [extend dynaconf](advanced.md) to add your custom loaders.

--- a/docs/settings_files.md
+++ b/docs/settings_files.md
@@ -7,7 +7,7 @@ mixed settings formats across your application.
 
 !!! tip
     You are not required to use settings files, if not specified dynaconf
-    can load your data only from [environment variables](/envvars/)
+    can load your data only from [environment variables](envvars.md)
 
 ## Supported formats
 
@@ -25,7 +25,7 @@ mixed settings formats across your application.
 !!! tip
     Can't find the file format you need for your settings?
     You can create your custom loader and read any data source.
-    read more on [extending dynaconf](/advanced/)
+    read more on [extending dynaconf](advanced.md)
 
 !!! warning
     To use the `.ini` or `.properties` file format you need to install an extra dependency
@@ -76,7 +76,7 @@ settings.name == "Bruno"
 
 Dynaconf will start looking for each file defined in `settings_files` from the folder where your entry point python file is located (like `app.py`). Then, it will look at each parent down to the root of the system. For each visited folder, it will also try looking inside a `/config` folder.
 
-- If you define [root_path](/configuration/#root_path), it will look start looking from there, instead. Keep in mind that `root_path` is relative to `cwd`, which is from where the python interpreter was called.
+- If you define [root_path](configuration.md/#root_path), it will look start looking from there, instead. Keep in mind that `root_path` is relative to `cwd`, which is from where the python interpreter was called.
 - Absolute paths are recognized and dynaconf will attempt to load them directly.
 - For each file specified in `settings_files` dynaconf will also try to load an optional `name`**.local.**`extension`. Eg, `settings_file="settings.toml"` will look for `settings.local.toml` too.
 - Globs are accepted.
@@ -107,7 +107,7 @@ export SETTINGS_FILES_FOR_DYNACONF='["settings.toml", "*.yaml"]'
 
 ## Includes and Preloads
 
-If you need, you can specify files to be loaded before or after the `settings_files` using the options [preload](/configuration/#preload) and [includes](/configuration/#includes). Their loading strategy is more strict, and will use `root_path` as the basepath for the relative paths provided. If `root_path` is not defined, `includes` will also try using the last found settings directory as the basepath.
+If you need, you can specify files to be loaded before or after the `settings_files` using the options [preload](configuration.md#preload) and [includes](configuration.md#includes). Their loading strategy is more strict, and will use `root_path` as the basepath for the relative paths provided. If `root_path` is not defined, `includes` will also try using the last found settings directory as the basepath.
 
 They can be defined in the Dynaconf instance or in a file:
 
@@ -131,7 +131,7 @@ anotherkey = value
 
 ## Layered environments on files
 
-It is also possible to make dynaconf read the files separated by layered 
+It is also possible to make dynaconf read the files separated by layered
 environments so each section or first level key is loaded as a
 distinct environment.
 
@@ -192,7 +192,7 @@ distinct environment.
 
 === "program.py"
 
-    Then in your program, you can use environment variables 
+    Then in your program, you can use environment variables
     to switch environments.
 
     `#!bash export ENV_FOR_DYNACONF=development`
@@ -210,7 +210,7 @@ distinct environment.
 !!! warning
     On **Flask** and **Django** extensions the default behaviour is already
     the layered environments.
-    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectively. 
+    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectively.
 
 !!! tip
     It is also possible to switch environments programmatically passing
@@ -226,7 +226,7 @@ Yaml parser used by dynaconf (ruamel.yaml) reads undefined values as `None` so
 key:
 key: ~
 key: null
-``` 
+```
 
 All those 3 keys will be parsed as python's `None` object.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -99,7 +99,7 @@ except dynaconf.ValidationError as e:
 By default, if the data of an instance is updated with `update`, `set` or `load_file` methods,
 no validation will be triggered.
 
-You can override this globally with the option [validate_on_update](/configuration/#validate_on_update) or
+You can override this globally with the option [validate_on_update](configuration.md/#validate_on_update) or
 set this on a per-call basis.
 
 ```python
@@ -113,7 +113,7 @@ settings.update({"NEW_VALUE": 123}) # will trigger with the global strategy
 
 ### With CLI
 
-It is possible to define validators in a `TOML` file called `dynaconf_validators.toml` placed in the same folder as your settings files. For more information, see the [CLI section](/cli#dynaconf-validate).
+It is possible to define validators in a `TOML` file called `dynaconf_validators.toml` placed in the same folder as your settings files. For more information, see the [CLI section](cli.md#dynaconf-validate).
 
 `dynaconf_validators.toml` is equivalent to the program below:
 
@@ -174,7 +174,7 @@ Validator(
   "NAME",
   ne="john",
   len_min=4,
-  must_exist=True, # redundant but allowed 
+  must_exist=True, # redundant but allowed
   startswith="user_",
   cast=str,
   condition=lambda v: v not in FORBIDEN_USERS,
@@ -359,8 +359,8 @@ Say you want to ensure that the `DATABASE.HOST` is set only when `DATABASE.USER`
 
 ```python
 Validator(
-    "DATABASE.HOST", 
-    must_exist=True, 
+    "DATABASE.HOST",
+    must_exist=True,
     when=Validator("DATABASE.USER", must_exist=True)
 )
 ```
@@ -371,8 +371,8 @@ Say you want to validate that `DATABASE.CONNECTION_ARGS` is set only when `DATAB
 
 ```python
 Validator(
-    "DATABASE.CONNECTION_ARGS", 
-    must_exist=True, 
+    "DATABASE.CONNECTION_ARGS",
+    must_exist=True,
     when=Validator("DATABASE.URI", condition=lambda v: v.startswith("sqlite://")),
     messages={"must_exist_true": "{name} is required when DATABASE is SQLite"}
 )
@@ -402,7 +402,7 @@ which generates a single `Validator` which succeeds only if both of these pass.
 
 > **New in 3.1.6**
 
-You can also choose what sections of the settings you do or don't want to validate. This is achieved by using the `validate_only` and `validate_exclude` kwargs to `Dynaconf` (read more in the [Configuration](/configuration) page) or by passing `only` or `exclude` to the `validate` method of the `Dynaconf.validators` list.
+You can also choose what sections of the settings you do or don't want to validate. This is achieved by using the `validate_only` and `validate_exclude` kwargs to `Dynaconf` (read more in the [Configuration](configuration.md) page) or by passing `only` or `exclude` to the `validate` method of the `Dynaconf.validators` list.
 
 This is useful when:
 
@@ -473,7 +473,7 @@ settings.validators.validate(
 
 ### Validating only the `current_env`
 
-You can specify if you want to validate all environments defined for a validator (default behavior) or only the current environment. To do so, you may use the `only_current_env` argument of single `Validator`s (i.e., in `Validator.validate`), the same argument on `ValidatorList`s (such as `Dynaconf.validators.validate`) or by passing the `validate_only_current_env` kwarg to `Dynaconf` (see [Configuration](/configuration)).
+You can specify if you want to validate all environments defined for a validator (default behavior) or only the current environment. To do so, you may use the `only_current_env` argument of single `Validator`s (i.e., in `Validator.validate`), the same argument on `ValidatorList`s (such as `Dynaconf.validators.validate`) or by passing the `validate_only_current_env` kwarg to `Dynaconf` (see [Configuration](configuration.md)).
 
 In the first case, the validators will run on all possible settings defined in their list of environments, while in the latter the validators with environments different from the current environment will be skipped.
 
@@ -543,23 +543,23 @@ Validators can be created by passing the following arguments:
 
 ```python
 # names: list[str]
-# can be a single or multiple positional strings 
+# can be a single or multiple positional strings
 Validator('VERSION', 'AGE', 'NAME'),
-# can also use dot notation 
+# can also use dot notation
 Validator('DATABASE.HOST', 'DATABASE.PORT'),
 Validator('DATABASE.HOST', 'DATABASE.PORT'),
 
 
 # must_exist: bool (alias: required)
-# Check whether variable must or not exist 
-Validator('VERSION', must_exist=True), 
+# Check whether variable must or not exist
+Validator('VERSION', must_exist=True),
 Validator('PASSWORD', must_exist=False),
 # there is an alias for must_exist called `required`
-Validator('VERSION', required=True), 
+Validator('VERSION', required=True),
 
-# condition: callable 
-# A function or any other callable that accepts `value` and 
-# must return a boolean 
+# condition: callable
+# A function or any other callable that accepts `value` and
+# must return a boolean
 Validator('VERSION', condition=lambda v: v.startswith("1.")),
 
 # when: Validator
@@ -570,15 +570,15 @@ Validator(
     when=Validator('ENV_FOR_DYNACONF', eq='development')
 ),
 
-# env: str 
-# Runs the validator against the specified env, only for 
-# settings that are loaded from files with environments=True 
+# env: str
+# Runs the validator against the specified env, only for
+# settings that are loaded from files with environments=True
 Validator('VERSION', must_exist=True, env='production'),
 
 # messages: dict[str, str]
-# A dictionary with custom messages for each validation type 
+# A dictionary with custom messages for each validation type
 Validator(
-    "VERSION", 
+    "VERSION",
     must_exist=True,
     condition=lambda v: v.startswith("1."),
     messages={
@@ -587,17 +587,17 @@ Validator(
     }
 ),
 
-# cast: callable/class 
+# cast: callable/class
 # A type or a callable to transform the type of the passed object
 # can also be used to apply transformations/normalizations
 Validator("VERSION", cast=str),
 Validator("VERSION", cast=lambda v: v.replace("1.", "2.")),
 Validator("STATIC_FOLDER", cast=Path)
-# Cast will be called for default values and also for values defined on 
+# Cast will be called for default values and also for values defined on
 # settings via files or envvars
 
-# default: any value or a callable 
-# If the value is not found it will be set to the default value 
+# default: any value or a callable
+# If the value is not found it will be set to the default value
 # if the default is a callable it will be called with the
 # settings and instance of validator as arguments.
 def default_connection_args(settings, validator):
@@ -606,24 +606,24 @@ def default_connection_args(settings, validator):
     else:
         return {}
 
-Validator("DATABASE.CONNECTION_ARGS", default=default_connection_args), 
-# default will be called only if the value is not explicitly set on settings 
+Validator("DATABASE.CONNECTION_ARGS", default=default_connection_args),
+# default will be called only if the value is not explicitly set on settings
 # via files or env vars.
 
 # description: str
-# As of 3.1.12 dynaconf doesn't use this for anything 
+# As of 3.1.12 dynaconf doesn't use this for anything
 # but there are plugins and external tools that uses it.
-# this value to generate documentation 
+# this value to generate documentation
 Validator("VERSION", description="The version of the app"),
 
-# apply_default_on_none: bool 
+# apply_default_on_none: bool
 # YAML parser parses empty values as `None` so in this case
-# you might want to force the application of default when the 
+# you might want to force the application of default when the
 # value in settings is `None`
 Validator("VERSION", default="1.0.0", apply_default_on_none=True),
 
 
-# Operations: comparison operations 
+# Operations: comparison operations
 # - eq: value == other
 # - ne: value != other
 # - gt: value > other
@@ -639,7 +639,7 @@ Validator("VERSION", default="1.0.0", apply_default_on_none=True),
 # - len_ne: len(value) != other
 # - len_min: len(value) > other
 # - len_max: len(value) < other
-# - startswith: value.startswith(other) 
+# - startswith: value.startswith(other)
 # - endswith: value.endswith(other)
 # Examples:
 Validator("VERSION", eq="1.0.0"),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ theme:
 markdown_extensions:
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.magiclink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,6 @@ plugins:
   - git-revision-date
   - search:
       lang: en
-      prebuild_index: true
 extra:
   disqus: dynaconf
   social:


### PR DESCRIPTION
Working on a recent PR, the output from `mkdocs build` and `mkdocs serve` was very noisy because of warnings. This PR fixes them all to make the build clean. There were many like the first screenshot.
![image](https://github.com/dynaconf/dynaconf/assets/42358474/b509369f-5644-4b73-a120-d6824a600fa9)
![image](https://github.com/dynaconf/dynaconf/assets/42358474/d29a066b-fe2c-41fc-8134-7a9d5a86ca6d)
![image](https://github.com/dynaconf/dynaconf/assets/42358474/320fdafc-751b-4308-98ff-cc15c1db3660)

### Result
![image](https://github.com/dynaconf/dynaconf/assets/42358474/d38733d7-f0aa-4a09-b8ed-a84c069f7885)

Much cleaner, only a few warnings around the Portuguese language docs which I wasn't sure how to deal with.

### Other comments

- My IDE automatically deleted some trailing whitespace from the markdown files on save
- I'm not sure if the previous version of the references was actually useful within the Portuguese docs? Can you advise how these are currently in use?