### PR TITLE
feat: Add support for decorated hooks on settings files

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -81,6 +81,37 @@ settings = Dynaconf(post_hooks=hook_function)
 You can also set the merging individually for each settings variable as seen on
 [merging](merging.md) documentation.
 
+
+#### Decorator approach
+
+**new in 3.2.8**
+
+When the settings file is a Python file, you can also use a decorator to define hooks.
+
+```python
+from dynaconf import Dynaconf
+
+settings = Dynaconf(settings_file="settings.py")
+```
+
+`settings.py`
+```python
+from dynaconf import post_hook
+
+VARIABLE = "value"
+# all regular settings here
+...
+
+@post_hook
+def set_debugging_database_url(settings):
+    data = {}
+    if settings.DEBUG:
+        data["DATABASE_URL"] = "sqlite://"
+    return data
+```
+
+Dynaconf will collect the decorated functions and execute them after the settings file is loaded.
+
 ## Inspecting History
 
 > **NEW** in version 3.2.0

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -94,8 +94,7 @@ from dynaconf import Dynaconf
 settings = Dynaconf(settings_file="settings.py")
 ```
 
-`settings.py`
-```python
+```python title="settings.py"
 from dynaconf import post_hook
 
 VARIABLE = "value"

--- a/dynaconf/__init__.py
+++ b/dynaconf/__init__.py
@@ -4,6 +4,7 @@ from dynaconf.base import LazySettings
 from dynaconf.constants import DEFAULT_SETTINGS_FILES
 from dynaconf.contrib import DjangoDynaconf
 from dynaconf.contrib import FlaskDynaconf
+from dynaconf.hooking import post_hook
 from dynaconf.utils.inspect import get_history
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.parse_conf import add_converter
@@ -39,4 +40,5 @@ __all__ = [
     "get_history",
     "DynaconfFormatError",
     "DynaconfParseError",
+    "post_hook",
 ]

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1161,6 +1161,10 @@ class Settings:
         """Clean end Execute all loaders"""
         self.clean()
         self._loaded_hooks.clear()
+        for hook in self._post_hooks:
+            with suppress(AttributeError, TypeError):
+                hook._called = False
+
         self.execute_loaders(env, silent)
 
     def execute_loaders(
@@ -1302,6 +1306,9 @@ class Settings:
                             identifier=source_metadata,
                         )
                         already_loaded.add(path)
+
+        # this will call any collected hook that was not called yet
+        execute_instance_hooks(self, "post", self._post_hooks)
 
         # handle param `validate`
         if validate is True:

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -184,3 +184,90 @@ def test_post_load_hooks(clean_env, tmpdir):
             "INSTALLED_APPS": ["dummyplugin"],
         }
     }
+
+
+def test_decorated_hooks(clean_env, tmpdir):
+    # Arrange
+    settings_path = tmpdir.join("settings.py")
+    settings_extra = tmpdir.join("extra.py")
+
+    to_write = {
+        str(settings_path): [
+            "INSTALLED_APPS = ['admin']",
+            "COLORS = ['red', 'green']",
+            "DATABASES = {'default': {'NAME': 'db'}}",
+            "BANDS = ['Rush', 'Yes']",
+            "from dynaconf import post_hook",
+            "@post_hook",
+            "def post_hook(settings):",
+            "    return {",
+            "        'INSTALLED_APPS': ['admin', 'plugin'],",
+            "        'COLORS': '@merge blue',",
+            "        'DATABASES__default': '@merge PORT=5151',",
+            "        'DATABASES__default__VERSION': 42,",
+            "        'DATABASES__default__FORCED_INT': '@int 12',",
+            "        'BANDS': ['Anathema', 'dynaconf_merge'],",
+            "    }",
+        ],
+        str(settings_extra): [
+            "NAME = 'Bruce'",
+            "BASE_PATH = '/etc/frutaria'",
+            "from dynaconf import post_hook",
+            "@post_hook",
+            "def post_hook(settings):",
+            "    return {",
+            "        'INSTALLED_APPS': ['admin', 'extra'],",
+            "        'COLORS': '@merge yellow',",
+            "        'DATABASES__default': '@merge PORT=5152',",
+            "        'DATABASES__default__VERSION': 43,",
+            "        'DATABASES__default__FORCED_INT': '@int 13',",
+            "        'BANDS': ['Opeth', 'dynaconf_merge'],",
+            # Not sure @format should be supported on hooks, as settings is available on scope.
+            # maybe useful to set as a lazy value to be resolved after all hooks are executed.
+            "        'FULL_NAME': '@format {this.NAME} Rock',",
+            "        'FULL_PATH': f'{settings.BASE_PATH}/batata/',",
+            "    }",
+        ],
+    }
+
+    for path, lines in to_write.items():
+        with open(
+            str(path), "w", encoding=default_settings.ENCODING_FOR_DYNACONF
+        ) as f:
+            for line in lines:
+                f.write(line)
+                f.write("\n")
+
+    # Act
+    settings = LazySettings(settings_file="settings.py")
+
+    # Assert
+    # settings has _post_hooks attribute with one hook registered
+    assert settings._post_hooks
+    assert len(settings._post_hooks) == 1
+
+    # assert values set by the first hook only
+    assert settings.INSTALLED_APPS == ["admin", "plugin"]
+    assert settings.COLORS == ["red", "green", "blue"]
+    assert settings.DATABASES.default.NAME == "db"
+    assert settings.DATABASES.default.PORT == 5151
+    assert settings.DATABASES.default.VERSION == 42
+    assert settings.DATABASES.default.FORCED_INT == 12
+    assert settings.BANDS == ["Rush", "Yes", "Anathema"]
+
+    # Call load_file to load the second file
+    settings.load_file(str(settings_extra))
+
+    # assert _post_hooks attribute has two hooks registered
+    assert len(settings._post_hooks) == 2
+
+    # assert values set by the second hook only
+    assert settings.INSTALLED_APPS == ["admin", "extra"]
+    assert settings.COLORS == ["red", "green", "blue", "yellow"]
+    assert settings.DATABASES.default.NAME == "db"
+    assert settings.DATABASES.default.PORT == 5152
+    assert settings.DATABASES.default.VERSION == 43
+    assert settings.DATABASES.default.FORCED_INT == 13
+    assert settings.BANDS == ["Rush", "Yes", "Anathema", "Opeth"]
+    assert settings.FULL_NAME == "Bruce Rock"
+    assert settings.FULL_PATH == "/etc/frutaria/batata/"


### PR DESCRIPTION
Related to #1245
To be ported to master branch after merge

#### Decorator approach

**new in 3.2.8**

When the settings file is a Python file, you can also use a decorator to define hooks.

```python
from dynaconf import Dynaconf

settings = Dynaconf(settings_file="settings.py")
```

`settings.py`
```python
from dynaconf import post_hook

VARIABLE = "value"
# all regular settings here
...

@post_hook
def set_debugging_database_url(settings):
    data = {}
    if settings.DEBUG:
        data["DATABASE_URL"] = "sqlite://"
    return data
```

Dynaconf will collect the decorated functions and execute them after the settings file is loaded.
