### PR TITLE
docs(hook):Add documentation and example of Access Hooks

### DIFF
--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -183,6 +183,10 @@ NOTES:
 - This may introduce overhead dependending on how the hook function is
     implemented
 
+To register an access hook, you need to wrap the `Dynaconf` instance with
+`HookableSettings` and pass a `Action` to `Hook` mapping in to the constructor
+in the `_registered_hooks` kwarg. For example,
+
 ```python
 # So you have a function that retrieves data from external source
 

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -237,8 +237,9 @@ assert settings.token == "lets believe it was retrieved from special place"
 ### Merging with access hooks
 
 When the `result.value` is a mergeable data structure like `dict` or `list`
-and you want the merging to be applied then the hook must use the `settings`
-to wrap the result value and process the merging before returning.
+and you want the merging to be applied, then the hook must delegate the merging
+to the given `settings` by `set`ing the result (which will perform the merging)
+and returning the result of `get`ing the setting from the given `settings`.
 
 ```py
 def get_data_from_somewhere(settings, result, key, *args, **kwargs):

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -177,10 +177,11 @@ cloud provider's secrets managers, or when you need special processing on top
 of raw values (such as decrypting an encrypted value).
 
 NOTES:
-   - You must define the logic of each hook, dynaconf just calls it
-   - You must take care of caching and caching invalidation
-   - This may introduce overhead dependending on how the hook function is
-      implemented
+
+- You must define the logic of each hook, dynaconf just calls it
+- You must take care of caching and caching invalidation
+- This may introduce overhead dependending on how the hook function is
+    implemented
 
 ```python
 # So you have a function that retrieves data from external source

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -194,8 +194,17 @@ CACHE = {}  # could be Redis
 
 def get_data_from_somewhere(settings, result, key, *args, **kwargs):
     """Your function that goes to external service like gcp, aws, vault, etc
-    NOTE: settings in this context is copy of settings, changes made are
-    valid only during the scope of this function.
+
+    Parameters:
+        settings: A copy of settings, changes made are valid only during the
+            scope of this function.
+        result: The object that holds the setting known to Dynaconf at the
+            moment of access in the .value attribute.
+        key: The accessed key just as passed to Dynaconf.get, usually a
+            single str, but if the requested key was dotted then the whole
+            path is passed to this function.
+        *args and **kwargs: extra positional or named arguments passed to .get
+            such as default,cast,fresh,parent etc.
     """
     if key in CACHE:
         return CACHE[key]
@@ -218,7 +227,7 @@ from dynaconf.hooking import HookableSettings, Hook, Action
 settings = Dynaconf(
     # set the Hookable wrapper class
     _wrapper_class=HookableSettings,
-    # Register your hooks, you can have AFTER_GET, BEFORE_GET
+    # Register your hooks, see the Action enum for available values
     # you can have multiple hooks, value passes from one to another
     _registered_hooks={
        Action.AFTER_GET: [Hook(get_data_from_somewhere)]

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -169,14 +169,12 @@ malformed expression, it is recommended to add validators.
 
 ## Access Hooks
 
-Dynaconf can be configured to retrieve a special variable from an external
-storage such as GCP or AWS secrets or a Vault server or even a secret located
-on the filesystem or encrypted.
+Dynaconf supports access hooks, which allow the user to register functions that
+will be called each time a variable is accessed on a `Dynaconf` instance.
 
-This works by registering a function hook that will be called for every variable
-access on Dynaconf.
-
-This feature is useful to load settings from BitWarden and other secret managers.
+This feature is useful to load settings from external sources, such as from
+cloud provider's secrets managers, or when you need special processing on top
+of raw values (such as decrypting an encrypted value).
 
 NOTES:
    - You must define the logic of each hook, dynaconf just calls it

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -165,3 +165,60 @@ other_number = "@get number @int 12"
 
 The `@get` is lazily evaluated and subject to `DynaconfFormatError` in case of
 malformed expression, it is recommended to add validators.
+
+
+## Access Hooks
+
+Dynaconf can be configured to retrieve a special variable from an external
+storage such as GCP or AWS secrets or a Vault server or even a secret located
+on the filesystem or encrypted.
+
+This feature is useful to load settings from BitWarden and other secret managers.
+
+NOTES:
+   - You must define the logic of each hook, dynaconf just calls it
+   - You must take care of caching and caching invalidation
+
+```python
+# So you have a function that retrieves data from external source
+
+CACHE = {}  # could be Redis
+
+def get_data_from_somewhere(settings, result, key, *args, **kwargs):
+    """Your function that goes to external service like gcp, aws, vault, etc"""
+    # result.value is 'special:/foo/bar:token'
+    if key in CACHE:
+        return CACHE[key]
+
+    if isinstance(result.value, str) and result.value.startswith("@special:"):
+        _, path, key = result.value.split(":")
+        # value = get_value_from_special_place(path, key)
+        value = CACHE[key] = "lets believe it was retrieved from special place"
+        return value
+
+    return result
+
+# ---
+
+from dynaconf import Dynaconf
+from dynaconf.hooking import HookableSettings, Hook, Action
+
+# Create a Dynaconf instance
+settings = Dynaconf(
+    # set the Hookable wrapper class
+    _wrapper_class=HookableSettings,
+    # Register your hooks, you can have AFTER_GET, BEFORE_GET
+    # you can have multiple hooks, value passes from one to another
+    _registered_hooks={
+       Action.AFTER_GET: [Hook(get_data_from_somewhere)]
+    },
+)
+
+# this value can actually come from settings files or envvars
+settings.set("token", "@special:/vault/path:token")
+
+assert settings.token == "lets believe it was retrieved from special place"
+
+# from cache this time
+assert settings.token == "lets believe it was retrieved from special place"
+```

--- a/tests_functional/legacy/hooking/app.py
+++ b/tests_functional/legacy/hooking/app.py
@@ -1,0 +1,43 @@
+# So you have a function that retrieves data from external source
+
+CACHE = {}  # could be Redis
+
+
+def get_data_from_somewhere(settings, result, key, *args, **kwargs):
+    """Your function that goes to external service like gcp, aws, vault, etc"""
+    # result.value is 'special:/foo/bar:token'
+    if key in CACHE:
+        return CACHE[key]
+
+    if isinstance(result.value, str) and result.value.startswith("@special:"):
+        _, path, key = result.value.split(":")
+        # value = get_value_from_special_place(path, key)
+        value = CACHE[key] = "lets believe it was retrieved from special place"
+        return value
+
+    return result
+
+
+# ---
+
+from dynaconf import Dynaconf
+from dynaconf.hooking import Action
+from dynaconf.hooking import Hook
+from dynaconf.hooking import HookableSettings
+
+# Create a Dynaconf instance
+settings = Dynaconf(
+    # set the Hookable wrapper class
+    _wrapper_class=HookableSettings,
+    # Register your hooks, you can have AFTER_GET, BEFORE_GET
+    # you can have multiple hooks, value passes from one to another
+    _registered_hooks={Action.AFTER_GET: [Hook(get_data_from_somewhere)]},
+)
+
+# this value can actually come from settings files or envvars
+settings.set("token", "@special:/vault/path:token")
+
+assert settings.token == "lets believe it was retrieved from special place"
+
+# from cache this time
+assert settings.token == "lets believe it was retrieved from special place"


### PR DESCRIPTION
fix #1095

feature added on 3.2.2 https://github.com/dynaconf/dynaconf/releases/tag/3.2.2

## Access Hooks

Dynaconf can be configured to retrieve a special variable from an external
storage such as GCP or AWS secrets or a Vault server or even a secret located
on the filesystem or encrypted.

This works by registering a function hook that will be called for every variable
access on Dynaconf.

This feature is useful to load settings from BitWarden and other secret managers.

NOTES:
   - You must define the logic of each hook, dynaconf just calls it
   - You must take care of caching and caching invalidation
   - This may introduce overhead dependending on how the hook function is
      implemented

```python
# So you have a function that retrieves data from external source

