### PR TITLE
fix: Implement repr for combined validators

### DIFF
--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -89,8 +89,8 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
 
     # 1) Create the lazy settings object reusing settings_module consts
     options = {
-        k.upper(): v
-        for k, v in django_settings_module.__dict__.items()
+        k: v
+        for k, v in inspect.getmembers(django_settings_module)
         if k.isupper()
     }
     options.update(kwargs)

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -550,6 +550,12 @@ class CombinedValidator(Validator):
             "subclasses OrValidator or AndValidator implements this method"
         )
 
+    def __repr__(self):
+        result = f"{self.__class__.__name__}("
+        result += ", ".join(repr(v) for v in self.validators)
+        result += ")"
+        return result
+
 
 class OrValidator(CombinedValidator):
     """Evaluates on Validator() | Validator()"""


### PR DESCRIPTION
- Combined Validators was failing with `tuple object has no attr get` because those were using superclass `repr`, implemented a custom repr that combined repr from every validator.
- Replaced use of __dict__ with inspect.getmembers as the use of `__dict__` is not recommended anymore.