### PR TITLE
fix(hooks):Improve performance of Access Hooks

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -241,9 +241,10 @@ class Settings:
         self._deleted = set()
 
         if kwargs.get("DYNABOXIFY", True):
-            self._store = DynaBox(box_settings=self)
+            default_store = DynaBox(box_settings=self)
         else:
-            self._store = {}  # Disabled dot access
+            default_store = {}  # Disabled dot access
+        self._store = kwargs.pop("_store", default_store)
 
         self._env_cache = {}
         self._loaded_by_loaders: dict[SourceMetadata | str, Any] = {}

--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -56,6 +56,13 @@ class DynaBox(Box):
             n_item = find_the_correct_casing(item, self) or item
             return super().__getitem__(n_item, *args, **kwargs)
 
+    def _safe_copy(self):
+        """Copy bypassing lazy evaluation"""
+        return self.__class__(
+            {k: self._safe_get(k) for k in self.keys()},
+            box_settings=self._box_config.get("box_settings"),
+        )
+
     def __copy__(self):
         return self.__class__(
             super(Box, self).copy(),


### PR DESCRIPTION
Aplied the same fix of 3.2.6 to avoid overhead on access hooks.

Summary:

With a `function` as `_registered_hooks` every time a key is accessed on `settings`
the `function` is invoked passing a `settings` object as first argument.

BEFORE:

The `settings` passed to the hook was instantiated for every call.

AFTER:

The `settings` is now a `TempSettingsHolder` that has no effect on passing
and is instantiated only if accessed.

Saved execution time from 0m49 to 0m3 on a Django openapi spec view.
