### PR TITLE
feat: populate_obj takes convert_to_dict

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -598,6 +598,11 @@ assert obj.VALUE == 42.1  # AttributeError
 - `populate_obj` will take `internals` boolean to enable or disable populating internal settings.
 
 
+**new in 3.2.8**
+
+- `populate_obj` will take `convert_to_dict` boolean to enable or disable converting the settings object to a dict before populating the object, this makes the data structures like Box and BoxList to be converted to the raw dict/list before populating the object.
+
+
 ## Exporting
 
 You can generate a file with current configs by calling `dynaconf list -o /path/to/file.ext` see more in [cli](cli.md)
@@ -610,7 +615,7 @@ from dynaconf import settings
 from dynaconf.utils.boxing import DynaBox
 
 # generates a dict with all the keys for `development` env
-data = settings.as_dict(env='development')
+data = settings.to_dict(env='development')
 
 # writes to a file, the format is inferred by extension
 # can be .yaml, .toml, .ini, .json, .py

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1385,22 +1385,33 @@ class Settings:
             value = self.get_fresh(key)
             return value is True or value in true_values
 
-    def populate_obj(self, obj, keys=None, ignore=None, internal=False):
+    def populate_obj(
+        self,
+        obj,
+        keys=None,
+        ignore=None,
+        internal=False,
+        convert_to_dict=False,
+    ):
         """Given the `obj` populate it using self.store items.
 
         :param obj: An object to be populated, a class instance.
         :param keys: A list of keys to be included.
         :param ignore: A list of keys to be excluded.
+        :param internal: Include internal keys.
+        :param convert_to_dict: Convert the settings to a pure dict (no Box)
+         before populating.
         """
+        data = self.to_dict(internal=internal) if convert_to_dict else self
         keys = keys or self.keys()
         for key in keys:
+            key = upperfy(key)
             if not internal:
                 if key in UPPER_DEFAULT_SETTINGS:
                     continue
-            key = upperfy(key)
             if ignore and key in ignore:
                 continue
-            value = self.get(key, empty)
+            value = data.get(key, empty)
             if value is not empty:
                 setattr(obj, key, value)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,6 +11,7 @@ from dynaconf import Validator
 from dynaconf.loaders import toml_loader
 from dynaconf.loaders import yaml_loader
 from dynaconf.strategies.filtering import PrefixFilter
+from dynaconf.utils.boxing import DynaBox
 from dynaconf.utils.parse_conf import true_values
 from dynaconf.vendor.box.box_list import BoxList
 
@@ -98,6 +99,26 @@ def test_populate_obj_with_ignore(settings):
 
     with pytest.raises(AttributeError):
         assert obj.VALUE == 42.1
+
+
+def test_populate_obj_convert_to_dict(settings):
+    class Obj:
+        pass
+
+    # first make sure regular populate brings in Box and BoxList
+    obj = Obj()
+    settings.populate_obj(obj)
+    assert isinstance(obj.ADICT, DynaBox)
+    assert isinstance(obj.ALIST, BoxList)
+    assert isinstance(obj.ADICT.to_yaml(), str)
+
+    # now make sure convert_to_dict=True brings in dict and list
+    obj = Obj()
+    settings.populate_obj(obj, convert_to_dict=True)
+    assert isinstance(obj.ADICT, dict)
+    assert isinstance(obj.ALIST, list)
+    with pytest.raises(AttributeError):
+        assert isinstance(obj.ADICT.to_yaml(), str)
 
 
 def test_call_works_as_get(settings):


### PR DESCRIPTION
Defaults to false, when set to true makes the
populated keys to not be Box values but Python types.

closes #1227