### PR TITLE
chore(ci): Add workflow to publish docs to netlify

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,51 @@
+name: Build and Deploy to Netlify
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      checkout_refspec:
+        description: "If provided, its passed to `git checkout <checkout_refspec>` before building."
+
+# https://github.com/marketplace/actions/netlify-actions#usage
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+
+      # build docs
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Customize checkout to use
+        run: |
+          checkout_refspec="${{ github.event.inputs.checkout_refspec }}"
+          if [[ -n $checkout_refspec ]] then;
+            git checkout $checkout_refspec;
+          fi
+      - name: Build documentation
+        run: |
+          make install
+          make docs
+
+      # deploy
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './site'
+          production-branch: master
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: true
+          overwrites-pull-request-comment: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [build]
 # if commit is not tagged don't build
-ignore = "git describe --exact-match --tags HEAD && exit 1 || exit 0"
-publish = "site"
-command = "pip install -r requirements.txt && mkdocs build --clean"
+# ignore = "git describe --exact-match --tags HEAD && exit 1 || exit 0"
+# publish = "site"
+# command = "pip install -r requirements.txt && mkdocs build --clean"
 
 [build.environment]
 


### PR DESCRIPTION
What this does:
- Add workflow to publish docs to netlify through [Netlify GitHub action](https://github.com/marketplace/actions/netlify-actions#usage) (instead of using the Netlify App)
  - The workflow is triggered on semver tags and through workflow dispatch.
  - The manual dispatch provides an option to checkout to another refspec before building the docs (in the case a building an on-tag build failed for some reason).
- Comment out the `netlify.toml` build definitions, so the App won't interfere with Github actions.

