### PR TITLE
fix(django):Run reload before returning lazy_settings to Django.

### DIFF
--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -137,6 +137,7 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
         ):
             stack_item.frame.f_globals["settings"] = lazy_settings
 
+    lazy_settings.reload()
     return lazy_settings
 
 

--- a/tests_functional/django_example/polls/tests.py
+++ b/tests_functional/django_example/polls/tests.py
@@ -13,6 +13,9 @@ class SettingsTest(TestCase):
         # hooks
         self.assertEqual(settings.BEST_BOSS, "Michael Scott")
 
+        # set as @reverse_lazy and evaluated to the @format string
+        self.assertEqual(settings.LOGIN_URL, "/admin/login/")
+
         self.assertEqual(settings.ISSUE, 596)
         self.assertEqual(settings.SERVER, "prodserver.com")
         # self.assertEqual(


### PR DESCRIPTION
Fix #1087
Closes #1086