### PR TITLE
Fix get_history behavior regarding lazy values

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -23,7 +23,7 @@ FlaskDynaconf(app)
 
 Dynaconf transform nested data structures to a new DynaBox instance, this is an
 object that allows dot notation access such as `app.config.key.value.other`.
-However this feature is imcompatible with some Flask extensions, for example:
+However this feature is incompatible with some Flask extensions, for example:
 `Flask-Alembic`.
 
 So in case you see a `BoxKeyError` when running your app with you can run it on


### PR DESCRIPTION
get_history() should provide the original representation, so the user can reliably inspect its data.
The evaluted value might be hard to track and potentially confusing to inspect.

Closes #1180

> [!NOTE]
> This should be backported to the 3.2.6 stream branch so it can be released before 3.3.0