### PR TITLE
Implement `__delitem__` method for base Settings

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -319,6 +319,10 @@ class Settings:
         if hasattr(self, name):
             super().__delattr__(name)
 
+    def __delitem__(self, name):
+        self._deleted.add(name)
+        self.set(name, "@del")
+
     def __contains__(self, item):
         """Respond to `item in settings`"""
         return item.upper() in self.store or item.lower() in self.store

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,7 +15,6 @@ from dynaconf.utils.parse_conf import true_values
 from dynaconf.vendor.box.box_list import BoxList
 
 
-@pytest.mark.xfail(raises=AttributeError, reason="AttributeError: __delitem__")
 def test_deleted_raise(settings):
     """asserts variable can be deleted"""
     assert "TODELETE" in settings

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,6 +15,7 @@ from dynaconf.utils.parse_conf import true_values
 from dynaconf.vendor.box.box_list import BoxList
 
 
+@pytest.mark.xfail(raises=AttributeError, reason="AttributeError: __delitem__")
 def test_deleted_raise(settings):
     """asserts variable can be deleted"""
     assert "TODELETE" in settings
@@ -35,7 +36,7 @@ def test_deleted_raise(settings):
     assert settings.exists("TODELETE3") is False
     assert settings.get("TODELETE3") is None
 
-    # case: del nested item
+    # case: del nested attribute
     settings.set("Abc.Xyz.Uv", 123)
     assert settings.abc.xyz.uv == 123
     del settings.abc.xyz.uv
@@ -44,6 +45,26 @@ def test_deleted_raise(settings):
     assert settings.exists("abc.xyz") is True
     assert settings.exists("abc.xyz.uv") is False
     assert settings.get("abc.xyz.uv") is None
+
+    # case: del item
+    settings.TODELETE4 = True
+    assert "TODELETE4" in settings
+    assert settings.TODELETE4 is True
+    del settings["TODELETE4"]
+    with pytest.raises(AttributeError):
+        assert settings.TODELETE4 is True
+    assert settings.exists("TODELETE4") is False
+    assert settings.get("TODELETE4") is None
+
+    # case: del item lowercase when orifinal was mixed-case
+    settings.ToDelete3 = True
+    assert "ToDelete3" in settings
+    assert settings.TODELETE3 is True
+    del settings["todelete3"]
+    with pytest.raises(AttributeError):
+        assert settings.TODELETE3 is True
+    assert settings.exists("TODELETE3") is False
+    assert settings.get("TODELETE3") is None
 
 
 def test_delete_and_set_again(settings):


### PR DESCRIPTION
Add support for deleting items by keyword, by
adding the __delitem__ method to the Settings
class.

This way, users may delete items by doing:
```
del settings["my_key"]
```

As a counterpart to delete only by attribute.