### PR TITLE
fix: del attr wouldnt work with lowercase

### DIFF
--- a/dynaconf/utils/functional.py
+++ b/dynaconf/utils/functional.py
@@ -63,7 +63,7 @@ class LazyObject:
             raise TypeError(f"can't delete {name}.")
         if self._wrapped is empty:
             self._setup()
-        delattr(self._wrapped, name)
+        delattr(self._wrapped, name.upper())
 
     def _setup(self):
         """

--- a/dynaconf/vendor/box/box.py
+++ b/dynaconf/vendor/box/box.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Union, Tuple, List, Dict
 
 from dynaconf.vendor import box
+from dynaconf.utils import find_the_correct_casing
 from .converters import (_to_json, _from_json, _from_toml, _to_toml, _from_yaml, _to_yaml, BOX_PARAMETERS)
 from .exceptions import BoxError, BoxKeyError, BoxTypeError, BoxValueError, BoxWarning
 
@@ -402,7 +403,7 @@ class Box(dict):
                     if _camel_killer(key) == each_key:
                         key = each_key
                         break
-        super().__delitem__(key)
+        super().__delitem__(find_the_correct_casing(key, self))
 
     def __delattr__(self, item):
         if self._box_config['frozen_box']:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,7 +22,7 @@ pytest
 pytest-cov
 pytest-mock
 commentjson
-lovely-pytest-docker
+pytest-docker
 tox
 
 # style check

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,6 +25,26 @@ def test_deleted_raise(settings):
     assert settings.exists("TODELETE") is False
     assert settings.get("TODELETE") is None
 
+    # case: del using lowercase when original was mixed-case
+    settings.ToDelete3 = True
+    assert "ToDelete3" in settings
+    assert settings.TODELETE3 is True
+    del settings.todelete3
+    with pytest.raises(AttributeError):
+        assert settings.TODELETE3 is True
+    assert settings.exists("TODELETE3") is False
+    assert settings.get("TODELETE3") is None
+
+    # case: del nested item
+    settings.set("Abc.Xyz.Uv", 123)
+    assert settings.abc.xyz.uv == 123
+    del settings.abc.xyz.uv
+    with pytest.raises(AttributeError):
+        assert settings.abc.xyz.uv == 123
+    assert settings.exists("abc.xyz") is True
+    assert settings.exists("abc.xyz.uv") is False
+    assert settings.get("abc.xyz.uv") is None
+
 
 def test_delete_and_set_again(settings):
     """asserts variable can be deleted and set again"""


### PR DESCRIPTION
Closes #1042 

Notes:
* The first level is always uppercase internally and calling del with different case attr-name would fail.
* Currently we only support deleting a nested level item with exact matching (not sure if needs "fixing").