### PR TITLE
fix incorrect combination of TOML table and inline table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,9 @@ pip install dynaconf
         number = 1234
         a_float = 56.8
         a_list = [1, 2, 3, 4]
-        a_dict = {hello="world"}
+
+        [a_dict]
+        hello = "world"
 
         [a_dict.nested]
         other_level = "nested value"


### PR DESCRIPTION
The `settings.toml` example for initializing Dynaconf includes an inline table and a separate section that looks like it should nest. However, TOML's inline tables must be entirely self contained, with no members in a separate section.