### PR TITLE
fix(flask):Allow disabling transformation of dict to Dynabox

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -18,6 +18,29 @@ FlaskDynaconf(app)
 
 > You can optionally use `init_app` as well.
 
+
+## Compatibility mode
+
+Dynaconf transform nested data structures to a new DynaBox instance, this is an
+object that allows dot notation access such as `app.config.key.value.other`.
+However this feature is imcompatible with some Flask extensions, for example:
+`Flask-Alembic`.
+
+So in case you see a `BoxKeyError` when running your app with you can run it on
+compatibility mode.
+
+```python
+FlaskDynaconf(app, compatibility_mode=True)
+```
+
+The downside is that now you cannot access nested elements using dot notation
+but the usual access interface via dict subscription will work normally:
+`app.config["KEY"]["value"]["other"]`
+
+!!! info
+    On Dynaconf 4.0 compatibility_mode will default to True when running
+    on Flask.
+
 ## Use `FLASK_` environment variables
 
 Then the `app.config` will work as a `dynaconf.settings` instance and `FLASK_` will be the global prefix for exporting environment variables.

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -111,6 +111,9 @@ class FlaskDynaconf:
 
     def init_app(self, app, **kwargs):
         """kwargs holds initial dynaconf configuration"""
+        if kwargs.pop("compatibility_mode", None) is True:
+            kwargs["DYNABOXIFY"] = False
+
         self.kwargs.update(kwargs)
         self.settings = self.dynaconf_instance or dynaconf.LazySettings(
             **self.kwargs

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -412,7 +412,7 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
     else:
         value = parse_with_toml(data) if tomlfy else data
 
-    if isinstance(value, dict):
+    if isinstance(value, dict) and box_settings.get("DYNABOXIFY", True):
         value = DynaBox(value, box_settings=box_settings)
 
     return value
@@ -441,21 +441,23 @@ def parse_conf_data(data, tomlfy=False, box_settings=None):
 
     if isinstance(data, DynaBox):
         # recursively parse inner dict items
-        _parsed = DynaBox({}, box_settings=box_settings)
+        # It is important to keep the same object id because
+        # of mutability
         for k, v in data._safe_items():
-            _parsed[k] = parse_conf_data(
+            data[k] = parse_conf_data(
                 v, tomlfy=tomlfy, box_settings=box_settings
             )
-        return _parsed
+        return data
 
     if isinstance(data, dict):
         # recursively parse inner dict items
-        _parsed = {}
+        # It is important to keep the same object id because
+        # of mutability
         for k, v in data.items():
-            _parsed[k] = parse_conf_data(
+            data[k] = parse_conf_data(
                 v, tomlfy=tomlfy, box_settings=box_settings
             )
-        return _parsed
+        return data
 
     # return parsed string value
     return _parse_conf_data(data, tomlfy=tomlfy, box_settings=box_settings)


### PR DESCRIPTION
fix #1113

## Compatibility mode

Dynaconf transform nested data structures to a new DynaBox instance, this is an
object that allows dot notation access such as `app.config.key.value.other`.
However this feature is imcompatible with some Flask extensions, for example:
`Flask-Alembic`.

So in case you see a `BoxKeyError` when running your app with you can run it on
compatibility mode.

```python
FlaskDynaconf(app, compatibility_mode=True)
```

The downside is that now you cannot access nested elements using dot notation
but the usual access interface via dict subscription will work normally:
`app.config["KEY"]["value"]["other"]`

!!! info
    On Dynaconf 4.0 compatibility_mode will default to True when running
    on Flask.