CACHE = {}  # could be Redis

def get_data_from_somewhere(settings, result, key, *args, **kwargs):
    """Your function that goes to external service like gcp, aws, vault, etc
    NOTE: settings in this context is copy of settings, changes made are
    valid only during the scope of this function.
    """
    if key in CACHE:
        return CACHE[key]

    # Assuming result.value is '@special:/foo/bar:token'
    if isinstance(result.value, str) and result.value.startswith("@special:"):
        _, path, identifier = result.value.split(":")
        # value = get_value_from_special_place(path, identifier)
        value = CACHE[key] = "lets believe it was retrieved from special place"
        return value

    return result

# ---

from dynaconf import Dynaconf
from dynaconf.hooking import HookableSettings, Hook, Action

# Create a Dynaconf instance
settings = Dynaconf(
    # set the Hookable wrapper class
    _wrapper_class=HookableSettings,
    # Register your hooks, you can have AFTER_GET, BEFORE_GET
    # you can have multiple hooks, value passes from one to another
    _registered_hooks={
       Action.AFTER_GET: [Hook(get_data_from_somewhere)]
    },
)

# this value can actually come from settings files or envvars
settings.set("token", "@special:/vault/path:token")

assert settings.token == "lets believe it was retrieved from special place"

# from cache this time
assert settings.token == "lets believe it was retrieved from special place"
```

### Merging with access hooks

When the `result.value` is a mergeable data structure like `dict` or `list`
and you want the merging to be applied then the hook must use the `settings`
to wrap the result value and process the merging before returning.

```py
def get_data_from_somewhere(settings, result, key, *args, **kwargs):
    """Your function that goes to external service like gcp, aws, vault, etc
    NOTE: settings in this context is copy of settings, changes made are
    valid only during the scope of this function.
    """
    if key in CACHE:
        return CACHE[key]

    ...

    interesting_keys = ["foo", "bar", "zaz"]  # known to be dicts or lists
    if key in interesting_keys:
      value = CACHE[key] = get_value_from_special_place(key)
      settings.set(key, value)  # process merging and parsing
      return settings.get(key, result.value)

    return result
```


### Registering Hooks After Dynaconf is instantiated

It is ok to register hooks later, which might be useful to do it conditionally.


```py
if something:
    settings.set("_registered_hooks", {Action.AFTER_GET: [Hook(....)]})
```

It also works if you use `dynaconf_hooks.py` to register it conditionally.

```py
# dynaconf_hooks.py
def post(settings):
    data = {}
    if settings.something:
        data["_registered_hooks"] = {Action.AFTER_GET: [Hook(....)]}
    return data
```