### PR TITLE
Validators aliases

### DIFF
--- a/dynaconf/typed/__init__.py
+++ b/dynaconf/typed/__init__.py
@@ -6,9 +6,9 @@ from .main import Dynaconf
 from .main import Options
 from .types import Annotated
 from .types import DictValue
-from .types import ItemsValidator
 from .types import NotRequired
-from .types import Validator
+from .validators import ItemsValidator
+from .validators import Validator
 
 __all__ = [
     "Annotated",

--- a/dynaconf/typed/types.py
+++ b/dynaconf/typed/types.py
@@ -1,15 +1,10 @@
 from __future__ import annotations  # WARNING: remove this when debugging
 
-from collections.abc import Sequence
 from typing import Annotated
-from typing import Any
-from typing import Callable
 from typing import TypeVar
 from typing import Union
 
-from dynaconf.utils.functional import Empty
 from dynaconf.utils.functional import empty
-from dynaconf.validator import Validator as BaseValidator
 
 from .compat import get_annotations
 
@@ -58,81 +53,6 @@ class DictValue:
                 defaults[name] = value
         defaults.update(kwargs)
         return defaults
-
-
-class Validator:
-    """Define an interface to generate a valid BaseValidator.
-
-    The `operations` are::
-
-        eq: value == other
-        ne: value != other
-        gt: value > other
-        lt: value < other
-        gte: value >= other
-        lte: value <= other
-        is_type_of: isinstance(value, type)
-        is_in:  value in sequence
-        is_not_in: value not in sequence
-        identity: value is other
-        cont: contain value in
-        len_eq: len(value) == other
-        len_ne: len(value) != other
-        len_min: len(value) > other
-        len_max: len(value) < other
-        startswith: value.startswith(term)
-        endswith:  value.endswith(term)
-        condition: fn(value) is True
-
-
-    """
-
-    __slots__ = ()
-
-    def __new__(
-        cls,
-        *,  # kw_only
-        # Operations
-        eq: Any = empty,
-        ne: Any = empty,
-        gt: Any = empty,
-        lt: Any = empty,
-        gte: Any = empty,
-        lte: Any = empty,
-        identity: Any = empty,
-        is_in: Any = empty,
-        is_not_in: Any = empty,
-        cont: Any = empty,
-        len_eq: Any = empty,
-        len_ne: Any = empty,
-        len_min: Any = empty,
-        len_max: Any = empty,
-        startswith: Any = empty,
-        endswith: Any = empty,
-        condition: Callable[[Any], bool] | None | Empty = empty,
-        # options
-        env: str | Sequence[str] | None | Empty = empty,
-        messages: dict[str, str] | None | Empty = empty,
-        cast: Callable[[Any], Any] | None | Empty = empty,
-        description: str | None | Empty = empty,
-        items_validators: list[BaseValidator] | None = None,
-        # To be implemented, a interface like this to generate a When Validator
-        # when: When | None = empty,
-    ):
-        kwargs = locals()
-        kwargs.pop("cls")
-        return BaseValidator(
-            **{k: v for k, v in kwargs.items() if v is not empty}
-        )
-
-
-class ItemsValidator:
-    """Interface to instantiate a new Validator with items_validators"""
-
-    __slots__ = ()
-
-    def __new__(cls, *args):
-        return BaseValidator(items_validators=args)
 
 
 """

--- a/dynaconf/typed/validators.py
+++ b/dynaconf/typed/validators.py
@@ -211,7 +211,7 @@ class Not(BaseValidator):
 # Generic Validation Aliases
 
 
-class GenericParametrizedOperation:
+class GenericOperation:
     """Base to create aliased Validator with generic parametrized operation.
 
     This class exists mainly to allow creation of semantic named validators.
@@ -239,133 +239,133 @@ class GenericParametrizedOperation:
         return Validator(**kwargs)
 
 
-class Eq(GenericParametrizedOperation):
+class Eq(GenericOperation):
     """Eq(x) -> Validator(eq=x)"""
 
     op_name = "eq"
 
 
-class Ne(GenericParametrizedOperation):
+class Ne(GenericOperation):
     """Ne(x) -> Validator(ne=x)"""
 
     op_name = "ne"
 
 
-class Gt(GenericParametrizedOperation):
+class Gt(GenericOperation):
     """Gt(x) -> Validator(gt=x)"""
 
     op_name = "gt"
 
 
-class Lt(GenericParametrizedOperation):
+class Lt(GenericOperation):
     """Lt(x) -> Validator(lt=x)"""
 
     op_name = "lt"
 
 
-class Gte(GenericParametrizedOperation):
+class Gte(GenericOperation):
     """Gte(x) -> Validator(gte=x)"""
 
     op_name = "gte"
 
 
-class Lte(GenericParametrizedOperation):
+class Lte(GenericOperation):
     """Lte(x) -> Validator(lte=x)"""
 
     op_name = "lte"
 
 
-class Id(GenericParametrizedOperation):
+class Id(GenericOperation):
     """Id(x) -> Validator(identity=x)"""
 
     op_name = "identity"
 
 
-class In(GenericParametrizedOperation):
+class In(GenericOperation):
     """In(x) -> Validator(is_in=x)"""
 
     op_name = "is_in"
 
 
-class NotIn(GenericParametrizedOperation):
+class NotIn(GenericOperation):
     """NotIn(x) -> Validator(is_not_in=x)"""
 
     op_name = "is_not_in"
 
 
-class Contains(GenericParametrizedOperation):
+class Contains(GenericOperation):
     """Contains(x) -> Validator(contains=x)"""
 
     op_name = "contains"
 
 
-class NotContains(GenericParametrizedOperation):
+class NotContains(GenericOperation):
     """NotContains(x) -> Validator(not_contains=x)"""
 
     op_name = "not_contains"
 
 
-class LenEq(GenericParametrizedOperation):
+class LenEq(GenericOperation):
     """LenEq(x) -> Validator(len_eq=x)"""
 
     op_name = "len_eq"
 
 
-class LenNe(GenericParametrizedOperation):
+class LenNe(GenericOperation):
     """LenNe(x) -> Validator(len_ne=x)"""
 
     op_name = "len_ne"
 
 
-class LenMin(GenericParametrizedOperation):
+class LenMin(GenericOperation):
     """LenMin(x) -> Validator(len_min=x)"""
 
     op_name = "len_min"
 
 
-class LenMax(GenericParametrizedOperation):
+class LenMax(GenericOperation):
     """LenMax(x) -> Validator(len_max=x)"""
 
     op_name = "len_max"
 
 
-class Starts(GenericParametrizedOperation):
+class Starts(GenericOperation):
     """Starts(x) -> Validator(startswith=x)"""
 
     op_name = "startswith"
 
 
-class Ends(GenericParametrizedOperation):
+class Ends(GenericOperation):
     """Ends(x) -> Validator(endswith=x)"""
 
     op_name = "endswith"
 
 
-class NotStarts(GenericParametrizedOperation):
+class NotStarts(GenericOperation):
     """NotStarts(x) -> Validator(not_startswith=x)"""
 
     op_name = "not_startswith"
 
 
-class NotEnds(GenericParametrizedOperation):
+class NotEnds(GenericOperation):
     """NotEnds(x) -> Validator(not_endswith=x)"""
 
     op_name = "not_endswith"
 
 
-class Regex(GenericParametrizedOperation):
+class Regex(GenericOperation):
     """Regex(x) -> Validator(regex=x)"""
 
     op_name = "regex"
 
 
-class NotRegex(GenericParametrizedOperation):
+class NotRegex(GenericOperation):
     """NotRegex(x) -> Validator(not_regex=x)"""
 
     op_name = "not_regex"
 
 
-class Condition(GenericParametrizedOperation):
+class Condition(GenericOperation):
     """Condition(x) -> Validator(condition=x)"""
 
     op_name = "condition"

--- a/dynaconf/typed/validators.py
+++ b/dynaconf/typed/validators.py
@@ -1,0 +1,449 @@
+from __future__ import annotations  # WARNING: remove this when debugging
+
+from collections.abc import Sequence
+from typing import Any
+from typing import Callable
+
+from dynaconf.utils.functional import Empty
+from dynaconf.utils.functional import empty
+from dynaconf.validator import Validator as BaseValidator
+
+from .exceptions import ValidationError
+
+
+class Validator:
+    """Define an interface to generate a valid dynaconf.Validator.
+
+    The `operations` are::
+
+        eq: value == other
+        ne: value != other
+        gt: value > other
+        lt: value < other
+        gte: value >= other
+        lte: value <= other
+        is_type_of: isinstance(value, type)
+        is_in:  value in sequence
+        is_not_in: value not in sequence
+        identity: value is other
+        contains: contain value in
+        not_contains: not contains value
+        len_eq: len(value) == other
+        len_ne: len(value) != other
+        len_min: len(value) > other
+        len_max: len(value) < other
+        startswith: value.startswith(term)
+        endswith:  value.endswith(term)
+        not_startswith: not value.startswith(term)
+        not_endswith:  not value.endswith(term)
+        regex: pattern.match(value)
+        not_regex: not pattern.match(value)
+        condition: fn(value) is True
+    """
+
+    __slots__ = ()
+
+    def __new__(
+        cls,
+        *,  # kw_only
+        # Operations
+        eq: Any = empty,
+        ne: Any = empty,
+        gt: Any = empty,
+        lt: Any = empty,
+        gte: Any = empty,
+        lte: Any = empty,
+        identity: Any = empty,
+        is_in: Any = empty,
+        is_not_in: Any = empty,
+        contains: Any = empty,
+        not_contains: Any = empty,
+        len_eq: Any = empty,
+        len_ne: Any = empty,
+        len_min: Any = empty,
+        len_max: Any = empty,
+        startswith: Any = empty,
+        endswith: Any = empty,
+        not_startswith: Any = empty,
+        not_endswith: Any = empty,
+        regex: Any = empty,
+        not_regex: Any = empty,
+        condition: Callable[[Any], bool] | None | Empty = empty,
+        # options
+        env: str | Sequence[str] | None | Empty = empty,
+        messages: dict[str, str] | None | Empty = empty,
+        cast: Callable[[Any], Any] | None | Empty = empty,
+        description: str | None | Empty = empty,
+        items_validators: list[BaseValidator] | None = None,
+        # To be implemented, a interface like this to generate a When Validator
+        # when: When | None = empty,
+    ):
+        kwargs = locals()
+        kwargs.pop("cls")
+        return BaseValidator(
+            **{k: v for k, v in kwargs.items() if v is not empty}
+        )
+
+
+class ItemsValidator:
+    """Validates each internal item in a sequence or mapping.
+
+    Validates all integers in a list are >= 10::
+
+        field: Annotated[list[int], ItemsValidator(gte=10)]
+
+    The same as above but reusing validators::
+
+        min_value = Validator(gte=10)
+        max_value = Validator(lte=100)
+        field: Annotated[list[int], ItemsValidator(min_value, max_value)]
+
+    Validates that values of the `port` key is not equal 5432::
+
+        field: Annotated[dict[str, int], ItemsValidator("port", ne=5432)]
+
+    Going down inside a dict of dict::
+
+        field: Annotated[
+            dict[str, dict[str, int]],
+            ItemsValidator(
+                "database",
+                ItemsValidator("port, ne=5432)
+            )
+        ]
+
+    For more complex cases the recommendations is to use `condition=function`::
+
+        def my_value_is_valid(value) -> bool: ...
+
+        field: Annotated[..., Validator(condition=my_value_is_valid)]
+
+    """
+
+    __slots__ = ()
+
+    def __new__(
+        cls,
+        *args,
+        # Operations
+        eq: Any = empty,
+        ne: Any = empty,
+        gt: Any = empty,
+        lt: Any = empty,
+        gte: Any = empty,
+        lte: Any = empty,
+        identity: Any = empty,
+        is_in: Any = empty,
+        is_not_in: Any = empty,
+        contains: Any = empty,
+        not_contains: Any = empty,
+        len_eq: Any = empty,
+        len_ne: Any = empty,
+        len_min: Any = empty,
+        len_max: Any = empty,
+        startswith: Any = empty,
+        endswith: Any = empty,
+        not_startswith: Any = empty,
+        not_endswith: Any = empty,
+        regex: Any = empty,
+        not_regex: Any = empty,
+        condition: Callable[[Any], bool] | None | Empty = empty,
+        # options
+        env: str | Sequence[str] | None | Empty = empty,
+        messages: dict[str, str] | None | Empty = empty,
+        cast: Callable[[Any], Any] | None | Empty = empty,
+        description: str | None | Empty = empty,
+        items_validators: list[BaseValidator] | None = None,
+        # To be implemented, a interface like this to generate a When Validator
+        # when: When | None = empty,
+    ):
+        kwargs = locals()
+        kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if v is not empty and k not in ("cls", "args", "items_validators")
+        }
+        if items_validators:
+            kwargs["items_validators"] = items_validators
+
+        validators = [arg for arg in args if isinstance(arg, BaseValidator)]
+        if kwargs:
+            names = [arg for arg in args if isinstance(args, str)]
+            validators.append(BaseValidator(*names, **kwargs))
+        return BaseValidator(items_validators=validators)
+
+
+# Utilities
+# Inspired by the module annotated_types
+
+
+class Not(BaseValidator):
+    """Inverts a Validator
+
+    field: Annotated[int, Not(Eq(10))]
+    # actually the same as
+    field: Annotated[int, Ne(10)]
+    # but for SpecifiedOperations is much more semantic
+    field: Annotated[str, Not(IsUrl())]
+    """
+
+    _validator: BaseValidator
+
+    def __init__(self, validator: BaseValidator):
+        self._validator = validator
+
+    def validate(self, *args, **kwargs):
+        self._validator.names = self.names
+        try:
+            # triggers validation of wrapped validator
+            self._validator.validate(*args, **kwargs)
+        except ValidationError:
+            # If it fails then it is ok!
+            return
+
+        # If not fails, than it is an error
+        raise ValidationError(f"Not({self._validator}) failed.")
+
+    def __getattr__(self, name):
+        return getattr(self._validator, name)
+
+
+# Generic Validation Aliases
+
+
+class GenericParametrizedOperation:
+    """Base to create aliased Validator with generic parametrized operation.
+
+    This class exists mainly to allow creation of semantic named validators.
+
+    Usage::
+
+      class NoWayItIs(GenericOperation):
+          op_name = "eq"
+
+      field: Annotated[T, NoWatItIs("pineapple")]
+
+    Which is equivalent to::
+
+      field: Annotatted[T, Validator(ne="pineapple")]
+
+    Non parametrized alternative would be::
+
+      NoWayItIsPineApple = Validator(ne="pineapple")
+      field: Annotated[T, NoWayItIsPineApple]
+
+    """
+
+    def __new__(cls, op_value):
+        kwargs = {cls.op_name: op_value}
+        return Validator(**kwargs)
+
+
+class Eq(GenericParametrizedOperation):
+    """Eq(x) -> Validator(eq=x)"""
+
+    op_name = "eq"
+
+
+class Ne(GenericParametrizedOperation):
+    """Ne(x) -> Validator(ne=x)"""
+
+    op_name = "ne"
+
+
+class Gt(GenericParametrizedOperation):
+    """Gt(x) -> Validator(gt=x)"""
+
+    op_name = "gt"
+
+
+class Lt(GenericParametrizedOperation):
+    """Lt(x) -> Validator(lt=x)"""
+
+    op_name = "lt"
+
+
+class Gte(GenericParametrizedOperation):
+    """Gte(x) -> Validator(gte=x)"""
+
+    op_name = "gte"
+
+
+class Lte(GenericParametrizedOperation):
+    """Lte(x) -> Validator(lte=x)"""
+
+    op_name = "lte"
+
+
+class Id(GenericParametrizedOperation):
+    """Id(x) -> Validator(identity=x)"""
+
+    op_name = "identity"
+
+
+class In(GenericParametrizedOperation):
+    """In(x) -> Validator(is_in=x)"""
+
+    op_name = "is_in"
+
+
+class NotIn(GenericParametrizedOperation):
+    """NotIn(x) -> Validator(is_not_in=x)"""
+
+    op_name = "is_not_in"
+
+
+class Contains(GenericParametrizedOperation):
+    """Contains(x) -> Validator(contains=x)"""
+
+    op_name = "contains"
+
+
+class NotContains(GenericParametrizedOperation):
+    """NotContains(x) -> Validator(not_contains=x)"""
+
+    op_name = "not_contains"
+
+
+class LenEq(GenericParametrizedOperation):
+    """LenEq(x) -> Validator(len_eq=x)"""
+
+    op_name = "len_eq"
+
+
+class LenNe(GenericParametrizedOperation):
+    """LenNe(x) -> Validator(len_ne=x)"""
+
+    op_name = "len_ne"
+
+
+class LenMin(GenericParametrizedOperation):
+    """LenMin(x) -> Validator(len_min=x)"""
+
+    op_name = "len_min"
+
+
+class LenMax(GenericParametrizedOperation):
+    """LenMax(x) -> Validator(len_max=x)"""
+
+    op_name = "len_max"
+
+
+class Starts(GenericParametrizedOperation):
+    """Starts(x) -> Validator(startswith=x)"""
+
+    op_name = "startswith"
+
+
+class Ends(GenericParametrizedOperation):
+    """Ends(x) -> Validator(endswith=x)"""
+
+    op_name = "endswith"
+
+
+class NotStarts(GenericParametrizedOperation):
+    """NotStarts(x) -> Validator(not_startswith=x)"""
+
+    op_name = "not_startswith"
+
+
+class NotEnds(GenericParametrizedOperation):
+    """NotEnds(x) -> Validator(not_endswith=x)"""
+
+    op_name = "not_endswith"
+
+
+class Regex(GenericParametrizedOperation):
+    """Regex(x) -> Validator(regex=x)"""
+
+    op_name = "regex"
+
+
+class NotRegex(GenericParametrizedOperation):
+    """NotRegex(x) -> Validator(not_regex=x)"""
+
+    op_name = "not_regex"
+
+
+class Condition(GenericParametrizedOperation):
+    """Condition(x) -> Validator(condition=x)"""
+
+    op_name = "condition"
+
+
+# Custom Validation Aliases
+# The aliases defined here are mostly examples
+# users can create their own aliases for domain specific validation.
+
+
+class CustomOperation:
+    """Base to create custom non-parametrized operations.
+
+    This base class is useful when the operation and parameters are constant.
+
+    Usage::
+
+        class IsAFruitILike(CustomOperation):
+            op_name = "is_in"
+            op_value = ["banana", "apple", "lemon", "orange"]
+
+            fruit: Annotated[str, IsAFruitILike()]  # callable
+
+    Which is equivalent to::
+
+       IsAFruitILike = Validator(is_in=["banana", "apple", "lemon", "orange"])
+       fruit: Annotated[str, IsAFruitILike]  # not callable
+
+    However simply assigning the validator to a variable doesnt allow for
+    inheritance and doesn't create a callable object, being a callable object
+    is useful to keep the possibility to accept arguments if needed without
+    breaking compatibility.
+    """
+
+    def __new__(cls):
+        kwargs = {cls.op_name: cls.op_value}
+        return Validator(**kwargs)
+
+
+class IsUrl(CustomOperation):
+    """IsUrl(x) -> Validator(regex=url_pattern)"""
+
+    op_name = "regex"
+    op_value = (
+        r"((http|https)://)"  # Match the protocol (http or https) required
+        r"(www\.)?"  # Match 'www.' optionally
+        r"[\w.-]+"  # Match the domain name
+        r"\.[a-z]{2,}"  # Match the top-level domain
+        r"(/[^\s]*)?"  # Match the path (everything after the domain name)
+    )
+
+
+class IsConnectionString(CustomOperation):
+    op_name = "regex"
+    op_value = (
+        r"^(?P<scheme>postgresql|mysql|sqlite):\/\/"
+        r"(?:(?P<user>[^:]+):"
+        r"(?P<password>[^@]+)@)?"
+        r"(?P<host>[^:\/]+)?"
+        r"(?::(?P<port>\d+))?"
+        r"\/(?P<path>[^\s]+)$"
+    )
+
+
+class IsSemVer(CustomOperation):
+    op_name = "regex"
+    op_value = (
+        r"^(\d+)\.(\d+)\.(\d+)"
+        r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+        r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+    )
+
+
+class PositiveInt(CustomOperation):
+    op_name = "gt"
+    op_value = 0
+
+
+class NegativeInt(CustomOperation):
+    op_name = "lt"
+    op_value = 0

