### PR TITLE
Introduce typos pre-commit and fix all current typos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 # When a Push is made on an existing branch/PR
-# it cancells any pre running job and
+# it cancels any pre running job and
 # let only the latest executing
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: "Prepare build environemnt"
+      - name: "Prepare build environment"
         run: |
           pip install --user python-minifier wheel setuptools
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,8 @@ repos:
     hooks:
       - id: mypy
         files: ^dynaconf/
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.18.2
+    hooks:
+      - id: typos
+        args: []  # Overrides default to write changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,7 +324,7 @@ Other
 
   * remove breakpoint
 
-  * Pinning ipython version for python 3.8 compatability.
+  * Pinning ipython version for python 3.8 compatibility.
 
   ---------
 - Fix AttributeError with integer keys (yaml) #919 (#920) [Pedro Pessoa]
@@ -364,7 +364,7 @@ Other
   * add test for #905 (item duplication in list)
 
   - when using validator with the default field, list items would get
-    duplicated under certain circunstances.
+    duplicated under certain circumstances.
 
   * fix for #905
 
@@ -529,7 +529,7 @@ Other
 
   * add path-filter to main ci. fix rfc #883
 
-  * fix identation (3 to 2 spaces)
+  * fix indentation (3 to 2 spaces)
 - Docs/add faq page (#882) [Pedro Pessoa]
 
   * add faq page to docs
@@ -1608,7 +1608,7 @@ Other
 - Fix #478 Make alias for environment -> environments (#534) [Bruno
   Rocha]
 
-  This is a commom mistake to pass `environment` so it is alias.
+  This is a common mistake to pass `environment` so it is alias.
 
   Fix #478
 - Fix #462 make DynaBox nested List to use DynaBox as default class
@@ -1768,7 +1768,7 @@ Other
 
   * Change map to list comprehension and create empty [] as default value
 
-  * fix wrong identation
+  * fix wrong indentation
 - Fix merging hyperlink to fix  #454 (#458) [Ilito Torquato, Ilito
   Torquato]
 - Specify flask extension initializers by entry point object reference
@@ -1871,7 +1871,7 @@ Other
 - Fix #432 no need for warning when env is missing on a file (#438)
   [Bruno Rocha]
 
-  When env is missing on a file ther eis no need to output
+  When env is missing on a file there is no need to output
   a warning.
 
   All envs are optional on files.
@@ -2149,7 +2149,7 @@ Other
             Fix #379 dict like iteration (#385)
             Fix #377 allow computed values (#386)
             Fix #388 URL reference for custom loaders (#389)
