### PR TITLE
docs(django):Improve Django Docs, make explicit mode the recommended.

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -1,163 +1,34 @@
 # Django
 
+Built-in integration with Django.
+
+## Overview
+
 Dynaconf can integrate with Django in two ways:
 
 - [Explicit Mode](#explicit-mode): Use dynaconf to load and merge data from multiple sources but settings control keeps with Django.
-  - Choose this if you want to fine control your settings, then use dynaconf only to populate your settings.py, keep in minf that on this mode you do not gain the [Extra Functionalities](#extra-functionalities) from dynaconf.
-
+    - Choose this if you want to fine control your settings, then use dynaconf only to populate your `settings.py`.
+      Keep in mind that on this mode you do not gain the [Extra Functionalities](#extra-functionalities) from dynaconf.
 - [Django Extension](#django-extension): Give full control of `django.conf.settings` to Dynaconf
-  - Choose this if you want to have access to all dynaconf features across the whole django application, with some [trade-offs](#known-caveats)
-
+    - Choose this if you want to have access to all dynaconf features across the whole django application, with some [trade-offs](#known-caveats)
 
 In both modes Dynaconf will be able to load variables from multiple sources (env vars, settings files in multiple formats)
 and perform the usual parsing, merging and validation and optionally  execute defined hooks.
 
-## Settings Sources
+## Integration Modes
 
-Besides the common `<app>/settings.py` you will be able to load extra settings
-from defined locations, can be a single file, multiple files or even a glob pattern,
-the variables from those extra sources will be merged with the variables from
-the main app settings and the merging can be controlled individually with markers.
-
-Choose the format that best suits your needs and preferences.
-
-### Using .py settings file
-
-`/etc/myapp/settings.py`
-```python
-DEBUG = false
-ADMIN_NAMESPACE = "admin"
-LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
-INSTALLED_APPS = "@merge my_new.app,otherapp"
-# ALTERNATIVELY
-INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
-
-LOGGING__handlers__console__formatter = "simple"
-# ALTERNATIVELY
-LOGGING = {"handlers": {"console": {"formatter":"simple"}}, "dynaconf_merge": true}
-
-DATABASES__default = {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite"}
-# ALTERNATIVELY
-DATABASES__default__ENGINE = "django.db.backends.sqlite3"
-DATABASES__default__NAME = "db.sqlite"
-
-AUTH_PASSWORD_VALIDATORS = [
-    {"name": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
-    {"name": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-]
-```
-
-### Using toml
-
-`/etc/myapp/settings.toml`
-```toml
-DEBUG = false
-ADMIN_NAMESPACE = "admin"
-LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
-
-INSTALLED_APPS = "@merge my_new.app,otherapp"
-# ALTERNATIVELY
-INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
-
-LOGGING__handlers__console__formatter = "simple"
-# ALTERNATIVELY
-LOGGING = {handlers={console={formatter="simple"}}, dynaconf_merge=true}
-
-[DATABASES.default]
-ENGINE = "django.db.backends.sqlite3"
-NAME = "db.sqlite"
-# ALTERNATIVELY
-DATABASES__default__ENGINE = "django.db.backends.sqlite3"
-DATABASES__default__NAME = "db.sqlite"
-
-[[AUTH_PASSWORD_VALIDATORS]]
-NAME = "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-
-[[AUTH_PASSWORD_VALIDATORS]]
-NAME = "django.contrib.auth.password_validation.MinimumLengthValidator"
-```
-
-### Using yaml
-
-`/etc/myapp/settings.yaml`
-```yaml
-DEBUG: false
-ADMIN_NAMESPACE: "admin"
-LOGIN_URL: "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
-
-INSTALLED_APPS: "@merge my_new.app,otherapp"
-# ALTERNATIVELY
-INSTALLED_APPS:
- - "mynew.app"
- - "otherapp"
- - "dynaconf_merge"
-
-LOGGING__handlers__console__formatter: "simple"
-# ALTERNATIVELY
-LOGGING:
-  dynaconf_merge: true
-  handlers:
-    console:
-      formatter: "simple"
-
-DATABASES:
-  default:
-    ENGINE: "django.db.backends.sqlite3"
-    NAME: "db.sqlite"
-# ALTERNATIVELY
-DATABASES__default__ENGINE: "django.db.backends.sqlite3"
-DATABASES__default__NAME: "db.sqlite"
-
-AUTH_PASSWORD_VALIDATORS
-  - NAME: "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-  - NAME: "django.contrib.auth.password_validation.MinimumLengthValidator"
-```
-
-### Using environment variables
-
-```bash
-export DJANGO_ENV=production
-
-export DJANGO_DEBUG=false
-export DJANGO_ADMIN_NAMESPACE="admin"
-export DJANGO_LOGIN_URL="@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
-
-export DJANGO_INSTALLED_APPS="@merge my_new.app,otherapp"
-# ALTERNATIVELY
-export DJANGO_INSTALLED_APPS='["mynew.app", "otherapp", "dynaconf_merge"]'
-
-export DJANGO_LOGGING__handlers__console__formatter="simple"
-# ALTERNATIVELY
-export DJANGO_LOGGING='@json {"handlers": {"console": {"formatter": "simple"}}, "dynaconf_merge": true}'
-
-export DJANGO_DATABASES__default__ENGINE: "django.db.backends.sqlite3"
-export DJANGO_DATABASES__default__NAME: "db.sqlite"
-# ALTERNATIVELY
-export DJANGO_DATABASES__default='@json {"NAME": "db.sqlite", "ENGINE": "dj.."}'
-
-export DJANGO_AUTH_PASSWORD_VALIDATORS___0__NAME="django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-export DJANGO_AUTH_PASSWORD_VALIDATORS___1__NAME="django.contrib.auth.password_validation.MinimumLengthValidator"
-# ALTERNATIVELY
-export DJANGO_AUTH_PASSWORD_VALIDATORS='[{NAME="dj..."}, {NAME="dj..."}]'
-```
-
-### Other sources
-
-Dynaconf also supports **JSON**, **INI**, **REDIS**, **HASHICORP VAULT** and custom loaders.
-
-
-## Explicit mode
+### Explicit mode
 
 Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the usual way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`, etc.
 
 Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings are managed by Django normally.
 
 
-### Preparing your settings.py
+#### Setup
 
 Edit your `<app>/settings.py`
 
-```py
+```py title="settings.py"
 # At the top of the file:
 import sys
 from pathlib import Path
@@ -198,10 +69,10 @@ settings.populate_obj(sys.modules[__name__])
     - `ignore`: Don't override local variables, only add new ones.
     (added in `2.1.1`)
     - `merge`: same as passing `merge_enabled=True` to Dynaconf
-    - `merge_unique`: don't duplicate items in lists. (this can also be controled individually on each variable)
+    - `merge_unique`: don't duplicate items in lists. (this can also be controlled individually on each variable)
     (added in 3.3.0)
 
-### Usage
+#### Usage
 
 The `Dynaconf` instance will load and parse all settings from your settings sources and
 then `populate_obj` will merge the loaded data with local settings variables.
@@ -213,7 +84,7 @@ from django.conf import settings
 assert "mynew.app" in settings.INSTALLED_APPS  # True: Merged from the toml file
 ```
 
-## Django Extension
+### Django Extension
 
 This mode is different from the Explicit Mode explained above, on this mode Dynaconf will
 automatically take lots of decisions and full control over your `django.conf.settings`
@@ -221,7 +92,7 @@ automatically take lots of decisions and full control over your `django.conf.set
 It works by patching the `settings.py` file with dynaconf loading hooks, the change is done on a single file and then in your whole project. Every time you call `django.conf.settings` you will have access to `dynaconf` attributes and methods.
 
 
-### Extra functionalities
+#### Extra functionalities
 
 On this mode you can still use the same settings file formats and sources, the main difference
 is that now every time you import `settings` it is a Dynaconf instance and you gain some
@@ -238,11 +109,11 @@ extra functionalities like:
 
 Those features comes with a price that you can see on [known caveats](#known-caveats)
 
-### Initialize the extension
+#### Setup
 
 You can manually append at the very bottom of your django project's `settings.py` the following code:
 
-```python
+```python title="settings.py"
 
 # Common django default settings comes here
 DEBUG = True
@@ -266,9 +137,9 @@ settings = dynaconf.DjangoDynaconf(
 ```
 
 !!! tip
-    Take a look at [tests_functional/django_example](https://github.com/dynaconf/dynaconf/tree/master/tests_functional/django_example)
+    Take a look at [tests_functional/django_example](https://github.com/dynaconf/dynaconf/tree/master/tests_functional/legacy/django_example)
 
-### Known Caveats
+#### Known Caveats
 
 - If `settings.configure()` is called directly it disables Dynaconf, use `settings.DYNACONF.configure()`
 - Inside the settings file `<app>/settings.py` and `<app>/dynaconf_hooks.py` it is not possible to use
@@ -278,7 +149,140 @@ settings = dynaconf.DjangoDynaconf(
 - Pylint-Django may raise linting error for [dynaconf_merge markers](https://github.com/dynaconf/dynaconf/issues/578)
 
 
-## Using `DJANGO_` environment variables
+## Settings Sources
+
+Besides the common `<app>/settings.py` you will be able to load extra settings
+from defined locations, can be a single file, multiple files or even a glob pattern,
+the variables from those extra sources will be merged with the variables from
+the main app settings and the merging can be controlled individually with markers.
+
+Choose the format that best suits your needs and preferences.
+
+### Common Sources
+
+=== "python"
+
+    ```python title="/etc/myapp/settings.py"
+    DEBUG = false
+    ADMIN_NAMESPACE = "admin"
+    LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+    INSTALLED_APPS = "@merge my_new.app,otherapp"
+    # ALTERNATIVELY
+    INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
+
+    LOGGING__handlers__console__formatter = "simple"
+    # ALTERNATIVELY
+    LOGGING = {"handlers": {"console": {"formatter":"simple"}}, "dynaconf_merge": true}
+
+    DATABASES__default = {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite"}
+    # ALTERNATIVELY
+    DATABASES__default__ENGINE = "django.db.backends.sqlite3"
+    DATABASES__default__NAME = "db.sqlite"
+
+    AUTH_PASSWORD_VALIDATORS = [
+        {"name": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+        {"name": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    ]
+    ```
+
+=== "toml"
+
+    ```toml title="/etc/myapp/settings.toml"
+    DEBUG = false
+    ADMIN_NAMESPACE = "admin"
+    LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+    INSTALLED_APPS = "@merge my_new.app,otherapp"
+    # ALTERNATIVELY
+    INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
+
+    LOGGING__handlers__console__formatter = "simple"
+    # ALTERNATIVELY
+    LOGGING = {handlers={console={formatter="simple"}}, dynaconf_merge=true}
+
+    [DATABASES.default]
+    ENGINE = "django.db.backends.sqlite3"
+    NAME = "db.sqlite"
+    # ALTERNATIVELY
+    DATABASES__default__ENGINE = "django.db.backends.sqlite3"
+    DATABASES__default__NAME = "db.sqlite"
+
+    [[AUTH_PASSWORD_VALIDATORS]]
+    NAME = "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+
+    [[AUTH_PASSWORD_VALIDATORS]]
+    NAME = "django.contrib.auth.password_validation.MinimumLengthValidator"
+    ```
+
+=== "yaml"
+
+    ```yaml title="/etc/myapp/settings.yaml"
+    DEBUG: false
+    ADMIN_NAMESPACE: "admin"
+    LOGIN_URL: "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+    INSTALLED_APPS: "@merge my_new.app,otherapp"
+    # ALTERNATIVELY
+    INSTALLED_APPS:
+     - "mynew.app"
+     - "otherapp"
+     - "dynaconf_merge"
+
+    LOGGING__handlers__console__formatter: "simple"
+    # ALTERNATIVELY
+    LOGGING:
+      dynaconf_merge: true
+      handlers:
+        console:
+          formatter: "simple"
+
+    DATABASES:
+      default:
+        ENGINE: "django.db.backends.sqlite3"
+        NAME: "db.sqlite"
+    # ALTERNATIVELY
+    DATABASES__default__ENGINE: "django.db.backends.sqlite3"
+    DATABASES__default__NAME: "db.sqlite"
+
+    AUTH_PASSWORD_VALIDATORS
+      - NAME: "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+      - NAME: "django.contrib.auth.password_validation.MinimumLengthValidator"
+    ```
+
+=== "environment variables"
+
+    ```bash
+    export DJANGO_ENV=production
+
+    export DJANGO_DEBUG=false
+    export DJANGO_ADMIN_NAMESPACE="admin"
+    export DJANGO_LOGIN_URL="@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+    export DJANGO_INSTALLED_APPS="@merge my_new.app,otherapp"
+    # ALTERNATIVELY
+    export DJANGO_INSTALLED_APPS='["mynew.app", "otherapp", "dynaconf_merge"]'
+
+    export DJANGO_LOGGING__handlers__console__formatter="simple"
+    # ALTERNATIVELY
+    export DJANGO_LOGGING='@json {"handlers": {"console": {"formatter": "simple"}}, "dynaconf_merge": true}'
+
+    export DJANGO_DATABASES__default__ENGINE: "django.db.backends.sqlite3"
+    export DJANGO_DATABASES__default__NAME: "db.sqlite"
+    # ALTERNATIVELY
+    export DJANGO_DATABASES__default='@json {"NAME": "db.sqlite", "ENGINE": "dj.."}'
+
+    export DJANGO_AUTH_PASSWORD_VALIDATORS___0__NAME="django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    export DJANGO_AUTH_PASSWORD_VALIDATORS___1__NAME="django.contrib.auth.password_validation.MinimumLengthValidator"
+    # ALTERNATIVELY
+    export DJANGO_AUTH_PASSWORD_VALIDATORS='[{NAME="dj..."}, {NAME="dj..."}]'
+    ```
+
+### Other Sources
+
+Dynaconf also supports **JSON**, **INI**, **REDIS**, **HASHICORP VAULT** and custom loaders.
+
+
+### Using `DJANGO_` environment variables
 
 Then **django.conf.settings** will work as a `dynaconf.settings` instance and `DJANGO_` will be the global prefix to export environment variables.
 
@@ -338,7 +342,7 @@ DATABASES = {
 
 Read more on [environment variables](https://www.dynaconf.com/merging/#nested-keys-in-dictionaries-via-environment-variables)
 
-## Settings files
+### Using Settings files
 
 You can also have settings files for your Django app.
 
@@ -508,7 +512,7 @@ print(settings.get('DATABASES'))
 
 Django testing must work out of the box!
 
-## Mocking envvars with django
+### Mocking envvars with django
 
 But in some cases when you `mock` stuff and need to add `environment variables` to `os.environ` on demand for test cases it may be needed to `reload` the `dynaconf`.
 
@@ -528,7 +532,7 @@ class TestCase(...):
         self.assertEqual(settings.FOO, 'BAR')
 ```
 
-## Using pytest and django
+### Using pytest and django
 
 Install `pip install pytest-django`
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -1,39 +1,282 @@
-# Django Extension
+# Django
 
-> **New in 2.0.0**
+Dynaconf can integrate with Django in two ways:
 
-Dynaconf extension for Django works by patching the `settings.py` file with dynaconf loading hooks, the change is done on a single file and then in your whole project. Every time you call `django.conf.settings` you will have access to `dynaconf` attributes and methods.
+- [Explicit Mode](#explicit-mode): Use dynaconf to load and merge data from multiple sources but settings control keeps with Django.
+  - Choose this if you want to fine control your settings, then use dynaconf only to populate your settings.py, keep in minf that on this mode you do not gain the [Extra Functionalities](#extra-functionalities) from dynaconf.
 
-Ensure dynaconf is installed on your env `pip install dynaconf[yaml]`
+- [Django Extension](#django-extension): Give full control of `django.conf.settings` to Dynaconf
+  - Choose this if you want to have access to all dynaconf features across the whole django application, with some [trade-offs](#known-caveats)
 
-## Initialize the extension
 
-You can manually append at the bottom of your django project's `settings.py` the following code:
+In both modes Dynaconf will be able to load variables from multiple sources (env vars, settings files in multiple formats)
+and perform the usual parsing, merging and validation and optionally  execute defined hooks.
+
+## Settings Sources
+
+Besides the common `<app>/settings.py` you will be able to load extra settings
+from defined locations, can be a single file, multiple files or even a glob pattern,
+the variables from those extra sources will be merged with the variables from
+the main app settings and the merging can be controlled individually with markers.
+
+Choose the format that best suits your needs and preferences.
+
+### Using .py settings file
+
+`/etc/myapp/settings.py`
+```python
+DEBUG = false
+ADMIN_NAMESPACE = "admin"
+LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+INSTALLED_APPS = "@merge my_new.app,otherapp"
+# ALTERNATIVELY
+INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
+
+LOGGING__handlers__console__formatter = "simple"
+# ALTERNATIVELY
+LOGGING = {"handlers": {"console": {"formatter":"simple"}}, "dynaconf_merge": true}
+
+DATABASES__default = {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite"}
+# ALTERNATIVELY
+DATABASES__default__ENGINE = "django.db.backends.sqlite3"
+DATABASES__default__NAME = "db.sqlite"
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"name": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"name": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+]
+```
+
+### Using toml
+
+`/etc/myapp/settings.toml`
+```toml
+DEBUG = false
+ADMIN_NAMESPACE = "admin"
+LOGIN_URL = "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+INSTALLED_APPS = "@merge my_new.app,otherapp"
+# ALTERNATIVELY
+INSTALLED_APPS = ["mynew.app", "otherapp", "dynaconf_merge"]
+
+LOGGING__handlers__console__formatter = "simple"
+# ALTERNATIVELY
+LOGGING = {handlers={console={formatter="simple"}}, dynaconf_merge=true}
+
+[DATABASES.default]
+ENGINE = "django.db.backends.sqlite3"
+NAME = "db.sqlite"
+# ALTERNATIVELY
+DATABASES__default__ENGINE = "django.db.backends.sqlite3"
+DATABASES__default__NAME = "db.sqlite"
+
+[[AUTH_PASSWORD_VALIDATORS]]
+NAME = "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+
+[[AUTH_PASSWORD_VALIDATORS]]
+NAME = "django.contrib.auth.password_validation.MinimumLengthValidator"
+```
+
+### Using yaml
+
+`/etc/myapp/settings.yaml`
+```yaml
+DEBUG: false
+ADMIN_NAMESPACE: "admin"
+LOGIN_URL: "@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+INSTALLED_APPS: "@merge my_new.app,otherapp"
+# ALTERNATIVELY
+INSTALLED_APPS:
+ - "mynew.app"
+ - "otherapp"
+ - "dynaconf_merge"
+
+LOGGING__handlers__console__formatter: "simple"
+# ALTERNATIVELY
+LOGGING:
+  dynaconf_merge: true
+  handlers:
+    console:
+      formatter: "simple"
+
+DATABASES:
+  default:
+    ENGINE: "django.db.backends.sqlite3"
+    NAME: "db.sqlite"
+# ALTERNATIVELY
+DATABASES__default__ENGINE: "django.db.backends.sqlite3"
+DATABASES__default__NAME: "db.sqlite"
+
+AUTH_PASSWORD_VALIDATORS
+  - NAME: "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+  - NAME: "django.contrib.auth.password_validation.MinimumLengthValidator"
+```
+
+### Using environment variables
+
+```bash
+export DJANGO_ENV=production
+
+export DJANGO_DEBUG=false
+export DJANGO_ADMIN_NAMESPACE="admin"
+export DJANGO_LOGIN_URL="@reverse_lazy @format {this.ADMIN_NAMESPACE}:login"
+
+export DJANGO_INSTALLED_APPS="@merge my_new.app,otherapp"
+# ALTERNATIVELY
+export DJANGO_INSTALLED_APPS='["mynew.app", "otherapp", "dynaconf_merge"]'
+
+export DJANGO_LOGGING__handlers__console__formatter="simple"
+# ALTERNATIVELY
+export DJANGO_LOGGING='@json {"handlers": {"console": {"formatter": "simple"}}, "dynaconf_merge": true}'
+
+export DJANGO_DATABASES__default__ENGINE: "django.db.backends.sqlite3"
+export DJANGO_DATABASES__default__NAME: "db.sqlite"
+# ALTERNATIVELY
+export DJANGO_DATABASES__default='@json {"NAME": "db.sqlite", "ENGINE": "dj.."}'
+
+export DJANGO_AUTH_PASSWORD_VALIDATORS___0__NAME="django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+export DJANGO_AUTH_PASSWORD_VALIDATORS___1__NAME="django.contrib.auth.password_validation.MinimumLengthValidator"
+# ALTERNATIVELY
+export DJANGO_AUTH_PASSWORD_VALIDATORS='[{NAME="dj..."}, {NAME="dj..."}]'
+```
+
+### Other sources
+
+Dynaconf also supports **JSON**, **INI**, **REDIS**, **HASHICORP VAULT** and custom loaders.
+
+
+## Explicit mode
+
+Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the usual way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`, etc.
+
+Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings are managed by Django normally.
+
+
+### Preparing your settings.py
+
+Edit your `<app>/settings.py`
+
+```py
+# At the top of the file:
+import sys
+from pathlib import Path
+from dynaconf import Dynaconf, Validator
+
+validators = [
+    Validator("INSTALLED_APPS", cont="mynew.app"),
+    Validator("DEBUG", ne=True, env="production"),
+]
+settings = Dynaconf(
+    validators=validators,  # Raises ValidationError for passed in validators
+    settings_files=["/etc/myapp/settings.toml"]  # .py, .yaml, .ini, .json etc..
+)
+
+# Common Django settings
+# ...
+BASE_DIR = Path(__file__).resolve().parent.parent
+DEBUG = True
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    ...
+]
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+# ...
+
+# At the end of your settings.py
+settings.populate_obj(sys.modules[__name__])
+```
+
+!!! info
+    `populate_obj` accepts the following arguments:
+    - `ignore`: Don't override local variables, only add new ones.
+    (added in `2.1.1`)
+    - `merge`: same as passing `merge_enabled=True` to Dynaconf
+    - `merge_unique`: don't duplicate items in lists. (this can also be controled individually on each variable)
+    (added in 3.3.0)
+
+### Usage
+
+The `Dynaconf` instance will load and parse all settings from your settings sources and
+then `populate_obj` will merge the loaded data with local settings variables.
+
+At the end your `django.conf.settings` is just a regular Django Settings.
 
 ```python
+from django.conf import settings
+assert "mynew.app" in settings.INSTALLED_APPS  # True: Merged from the toml file
+```
+
+## Django Extension
+
+This mode is different from the Explicit Mode explained above, on this mode Dynaconf will
+automatically take lots of decisions and full control over your `django.conf.settings`
+
+It works by patching the `settings.py` file with dynaconf loading hooks, the change is done on a single file and then in your whole project. Every time you call `django.conf.settings` you will have access to `dynaconf` attributes and methods.
+
+
+### Extra functionalities
+
+On this mode you can still use the same settings file formats and sources, the main difference
+is that now every time you import `settings` it is a Dynaconf instance and you gain some
+extra functionalities like:
+
+- Dict like access: `settings["KEY"]`
+- Get method: `settings.get("KEY", default)`
+- Dotted dict access: `settings["DATABASES.default.name"]`
+- Attribute access: `settings.databases.default.name`
+- Case insensitivity: `settings.databases == settings.DATABASES`
+- Context manager: `with settings.using_env("testing"):`
+- Temporary settings copy `settings = settings.clone(foo=bar)`
+- Real time hooks: `settings.MY_SPECIAL_KEY` triggers a custom `get_special_key_value() -> value` function at access time.
+
+Those features comes with a price that you can see on [known caveats](#known-caveats)
+
+### Initialize the extension
+
+You can manually append at the very bottom of your django project's `settings.py` the following code:
+
+```python
+
+# Common django default settings comes here
+DEBUG = True
+...
+
+# Then at the very bottom of settings.py
+
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://www.dynaconf.com/django/
-import dynaconf  # noqa
-settings = dynaconf.DjangoDynaconf(__name__)  # noqa
+import dynaconf
+validators = [
+    dynaconf.Validator("INSTALLED_APPS", cont="mynew.app"),
+    dynaconf.Validator("DEBUG", ne=True, env="production"),
+]
+settings = dynaconf.DjangoDynaconf(
+    __name__,
+    settings_files=["/etc/myapp/settings.toml"],
+    validators=validators,
+)
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
 ```
 
-Or **optionally** you can, on the same directory where your `manage.py` is located run:
-
-```bash
-export DJANGO_SETTINGS_MODULE=yourapp.settings
-$ dynaconf init
-
-# or passing the location of the settings file
-
-$ dynaconf init --django yourapp/settings.py
-
-```
-
-Dynaconf will append its extension loading code to the bottom of your `yourapp/settings.py` file and will create `settings.toml` and `.secrets.toml` in the current folder (the same where `manage.py` is located).
-
 !!! tip
     Take a look at [tests_functional/django_example](https://github.com/dynaconf/dynaconf/tree/master/tests_functional/django_example)
+
+### Known Caveats
+
+- If `settings.configure()` is called directly it disables Dynaconf, use `settings.DYNACONF.configure()`
+- Inside the settings file `<app>/settings.py` and `<app>/dynaconf_hooks.py` it is not possible to use
+  translation functions such as `gettext` and `gettext_lazy`, those functions works normally on any part
+  of the application except the settings files due to a lifecycle limitation, if you want to use translation
+  tools inside the `<app>/settings.py` file you have to opt to [dynaconf explicit mode](#explicit-mode).
+- Pylint-Django may raise linting error for [dynaconf_merge markers](https://github.com/dynaconf/dynaconf/issues/578)
+
 
 ## Using `DJANGO_` environment variables
 
@@ -104,8 +347,6 @@ In the root directory (the same where `manage.py` is located) put your `settings
 To switch the working environment the `DJANGO_ENV` variable can be used, so `DJANGO_ENV=development` to work
 in development mode or `DJANGO_ENV=production` to switch to production.
 
-If you don't want to manually create your config files take a look at the [CLI](cli.md)
-
 !!! tip
     **.yaml** is the recommended format for Django applications because it allows easily writing complex data structures. Nevertheless, feel free to choose any format you are familiar with.
 
@@ -147,7 +388,7 @@ settings = dynaconf.DjangoDynaconf(
 # HERE ENDS DYNACONF EXTENSION LOAD
 ```
 
- Variables on environment can be set/override using `PROJECTNAME_` prefix e.g: `export PROJECTNAME_DEBUG=true`.
+Variables on environment can be set/override using `PROJECTNAME_` prefix e.g: `export PROJECTNAME_DEBUG=true`.
 
 The working environment can now be switched using `export PROJECTNAME_ENV=production` it defaults to `development`.
 
@@ -303,47 +544,6 @@ def set_test_settings():
     from django.conf import settings
     settings.setenv('testing')  # force the environment to be whatever you want
 ```
-
-## Explicit mode
-
-Some users prefer to explicitly load each setting variable inside the `settings.py` and then let django manage it in the usual way. This is possible, but keep in mind that doing so will prevent the usage of dynaconf methods like `using_env`, `get`.
-
-Dynaconf will be available only on `settings.py` scope. On the rest of your application, settings are managed by Django normally.
-
-```py
-# settings.py
-
-import sys
-from dynaconf import LazySettings
-
-settings = LazySettings(**YOUR_OPTIONS_HERE)
-
-DEBUG = settings.get('DEBUG', False)
-DATABASES = settings.get('DATABASES', {
-    'default': {
-        'ENGINE': '...',
-        'NAME': '...
-    }
-})
-...
-
-# At the end of your settings.py
-settings.populate_obj(sys.modules[__name__], ignore=locals())
-```
-
-!!! info
-    populate_obj accepts a `merge` and `merge_unique` booleans to control
-    how merge is performed.
-    (added in 3.3.0)
-
-You can still change env with `export DJANGO_ENV=production` and also can export variables like `export DJANGO_DEBUG=true`
-
-!!! note
-    Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exist in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
-
-## Known Caveats
-
-- If `settings.configure()` is called directly it disables Dynaconf, use `settings.DYNACONF.configure()`
 
 ## Deprecation note
 


### PR DESCRIPTION
Closes #648

The issue #648 is currently **impossible** to fix, it is a trede-off of patching the django settings, as our plan for 4.0 is to deprecate Django patching in favour of a more explicit way to attach dynaconf to Django, I condider that issue closed and improved the django docs.

Closes #578 
Added Pylint issue to known caveats