### PR TITLE
fix: using merge with comma separated values will infer type [port from 3.2.8]

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -133,7 +133,12 @@ class Merge(MetaValue):
                     }
                 elif "," in self.value:
                     # @merge foo,bar
-                    self.value = self.value.split(",")
+                    self.value = [
+                        parse_conf_data(
+                            v, tomlfy=True, box_settings=box_settings
+                        )
+                        for v in self.value.split(",")
+                    ]
                 else:
                     # @merge foo
                     self.value = [self.value]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -469,6 +469,42 @@ def test_set_explicit_merge_token(tmpdir):
     settings.set("b_list", "@merge zaz")
     assert settings.B_LIST == [1, 2, 3, 4, 5, 6.6, False, "foo", "bar", "zaz"]
 
+    settings.set("b_list", "@merge 7, 8, 9")
+    assert settings.B_LIST == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6.6,
+        False,
+        "foo",
+        "bar",
+        "zaz",
+        7,
+        8,
+        9,
+    ]
+    settings.set("b_list", "@merge '10','11','12'")
+    assert settings.B_LIST == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6.6,
+        False,
+        "foo",
+        "bar",
+        "zaz",
+        7,
+        8,
+        9,
+        "10",
+        "11",
+        "12",
+    ]
+
     settings.set("a_dict", "@merge {city='Guarulhos'}")
     assert settings.A_DICT.name == "Bruno"
     assert settings.A_DICT.city == "Guarulhos"


### PR DESCRIPTION


Fix: #1240