-            Fix #382 add is_overriden method (#390)
+            Fix #382 add is_overridden method (#390)
 
       John Vandenberg (1):
             Allow testing against local redis server (#387)
@@ -2177,7 +2177,7 @@ Other
             Fix #379 dict like iteration (#385)
             Fix #377 allow computed values (#386)
             Fix #388 URL reference for custom loaders (#389)
-            Fix #382 add is_overriden method (#390)
+            Fix #382 add is_overridden method (#390)
 
       John Vandenberg (1):
             Allow testing against local redis server (#387)
@@ -2187,9 +2187,9 @@ Other
 - Allow importing SEARCHTREE before settings are configured (#383)
   [Andreas Poehlmann]
 - Allow testing against local redis server (#387) [John Vandenberg]
-- Fix #382 add is_overriden method (#390) [Bruno Rocha]
+- Fix #382 add is_overridden method (#390) [Bruno Rocha]
 
-  Fix #382 add is_overriden method for DJDT
+  Fix #382 add is_overridden method for DJDT
 - Fix #388 URL reference for custom loaders (#389) [Bruno Rocha]
 
   Fix #388 URL reference for custom loaders
@@ -2208,7 +2208,7 @@ Other
   Fix #327
   Fix #341
 
-  Exemples added:
+  Examples added:
 
   	example/issues/323_DEFAULT_VALUES_RESOLUTION/
   	example/issues/325_flask_dot_env/
@@ -2562,7 +2562,7 @@ Other
   The release of python-box https://github.com/cdgriffith/Box/pull/116
   is a breaking change.
 
-  So pinning this until this project addapts.
+  So pinning this until this project adapts.
 
   Also pinning other direct deps.
 - Fix #258 custom message for validators. [Bruno Rocha]
@@ -2953,7 +2953,7 @@ Other
             Use the Key Value API rather than the old 'read' and 'write' methods (#198)
 - Fix #194 flask.app.config __setitem__ (#199) [Bruno Rocha]
 
-  Flask.config was not proxying __setitem__ atribute so this
+  Flask.config was not proxying __setitem__ attribute so this
   change adds a call to __setitem__ on contrib/flask_dynaconf
 - Use the Key Value API rather than the old 'read' and 'write' methods
   (#198) [Raoul Snyman]
@@ -3067,7 +3067,7 @@ Other
             HOTFIX config.md on docs [skip ci] (#171)
             Fix some open file descriptors on exampls and tests (#172)
             Fix #151 setup pre-commit and black (#173)
-            Add CONTRIBUTING.md, conrtib isntructions and Black badge (#174)
+            Add CONTRIBUTING.md, contrib instructions and Black badge (#174)
             Fix release script
 
       David Moreau Simard (1):
@@ -3100,7 +3100,7 @@ Other
             HOTFIX config.md on docs [skip ci] (#171)
             Fix some open file descriptors on exampls and tests (#172)
             Fix #151 setup pre-commit and black (#173)
-            Add CONTRIBUTING.md, conrtib isntructions and Black badge (#174)
+            Add CONTRIBUTING.md, contrib instructions and Black badge (#174)
             Fix release script
 
       David Moreau Simard (1):
@@ -3110,7 +3110,7 @@ Other
             Skip reloading envs for validators that only apply to current_env (#162)
             Fix #163 Allow disabling env prefix (#164)
 - Fix release script. [Bruno Rocha]
-- Add CONTRIBUTING.md, conrtib isntructions and Black badge (#174)
+- Add CONTRIBUTING.md, contrib instructions and Black badge (#174)
   [Bruno Rocha]
 - Fix #151 setup pre-commit and black (#173) [Bruno Rocha]
 
@@ -3178,7 +3178,7 @@ Other
 
   removed logzero, cached logger using lru_cache (that means that if loglevel changes, log changes)
 
-  - imporved docs and badges.
+  - improved docs and badges.
 - Fix typos in bash export examples. [David Moreau Simard]
 - HOTIX: Django doc. [Bruno Rocha]
 - Added Django explicit mode to docs (#149) [Bruno Rocha]
@@ -3209,7 +3209,7 @@ Other
             Fix #110 add docs for dynaconf_include
             Add dynaconf_include examples
             Set up CI with Azure Pipelines (#142)
-            Add dynaconf_merge fucntionality for dict and list settings. (#139)
+            Add dynaconf_merge functionality for dict and list settings. (#139)
             Preparing for 2.0.0
 
       Byungjin Park (1):
@@ -3271,7 +3271,7 @@ Other
             Fix #110 add docs for dynaconf_include
             Add dynaconf_include examples
             Set up CI with Azure Pipelines (#142)
-            Add dynaconf_merge fucntionality for dict and list settings. (#139)
+            Add dynaconf_merge functionality for dict and list settings. (#139)
             Preparing for 2.0.0
 
       Byungjin Park (1):
@@ -3330,10 +3330,10 @@ Other
   - start_dotenv is now Lazy (only when settings._setup is called)
   - Added new _FOR_DYNACONF config options ENV_SWITCHER, SKIP_FILES, INCLUDES & SECRETS
   - Renamed config PROJECT_ROOT -> ROOT_PATH
-- Add dynaconf_merge fucntionality for dict and list settings. (#139)
+- Add dynaconf_merge functionality for dict and list settings. (#139)
   [Bruno Rocha]
 
-  If your settings has existing variables of types `list` ot `dict` and you want to `merge` instead of `override` then
+  If your settings has existing variables of types `list` or `dict` and you want to `merge` instead of `override` then
   the `dynaconf_merge` and `dynaconf_merge_unique` stanzas can mark that variable as a candidate for merging.
 
   For **dict** value:
@@ -3370,7 +3370,7 @@ Other
       dynaconf_merge: true
   ```
 
-  The `dynaconf_merge` token will mark that object to be merged with existing values (of course `dynaconf_merge` key will not be added to the final settings it is jsut a mark)
+  The `dynaconf_merge` token will mark that object to be merged with existing values (of course `dynaconf_merge` key will not be added to the final settings it is just a mark)
 
   The end result will be on `[development]` env:
 
@@ -3653,7 +3653,7 @@ Other
 - Python 3.4 has different error message. [Mantas]
 - Remove mocker fixture. [Mantas]
 
-  Left this accidentaly.
+  Left this accidentally.
 
   https://travis-ci.org/rochacbruno/dynaconf/jobs/452612532
 - Add INSTANCE_FOR_DYNACONF and --instance. [Mantas]
@@ -3855,8 +3855,8 @@ Other
 - Add example for merge_configs. [Bruno Rocha]
 - Add setting merging. [Raoul Snyman]
 
-  - Addd the ability to merge nested structures instead of completely overwriting them
-  - Use monkeypatch to stop one test from interferring with another
+  - Add the ability to merge nested structures instead of completely overwriting them
+  - Use monkeypatch to stop one test from interfering with another
   - Updated documentation
 
 
@@ -3906,7 +3906,7 @@ Other
   [latty]
 - Release 1.0.3. [Bruno Rocha]
 
-  - Excluded example and tests from realease dist
+  - Excluded example and tests from release dist
   - removed root logger configuration
 
 
@@ -4003,7 +4003,7 @@ Other
 - Increase cli test coverage. [Bruno Rocha]
 - Dynaconf variables in blue and user variables in green. [Bruno Rocha]
 - Added `dynaconf list` and `dynaconf write` subcommands. [Bruno Rocha]
-- More cli commands lsit and write. [Bruno Rocha]
+- More cli commands list and write. [Bruno Rocha]
 - Added more tests for cli and py loader. [Bruno Rocha]
 - Replaced coveralls with codecov #57. [Bruno Rocha]
 - Modularized the loaders, added `dynaconf init` command. [Bruno Rocha]
@@ -4019,9 +4019,9 @@ Other
 - Merge pull request #52 from rochacbruno/fix_namespace_in_django.
   [Bruno Rocha]
 
-  Fix namespace swithc in django apps
+  Fix namespace switch in django apps
 - Add missing .env. [Bruno Rocha]
-- Fix namespace swithc in django apps. [Bruno Rocha]
+- Fix namespace switch in django apps. [Bruno Rocha]
 
 
 0.7.5 (2018-05-20)
@@ -4209,7 +4209,7 @@ Other
 - Add Pipfile.lock to .gitignore. [Douglas Soares de Andrade]
 - Small Refactory. [Douglas Soares de Andrade]
 
-  - Adding object to the Settings classe to make it work with Python2
+  - Adding object to the Settings class to make it work with Python2
 - Small Refactory. [Douglas Soares de Andrade]
 
   - Reordering the imports according to  pylint and flake8
@@ -4278,7 +4278,7 @@ Other
 - Added note about get_fresh in readme. [Bruno Rocha]
 - Better namespace management, get_fresh(key) to access redis. [Bruno
   Rocha]
-- Now it can be used programatically. [Bruno Rocha]
+- Now it can be used programmatically. [Bruno Rocha]
 
 
 0.2.1 (2015-12-20)
@@ -4289,7 +4289,7 @@ Other
 
 0.2.0 (2015-12-20)
 ------------------
-- Can also load from arbitraty filepath. [Bruno Rocha]
+- Can also load from arbitrary filepath. [Bruno Rocha]
 - Renamed var, added loaders, bump version. [Bruno Rocha]
 
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["*.svg", "pt-br", "./dynaconf/vendor/"]
+extend-exclude = ["*.svg", "pt-br", "dynaconf/vendor/*"]
 
 [default.extend-words]
 Fo = "Fo"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["*.svg", "pt-br", "dynaconf/vendor/*"]
+extend-exclude = ["*.svg", "pt-br", "dynaconf/vendor/*", ".github/*"]
 
 [default.extend-words]
 Fo = "Fo"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,7 @@
 [files]
-extend-exclude = ["*.svg", "pt-br"]
+extend-exclude = ["*.svg", "pt-br", "./dynaconf/vendor/"]
+
+[default.extend-words]
+Fo = "Fo"
+portugues = "portugues"
+hashi = "hashi"

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,3 +5,4 @@ extend-exclude = ["*.svg", "pt-br", "dynaconf/vendor/*"]
 Fo = "Fo"
 portugues = "portugues"
 hashi = "hashi"
+ba = "ba"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["*.svg", "pt-br"]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,7 +120,7 @@ Usage: dynaconf inspect [OPTIONS]
 
   Inspect the loading history of the given settings instance.
 
-  Filters by key and environement, otherwise shows all.
+  Filters by key and environment, otherwise shows all.
 
 Options:
   -k, --key TEXT                  Filters result by key.
@@ -176,7 +176,7 @@ Usage: dynaconf get [OPTIONS] KEY
 
   Returns the raw value for a settings key.
 
-  If result is a dict, list or tuple it is printes as a valid json string.
+  If result is a dict, list or tuple it is printed as a valid json string.
 
 Options:
   -d, --default TEXT  Default value if settings doesn't exist

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -177,7 +177,7 @@ Validator(
   must_exist=True, # redundant but allowed
   startswith="user_",
   cast=str,
-  condition=lambda v: v not in FORBIDEN_USERS,
+  condition=lambda v: v not in FORBIDDEN_USERS,
   ...
 )
 ```

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -924,7 +924,7 @@ class Settings:
         :param key: The key to store. Can be of any type.
         :param value: The raw value to parse and store
         :param loader_identifier: Optional loader name e.g: toml, yaml etc.
-                                  Or isntance of SourceMetadata
+                                  Or instance of SourceMetadata
         :param tomlfy: Bool define if value is parsed by toml (defaults False)
         :param merge: Bool define if existing nested data will be merged.
         :param validate: Bool define if validation will be triggered

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -461,7 +461,7 @@ def init(ctx, fileformat, path, env, _vars, _secrets, wg, y, django):
 def get(key, default, env, unparse):
     """Returns the raw value for a settings key.
 
-    If result is a dict, list or tuple it is printes as a valid json string.
+    If result is a dict, list or tuple it is printed as a valid json string.
     """
     if env:
         env = env.strip()
@@ -860,7 +860,7 @@ def inspect(
     """
     Inspect the loading history of the given settings instance.
 
-    Filters by key and environement, otherwise shows all.
+    Filters by key and environment, otherwise shows all.
     """
     try:
         inspect_settings(

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -28,7 +28,7 @@ def default_loader(obj, defaults=None):
     """Initial loader for the initialization process.
 
     Steps:
-    - Load default settings (from static module) + kwargs overrides (togheter)
+    - Load default settings (from static module) + kwargs overrides (together)
     - Load envvar overrides
     """
     # LOAD DEFAULT STATIC + KWARGS OVERRIDES

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -227,7 +227,7 @@ class BaseLoader:
 
 class SourceMetadata(NamedTuple):
     """
-    Usefull metadata about some loaded source (file, envvar, etc).
+    Useful metadata about some loaded source (file, envvar, etc).
 
     Serve as a unique identifier for data from a specific env
     and a specific source (file, envvar, validationd default, etc)

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -300,7 +300,7 @@ def trimmed_split(
             continue
         data = [item.strip() for item in s.strip().split(sep)]
         return data
-    return [s]  # raw un-splitted
+    return [s]  # raw un-split
 
 
 T = TypeVar("T")

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -487,7 +487,7 @@ def boolean_fix(value: str | None):
     """Gets a value like `True/False` and turns to `true/false`
     This function exists because of issue #976
     Toml parser casts booleans from true/false lower case
-    however envvars are usually exportes as True/False capitalized
+    however envvars are usually exported as True/False capitalized
     by mistake, this helper fixes it for envvars only.
 
     Assume envvars are always str.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,6 +28,7 @@ flake8-todo
 radon
 pre-commit
 mypy
+typos
 
 # tools
 ipython<=8.12.1

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -161,6 +161,6 @@ def test_setting_instance_options_works_case_insensitive():
     assert app.config.env_switcher_for_dynaconf == "MY_ENV_SWITCHER"
     assert app.config.environments_for_dynaconf is False
 
-    # oddly, using '_for_dynaconf' won't work, altough
+    # oddly, using '_for_dynaconf' won't work, although
     # the option functionality seems to work as expected
     assert app.config.load_dotenv is False

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -444,7 +444,7 @@ def test_get_history_env_true__merge_marks(tmp_path):
 
 
 def test_get_history_key_filter(tmp_path):
-    """Asserts key filtering throught get_history param works"""
+    """Asserts key filtering through get_history param works"""
     file_a = tmp_path / "file_a.toml"
     file_b = tmp_path / "file_b.toml"
     file_c = tmp_path / "file_c.toml"
@@ -460,7 +460,7 @@ def test_get_history_key_filter(tmp_path):
 
 
 def test_get_history_key_filter_nested(tmp_path):
-    """Asserts key filtering throught get_history param works"""
+    """Asserts key filtering through get_history param works"""
     file_a = tmp_path / "file_a.toml"
     file_b = tmp_path / "file_b.toml"
     file_c = tmp_path / "file_c.toml"
@@ -802,7 +802,7 @@ def test_inspect_to_file(tmp_path):
 def test_inspect_exception_key_not_found():
     settings = Dynaconf()
     with pytest.raises(KeyNotFoundError):
-        inspect_settings(settings, key="non_existant")
+        inspect_settings(settings, key="non_existent")
 
 
 def test_inspect_empty_settings():
@@ -814,7 +814,7 @@ def test_inspect_empty_settings():
 def test_inspect_exception_env_not_found():
     settings = Dynaconf(environments=True)
     with pytest.raises(EnvNotFoundError):
-        inspect_settings(settings, env="non_existant")
+        inspect_settings(settings, env="non_existent")
 
 
 def test_inspect_exception_invalid_format():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,7 +231,7 @@ def test_tomlfy(settings):
 
 
 @pytest.mark.parametrize("test_input", ["something=42"])
-def test_tomlfy_unparseable(test_input, settings):
+def test_tomlfy_unparsable(test_input, settings):
     assert (
         parse_conf_data(test_input, tomlfy=True, box_settings=settings)
         == test_input
@@ -356,7 +356,7 @@ def test_ensure_a_list():
     assert ensure_a_list((1, 2)) == [1, 2]
     assert ensure_a_list({1, 2}) == [1, 2]
 
-    # A string is trimmed_splitted
+    # A string is trimmed_split
     assert ensure_a_list("ab.toml") == ["ab.toml"]
     assert ensure_a_list("ab.toml,cd.toml") == ["ab.toml", "cd.toml"]
     assert ensure_a_list("ab.toml;cd.toml") == ["ab.toml", "cd.toml"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -257,7 +257,7 @@ def test_no_reload_on_single_env(tmpdir, mocker):
 
     settings = LazySettings(
         environments=True,
-        ENV_FOR_DYNACONF="DEVELOPMENt",
+        ENV_FOR_DYNACONF="DEVELOPMENT",
         SETTINGS_FILE_FOR_DYNACONF=str(tmpfile),
     )
     using_env = mocker.patch.object(settings, "from_env")
@@ -834,7 +834,7 @@ def test_use_default_value_when_yaml_is_empty_and_explicitly_marked(tmpdir):
     settings = Dynaconf(
         settings_file=str(tmpfile),
         validators=[
-            # Explicitly say thar default must be applied to None
+            # Explicitly say that default must be applied to None
             Validator(
                 "hasemptyvalues.key1",
                 default="value1",

--- a/tests_functional/full_test/app.py
+++ b/tests_functional/full_test/app.py
@@ -61,7 +61,7 @@ for k, v in EXPECTED.items():
 
 print("store:", settings.store)
 print("loaders:", settings.loaded_by_loaders)
-print("dotenv_overrride:", settings.DOTENV_OVERRIDE_FOR_DYNACONF)
+print("dotenv_override:", settings.DOTENV_OVERRIDE_FOR_DYNACONF)
 print("redis:", settings.REDIS_FOR_DYNACONF)
 print("PYVAR", settings.PYVAR)
 print("YAMLVAR", settings.YAMLVAR)

--- a/tests_functional/issues/1000_django_attribute_error/flab/README.md
+++ b/tests_functional/issues/1000_django_attribute_error/flab/README.md
@@ -1,1 +1,1 @@
-The error described in #1000 happens only when acessing the /admin page
+The error described in #1000 happens only when accessing the /admin page

--- a/tests_functional/validators/with_python/.env
+++ b/tests_functional/validators/with_python/.env
@@ -2,5 +2,5 @@
 EXAMPLE_MYSQL_PASSWD=SuperSecret
 
 # change dynaconf's global namespace to EXAMPLE
-# so the previou defined value is loaded
+# so the previous defined value is loaded
 ENVVAR_PREFIX_FOR_DYNACONF='EXAMPLE'


### PR DESCRIPTION
Hey guys, this is optional but I've found this tool to be quite good. It's built in rust so it's fast and I've found it to be pretty accurate. However, in the pre-commit I've put it to warn, rather than write the changes automatically so that the developer has the choice to configure if needed. Let me know if there are other sections that you'd want excluded.

https://github.com/crate-ci/typos/tree/master

### Usage

```typos```

```typos -w    # Writes the changes```