--- a/dynaconf/validator_conditions.py
+++ b/dynaconf/validator_conditions.py
@@ -5,6 +5,7 @@ Implement basic assertions to be used in assertion action
 
 from __future__ import annotations
 
+import re
 from typing import get_args
 from typing import get_origin
 from typing import Union
@@ -17,42 +18,42 @@ except ImportError:
 # /NOTE
 
 
-def eq(value, other):
-    """Equal"""
+def eq(value, other) -> bool:
+    """Equals"""
     return value == other
 
 
-def ne(value, other):
-    """Not equal"""
+def ne(value, other) -> bool:
+    """Not equals"""
     return value != other
 
 
-def gt(value, other):
+def gt(value, other) -> bool:
     """Greater than"""
     return value > other
 
 
-def lt(value, other):
+def lt(value, other) -> bool:
     """Lower than"""
     return value < other
 
 
-def gte(value, other):
+def gte(value, other) -> bool:
     """Greater than or equal"""
     return value >= other
 
 
-def lte(value, other):
+def lte(value, other) -> bool:
     """Lower than or equal"""
     return value <= other
 
 
-def identity(value, other):
+def identity(value, other) -> bool:
     """Identity check using ID"""
     return value is other
 
 
-def is_type_of(value, other):
+def is_type_of(value, other) -> bool:
     """Type check that performs lookup on parameterized generic types.
     For singular primary types this check is very fast ans just
     calls isinstance.
@@ -89,46 +90,78 @@ def is_type_of(value, other):
     return isinstance(value, other)
 
 
-def is_in(value, other):
+def is_in(value, other) -> bool:
     """Existence"""
     return value in other
 
 
-def is_not_in(value, other):
+def is_not_in(value, other) -> bool:
     """Inexistence"""
     return value not in other
 
 
-def cont(value, other):
+def contains(value, other) -> bool:
     """Contains"""
     return other in value
 
 
-def len_eq(value, other):
+cont = contains  # backwards compatibility
+
+
+def not_contains(value, other) -> bool:
+    """Not Contains"""
+    return other not in value
+
+
+def len_eq(value, other) -> bool:
     """Length Equal"""
     return len(value) == other
 
 
-def len_ne(value, other):
+def len_ne(value, other) -> bool:
     """Length Not equal"""
     return len(value) != other
 
 
-def len_min(value, other):
+def len_min(value, other) -> bool:
     """Minimum length"""
     return len(value) >= other
 
 
-def len_max(value, other):
+def len_max(value, other) -> bool:
     """Maximum length"""
     return len(value) <= other
 
 
-def startswith(value, term):
+def startswith(value, term) -> bool:
     """returns value.startswith(term) result"""
     return value.startswith(term)
 
 
-def endswith(value, term):
+def endswith(value, term) -> bool:
     """returns value.endswith(term) result"""
     return value.endswith(term)
+
+
+def not_startswith(value, term) -> bool:
+    """returns not value.startswith(term) result"""
+    return not value.startswith(term)
+
+
+def not_endswith(value, term) -> bool:
+    """returns not value.endswith(term) result"""
+    return not value.endswith(term)
+
+
+def regex(value, pattern: str | re.Pattern) -> bool:
+    """Matches a regexp against the value"""
+    if isinstance(pattern, str):
+        pattern = re.compile(pattern)
+    return bool(pattern.match(value))
+
+
+def not_regex(value, pattern: str | re.Pattern) -> bool:
+    """Not Matches a regexp against the value"""
+    if isinstance(pattern, str):
+        pattern = re.compile(pattern)
+    return not pattern.match(value)

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -98,7 +98,7 @@ def test_annotated_with_dictvalue():
 
     class Settings(Dynaconf):
         # This is not allowed, should add validators on the dictvalue type itself
-        plug: Annotated[Plugin, Validator(cont="name")]
+        plug: Annotated[Plugin, Validator(contains="name")]
 
     msg = "plug.name must is_type_of.+Union\[str, int]"
     with pytest.raises(ValidationError, match=msg):
@@ -567,7 +567,7 @@ def test_extracted_validators_from_annotated(monkeypatch):
         name: Annotated[str, Validator(ne="Valdemort")]
         age: int
         team: str = "Default"
-        colors: Annotated[list, Validator(cont="red")]
+        colors: Annotated[list, Validator(contains="red")]
         port: Annotated[int, Validator(lt=1000), Validator(gt=10)]
         url: Annotated[str, Validator(cast=cast_url)]
         auth: Annotated[dict, Validator(condition=auth_condition)]
@@ -602,7 +602,7 @@ def test_extracted_validators_from_annotated(monkeypatch):
         },
         {
             "names": ("colors",),
-            "operations": {"cont": "red"},
+            "operations": {"contains": "red"},
         },
         {
             "names": ("port",),
@@ -647,7 +647,7 @@ def test_extracted_validators_from_annotated(monkeypatch):
         },
         {
             "names": ("fruits",),
-            "items_validators": (not_banana,),
+            "items_validators": [not_banana],
         },
     ]
 
@@ -938,7 +938,7 @@ def test_list_enclosed_type_annotated():
     # Annotated with Validator
     class Settings(Dynaconf):
         dynaconf_options = Options(_trigger_validation=False)
-        colors: Annotated[list[str], Validator(cont="red")]
+        colors: Annotated[list[str], Validator(contains="red")]
 
     Settings(colors=["red"])
     with pytest.raises(
@@ -948,12 +948,12 @@ def test_list_enclosed_type_annotated():
         Settings(colors=1).validators.validate()
     with pytest.raises(
         ValidationError,
-        match="Invalid Operation 'cont' for type <class 'int'> on 'colors'",
+        match="Invalid Operation 'contains' for type <class 'int'> on 'colors'",
     ):
         Settings(colors=1).validators.validate_all()
     with pytest.raises(
         ValidationError,
-        match="colors must cont red",
+        match="colors must contains red",
     ):
         Settings(colors=[]).validators.validate()
 
@@ -961,7 +961,7 @@ def test_list_enclosed_type_annotated():
 def test_list_enclosed_type_annotated_with_union():
     # Annotated and Unionized
     class Settings(Dynaconf):
-        colors: Annotated[Union[list[str], str], Validator(cont="blue")]
+        colors: Annotated[Union[list[str], str], Validator(contains="blue")]
 
     Settings(colors=["blue"])
     with pytest.raises(
@@ -971,7 +971,7 @@ def test_list_enclosed_type_annotated_with_union():
         Settings(colors=1)
     with pytest.raises(
         ValidationError,
-        match="colors must cont blue",
+        match="colors must contains blue",
     ):
         Settings(colors=[])
 
@@ -980,7 +980,7 @@ def test_list_enclosed_type_annotated_with_union():
 def test_list_enclosed_type_annotated_with_new_union():
     # Annotated and Unionized
     class Settings(Dynaconf):
-        colors: Annotated[list[str] | str, Validator(cont="blue")]
+        colors: Annotated[list[str] | str, Validator(contains="blue")]
 
     Settings(colors=["blue"])
     with pytest.raises(
@@ -990,7 +990,7 @@ def test_list_enclosed_type_annotated_with_new_union():
         Settings(colors=1)
     with pytest.raises(
         ValidationError,
-        match="colors must cont blue",
+        match="colors must contains blue",
     ):
         Settings(colors=[])
 
@@ -999,7 +999,7 @@ def test_list_enclosed_type_annotated_with_union_nested():
     # Annotated and Unionized with Nesting Union (python will flatten it)
     class Settings(Dynaconf):
         colors: Annotated[
-            Union[list[Union[str, int]], str], Validator(cont="green")
+            Union[list[Union[str, int]], str], Validator(contains="green")
         ]
 
     Settings(colors=["green"])
@@ -1010,7 +1010,7 @@ def test_list_enclosed_type_annotated_with_union_nested():
         Settings(colors=1)
     with pytest.raises(
         ValidationError,
-        match="colors must cont green",
+        match="colors must contains green",
     ):
         Settings(colors=[])
 
@@ -1020,7 +1020,7 @@ def test_list_enclosed_type_with_more_complex_unions():
     class Settings(Dynaconf):
         colors: Annotated[
             Union[list[Union[str, int]], str, Union[str, int]],
-            Validator(cont="purple"),
+            Validator(contains="purple"),
         ]
 
     Settings(colors=["purple"])
@@ -1031,7 +1031,7 @@ def test_list_enclosed_type_with_more_complex_unions():
         Settings(colors=4.2)
     with pytest.raises(
         ValidationError,
-        match="colors must cont purple",
+        match="colors must contains purple",
     ):
         Settings(colors=[])
 
@@ -1043,7 +1043,7 @@ def test_list_enclosed_type_crazy_type():
     ]
 
     class Settings(Dynaconf):
-        colors: Annotated[crazy_type, Validator(cont="pink")]
+        colors: Annotated[crazy_type, Validator(contains="pink")]
 
     Settings(colors=["pink"])
     with pytest.raises(
@@ -1053,7 +1053,7 @@ def test_list_enclosed_type_crazy_type():
         Settings(colors=4.2)
     with pytest.raises(
         ValidationError,
-        match="colors must cont pink",
+        match="colors must contains pink",
     ):
         Settings(colors=[])
 
@@ -1061,7 +1061,7 @@ def test_list_enclosed_type_crazy_type():
 def test_list_enclosed_type_annotated_notrequired():
     # NotRequired
     class Settings(Dynaconf):
-        colors: Annotated[NotRequired[list[str]], Validator(cont="yellow")]
+        colors: Annotated[NotRequired[list[str]], Validator(contains="yellow")]
 
     Settings()
     with pytest.raises(
@@ -1071,7 +1071,7 @@ def test_list_enclosed_type_annotated_notrequired():
         Settings(colors=[1, 2, 3])
     with pytest.raises(
         ValidationError,
-        match="colors must cont yellow",
+        match="colors must contains yellow",
     ):
         Settings(colors=["red"])
 
@@ -1096,7 +1096,7 @@ def test_list_enclosed_type_with_default():
     ]
 
     class Settings(Dynaconf):
-        colors: Annotated[crazy_type, Validator(cont="cyan")] = ["cyan", 1]
+        colors: Annotated[crazy_type, Validator(contains="cyan")] = ["cyan", 1]
 
     assert Settings().colors == ["cyan", 1]
 
@@ -1187,7 +1187,7 @@ def test_usage_of_dict_value():
         # covered
         number: int = 99
         person: Person = {"profile": {"username": "aaa", "group": 2}}
-        contact: Annotated[Person, Validator(cont="name")]
+        contact: Annotated[Person, Validator(contains="name")]
         person_optional: Optional[Person] = None
         person_default: Person = Person(
             name="Person With Defaults",

--- a/tests_functional/typed/typed_with_dotenv_toml_secrets_validator_condition/app.py
+++ b/tests_functional/typed/typed_with_dotenv_toml_secrets_validator_condition/app.py
@@ -4,6 +4,7 @@ assert settings.title == "My Awesome App"
 assert settings.api_prefix == "https://my-great-api"
 assert "admin" in settings.middlewares
 assert settings.database.host == "postgres.com"
+assert settings.database.port == 5433, settings.database.port
 assert len(settings.plugins) == 3
 assert settings.get("flags.power_mode") is True
 assert settings.static_url.startswith("http")

--- a/tests_functional/typed/typed_with_dotenv_toml_secrets_validator_condition/settings.toml
+++ b/tests_functional/typed/typed_with_dotenv_toml_secrets_validator_condition/settings.toml
@@ -4,7 +4,9 @@ middlewares= ["new.plugin", "admin"]
 static_url = "https://static.site.com/"
 
 [database]
+dynaconf_merge = true
 host = "postgres.com"
+conn = "@format postgresql://user:password@{this.database.host}:{this.database.port}/database"
 
 [flags]
 ui_enabled = true


### PR DESCRIPTION
Inspired by the module https://github.com/annotated-types/annotated-types added some better named validators.

Also reorganized validation objects under typed/validators.py

```python
from typing import Annotated
from dynaconf.typed import Dynaconf
from dynaconf.typed.validators import Eq, Contains, IsUrl, Regex, Not

class Settings(Dynaconf):
    fruit: Annotated[str, Not(Eq("banana"))]
    static_url: Annotated[str, IsUrl()]
    version: Annotated[str, Regex(r"^(\d+).(\d+).(\d+)$")]
    colors: Annotated[list[str], Contains("red")]
```

all the above are just aliases, which is equivalent to

```python
from typing import Annotated
from dynaconf.typed import Dynaconf, Validator

class Settings(Dynaconf):
    fruit: Annotated[str, Validator(ne="banana"))]
    static_url: Annotated[str, Validator(regex=r"((http|https)://)...")]
    version: Annotated[str, Validator(regex=r"^(\d+).(\d+).(\d+)$")]
    colors: Annotated[list[str], Validator(contains="red")]
```
