### PR TITLE
Fix #1055 allow multiple validators with cast for the same field

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -350,6 +350,10 @@ assert settings.colors == '["red", "green", "blue"]'
 assert type(settings.colors) == str
 ```
 
+> **NOTE**: When multiple validators for the same field specifies a `cast`, Dynaconf
+> will execute both in order, so the end result in the settings object is the result
+> of the cumulative pipeline.
+
 ### Custom conditional expressions
 
 The `condition` argument expects a `Callable` that receives the setting's value as its only argument and returns a `bool`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -350,9 +350,8 @@ assert settings.colors == '["red", "green", "blue"]'
 assert type(settings.colors) == str
 ```
 
-> **NOTE**: When multiple validators for the same field specifies a `cast`, Dynaconf
-> will execute both in order, so the end result in the settings object is the result
-> of the cumulative pipeline.
+!!! info
+    When multiple validators for the same field specifies a `cast`, Dynaconf will execute both in order, so the end result in the settings object is the result of the cumulative pipeline.
 
 ### Custom conditional expressions
 

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
     from dynaconf.base import LazySettings  # noqa: F401
     from dynaconf.base import Settings
 
+
+DEFAULT_CAST = lambda value: value  # noqa
+
+
 EQUALITY_ATTRS = (
     "names",
     "must_exist",
@@ -23,6 +27,7 @@ EQUALITY_ATTRS = (
     "condition",
     "operations",
     "envs",
+    "cast",
 )
 
 
@@ -132,7 +137,7 @@ class Validator:
         self.must_exist = must_exist if must_exist is not None else required
         self.condition = condition
         self.when = when
-        self.cast = cast or (lambda value: value)
+        self.cast = cast or DEFAULT_CAST
         self.operations = operations
         self.default = default
         self.description = description

--- a/tests_functional/issues/1055_double_cast_validator/app.py
+++ b/tests_functional/issues/1055_double_cast_validator/app.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dynaconf import Dynaconf
+from dynaconf import Validator
+
+settings = Dynaconf(var="dynaconf")
+
+
+def a(v):
+    print("called a, replace conf -> settings")
+    return v.replace("conf", "settings")
+
+
+def b(v):
+    print("called b, transform to upper DYNASETTINGS")
+    return v.upper()
+
+
+validators = [
+    Validator("var", cast=a),
+    Validator("var", cast=b),
+]
+
+settings.validators.register(*validators)
+settings.validators.validate_all()
+
+
+assert settings.var == "DYNASETTINGS", settings.var


### PR DESCRIPTION
```python
from dynaconf import Dynaconf
from dynaconf import Validator

settings = Dynaconf(var="dynaconf")

def a(v):
    print("called a, replace conf -> settings")
    return v.replace("conf", "settings")

def b(v):
    print("called b, transform to upper DYNASETTINGS")
    return v.upper()

validators = [
    Validator("var", cast=a),
    Validator("var", cast=b),
]

settings.validators.register(*validators)
settings.validators.validate_all()

assert settings.var == "DYNASETTINGS", settings.var
```

Fix #1055