### PR TITLE
feat: dynaconf list with `--json` will print valid JSON to stdout

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,9 +212,20 @@ Options:
   -l, --loader TEXT  a loader identifier to filter e.g: toml|yaml
   -a, --all          show dynaconf internal settings?
   -o, --output FILE  Filepath to write the listed values as json
+  -j, --json         Prints out a valid JSON string
   --output-flat      Output file is flat (do not include [env] name)
   --help             Show this message and exit.
 ```
+
+#### Printing out the settings as JSON
+
+```console
+$ dynaconf list --json
+{"a_valid_raw": "json_output"}
+```
+
+The above output is printed to stdout and can be piped to a file or processed
+using tools such as `jq`.
 
 #### Exporting current environment as a file
 

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -7,6 +7,7 @@ import pprint
 import sys
 import warnings
 import webbrowser
+from contextlib import redirect_stdout
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -132,7 +133,8 @@ def import_settings(dotted_path):
             f"invalid path to settings instance: {dotted_path}"
         )
     try:
-        module = importlib.import_module(module)
+        with redirect_stdout(None):
+            module = importlib.import_module(module)
     except ImportError as e:
         raise click.UsageError(e)
     except FileNotFoundError:

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -5,6 +5,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterator
 from json import JSONDecoder
+from pathlib import Path
 from typing import Any
 from typing import Literal
 from typing import TYPE_CHECKING
@@ -537,3 +538,23 @@ def find_the_correct_casing(key: str, data: dict[str, Any]) -> str | None:
         if k.replace(" ", "_").lower() == key.lower():
             return k
     return None
+
+
+def prepare_json(data: Any) -> Any:
+    """Takes a data dict and transforms unserializable values to str for JSON.
+    {1: PosixPath("/foo")} -> {"1": "/foo"}
+    """
+    unserializable_types = (Path,)
+    if isinstance(data, dict):
+        return_data = {}
+        for key, val in data.items():
+            value = str(val) if isinstance(val, unserializable_types) else val
+            return_data[str(key)] = value
+        return return_data
+    elif isinstance(data, (list, tuple)):
+        return_data = []
+        for val in data:
+            value = str(val) if isinstance(val, unserializable_types) else val
+            return_data.append(value)
+        return return_data
+    return data

--- a/tests/config.py
+++ b/tests/config.py
@@ -9,5 +9,5 @@ settings = Dynaconf(
     TEST_KEY="test_value",
     ANOTHER_KEY="another_value",
     DATA={"KEY": "value", "OTHERKEY": "other value"},
-    A_PATH=Path("/foo/bar"),
+    A_PATH=Path("foo"),
 )

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from dynaconf import Dynaconf
 
 settingsenv = Dynaconf(environments=True)
@@ -7,4 +9,5 @@ settings = Dynaconf(
     TEST_KEY="test_value",
     ANOTHER_KEY="another_value",
     DATA={"KEY": "value", "OTHERKEY": "other value"},
+    A_PATH=Path("/foo/bar"),
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,17 @@ def test_list_export_json(testdir):
     assert json.loads(read_file("sets.json"))["TEST_KEY"] == "test_value"
 
 
+def test_list_prints_json(testdir):
+    """Ensure output of list --json is JSON compatible"""
+    result = run(
+        ["-i", "tests.config.settings", "list", "--json"],
+        env={"ROOT_PATH_FOR_DYNACONF": testdir},
+    )
+    data = json.loads(result)
+    assert data["TEST_KEY"] == "test_value"
+    assert data["A_PATH"] == "/foo/bar"
+
+
 def test_list_with_all(testdir):
     """Test list command with --all includes interval vars"""
     result = run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,7 +239,7 @@ def test_list_prints_json(testdir):
     )
     data = json.loads(result)
     assert data["TEST_KEY"] == "test_value"
-    assert data["A_PATH"] == "/foo/bar"
+    assert data["A_PATH"] == "foo"
 
 
 def test_list_with_all(testdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -547,10 +547,10 @@ def test_get_converter_error_when_converting(settings):
 @pytest.mark.parametrize(
     "input_expected",
     [
-        ({"path": Path("/foo/bar")}, {"path": "/foo/bar"}),
-        ({1: Path("/foo/bar")}, {"1": "/foo/bar"}),
-        ({True: Path("/foo/bar")}, {"True": "/foo/bar"}),
-        ([Path("/one"), Path("/two"), 1, True], ["/one", "/two", 1, True]),
+        ({"path": Path("foo")}, {"path": "foo"}),
+        ({1: Path("foo")}, {"1": "foo"}),
+        ({True: Path("foo")}, {"True": "foo"}),
+        ([Path("one"), Path("two"), 1, True], ["one", "two", 1, True]),
         (1, 1),
         (True, True),
         ("test", "test"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from dynaconf.utils import isnamedtupleinstance
 from dynaconf.utils import Missing
 from dynaconf.utils import missing
 from dynaconf.utils import object_merge
+from dynaconf.utils import prepare_json
 from dynaconf.utils import trimmed_split
 from dynaconf.utils import upperfy
 from dynaconf.utils.files import find_file
@@ -541,3 +542,20 @@ def test_get_converter_error_when_converting(settings):
 
     with pytest.raises(DynaconfFormatError):
         settings.BLA
+
+
+@pytest.mark.parametrize(
+    "input_expected",
+    [
+        ({"path": Path("/foo/bar")}, {"path": "/foo/bar"}),
+        ({1: Path("/foo/bar")}, {"1": "/foo/bar"}),
+        ({True: Path("/foo/bar")}, {"True": "/foo/bar"}),
+        ([Path("/one"), Path("/two"), 1, True], ["/one", "/two", 1, True]),
+        (1, 1),
+        (True, True),
+        ("test", "test"),
+    ],
+)
+def test_prepare_json(input_expected):
+    data, expected = input_expected
+    assert prepare_json(data) == expected


### PR DESCRIPTION
Problem: `dynaconf list` is formatted and cannot be processed by JSON tools in terminal.

stdout can't be piped to a file `> settings.json` or processed by tools such as `jq` 

Current output on `$ cd dynaconf/tests_functional/full_example`

```console
$ dynaconf -i app.settings list                        
Working in development environment 
LOAD_DOTENV<bool> True
DEFAULT_SETTINGS_PATHS<list> ['settings.py',
 'settings.toml',
 'settings.tml',
 'settings.yaml',
 'settings.yml',
 'settings.ini',
 'settings.conf',
 'settings.properties',
 'settings.json',
 '.secrets.py',
 '.secrets.toml',
 '.secrets.tml',
 '.secrets.yaml',
 '.secrets.yml',
 '.secrets.ini',
 '.secrets.conf',
 '.secrets.properties',
 '.secrets.json']
WORKS<str> 'full_example'
HOSTNAME<str> 'host.com'
PORT<int> 5000
VALUE<float> 42.1
ALIST<list> ['item1', 'item2', 'item3']
ADICT<dict> {'key': 'value'}
DEBUG<bool> True
ONE<dict> {'TWO': 'value'}

```

## Whith this new feature

JSON output

```console
$ dynaconf -i app.settings list --json
{"ADICT": {"key": "value"}, "ALIST": ["item1", "item2", "item3"], "DEBUG": true, "DEFAULT_SETTINGS_PATHS": ["settings.py", "settings.toml", "settings.tml", "settings.yaml", "settings.yml", "settings.ini", "settings.conf", "settings.properties", "settings.json", ".secrets.py", ".secrets.toml", ".secrets.tml", ".secrets.yaml", ".secrets.yml", ".secrets.ini", ".secrets.conf", ".secrets.properties", ".secrets.json"], "HOSTNAME": "host.com", "LOAD_DOTENV": true, "ONE": {"TWO": "value"}, "PORT": 5000, "VALUE": 42.1, "WORKS": "full_example"}%      
```

Processing output

```console 
$ dynaconf -i app.settings list --json | jq
{
  "ADICT": {
    "key": "value"
  },
  "ALIST": [
    "item1",
    "item2",
    "item3"
  ],
  "DEBUG": true,
  "DEFAULT_SETTINGS_PATHS": [
    "settings.py",
    "settings.toml",
    "settings.tml",
    "settings.yaml",
    "settings.yml",
    "settings.ini",
    "settings.conf",
    "settings.properties",
    "settings.json",
    ".secrets.py",
    ".secrets.toml",
    ".secrets.tml",
    ".secrets.yaml",
    ".secrets.yml",
    ".secrets.ini",
    ".secrets.conf",
    ".secrets.properties",
    ".secrets.json"
  ],
  "HOSTNAME": "host.com",
  "LOAD_DOTENV": true,
  "ONE": {
    "TWO": "value"
  },
  "PORT": 5000,
  "VALUE": 42.1,
  "WORKS": "full_example"
}

```

Alternative to `get` command

```console
$ dynaconf -i app.settings list --json | jq ".HOSTNAME"
"host.com"

```