### PR TITLE
feat: Add CLI command `debug-info`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -221,6 +221,44 @@ Kwargs-only:
 
 Returns a list of history-records (the same as in the `history` key of `inspect_settings` records. In fact, `inspect_settings` uses `get_history`, so this is just available if your main goal is to use the data directly. It offer some basic filtering capabilities, but it is assumed that if you choose to use this you'll probably want to process and filter the data by your own.
 
+
+### `get_debug_info`
+
+Returns a dictionary containing debug information about the settings object. This information includes the current environment, the settings file, the loaders, and the history of the settings object.
+
+```python
+from dynaconf.utils.inspect_settings import get_debug_info
+get_debug_info(settings.DYNACONF, verbosity=0, key="data")
+# result
+{'core_loaders': [],
+ 'environments': ['development', 'production'],
+ 'history': [{'data': {}, 'identifier': 'init_kwargs', 'loader': 'set_method'},
+             {'data': {},
+              'identifier': 'default_settings',
+              'loader': 'set_method'},
+             {'data': {},
+              'identifier': 'envvars_first_load',
+              'loader': 'set_method'},
+             {'data': {},
+              'identifier': 'settings_module_method',
+              'loader': 'set_method'},
+             {'data': {'data': [0]},
+              'identifier': '/etc/app/defaults.py',
+              'loader': 'py'},
+             {'data': {'data': '@merge 7,8,9'},
+              'identifier': '/etc/app/settings.yaml',
+              'loader': 'yaml'},
+ 'loaded_envs': ["development"],
+ 'loaded_files': ['/etc/app/defaults.py',
+                  '/etc/app/settings.yaml'],
+ 'loaded_hooks': [],
+ 'post_hooks': [],
+ 'root_path': '/run/app',
+ 'validators': [],
+ 'versions': {'django': '4.2.16', 'dynaconf': '3.2.8.dev0'}}
+```
+
+
 ## Update dynaconf settings using command-line arguments (cli)
 
 Dynaconf is designed to load the settings file and, when applicable, prioritize overrides from envvar.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,15 +124,25 @@ Usage: dynaconf inspect [OPTIONS]
 
 Options:
   -k, --key TEXT                  Filters result by key.
-  -e, --env TEXT                  Filters result by environment.
+  -e, --env TEXT                  Filters result by environment on --report-
+                                  mode=inspect.
+
   -f, --format [yaml|json|json-compact]
                                   The output format.
-  -s, --old-first                 Invert history sorting to 'old-first'
-  -n, --limit INTEGER             Limits how many history entries are shown.
-  -a, --all                       Show dynaconf internal settings?
-  --help                          Show this message and exit.
-```
+  -s, --old-first                 Invert history sorting to 'old-first' on
+                                  --report-mode=inspect.
 
+  -n, --limit INTEGER             Limits how many history entries are shown on
+                                  --report-mode=inspect.
+
+  -a, --all                       Show dynaconf internal settings?
+  -m, --report-mode [inspect|debug]
+  -v, --verbose                   Increase verbosity of the output on
+                                  --report-mode=debug.
+
+  --help                          Show this message and exit.
+                    Show this message and exit.
+```
 
 Sample usage:
 
@@ -167,55 +177,24 @@ To save to a file, use regular stream redirect methods:
 $ dynaconf -i app.settings inspect -k foo -f yaml > dump.yaml
 ```
 
-### Dynaconf get
+#### Inspect Debug Info
 
-Get raw value for a single key
-
-```bash
-Usage: dynaconf get [OPTIONS] KEY
-
-  Returns the raw value for a settings key.
-
-  If result is a dict, list or tuple it is printed as a valid json string.
-
-Options:
-  -d, --default TEXT  Default value if settings doesn't exist
-  -e, --env TEXT      Filters the env to get the values
-  -u, --unparse       Unparse data by adding markers such as @none, @int etc..
-  --help              Show this message and exit.
-```
-
-Example:
-
-```bash
-export FOO=$(dynaconf get DATABASE_NAME -d 'default')
-```
-
-If the key doesn't exist and no default is provided it will exit with code 1.
-
-### dynaconf debug-info
+> **NEW** in version 3.2.8
 
 Prints debug information about the current settings instance
 
 ```bash
-dynaconf debug-info --help
-Usage: dynaconf debug-info [OPTIONS]
-
-  Prints debug information about the settings instance.
-
-Options:
-  -k, --key TEXT                  Filters result by key.
-  -v, --verbose                   Increase verbosity of the output.
-  -f, --format [yaml|json|json-compact]
-                                  The output format.
-  --help                          Show this message and exit.
+dynaconf inspect -m debug -vv
 ```
 
-The default format is JSON, and the verbosity levels are
+Verbosity levels are
 
 - 0 (default): Include only the count of keys loaded by each loader
 - 1: Include the keys loaded by each loader
 - 2: Include the keys loaded by each loader and the values of each key
+
+
+Debug mode also accepts the `-k key` to filter the output by a specific key.
 
 
 Sample output in YAML format:
@@ -223,7 +202,7 @@ Sample output in YAML format:
 **TIP**: adding `-v` will list the keys and `-vv` will list the keys and values. 
 
 ```yaml
-# dynaconf debug-info --format=yaml
+# dynaconf inspect -m debug --format=yaml
 versions:
   dynaconf: 3.2.8
   django: 4.2.16
@@ -263,6 +242,32 @@ environments:
 - production
 loaded_envs: ['development']
 ```
+
+### Dynaconf get
+
+Get raw value for a single key
+
+```bash
+Usage: dynaconf get [OPTIONS] KEY
+
+  Returns the raw value for a settings key.
+
+  If result is a dict, list or tuple it is printed as a valid json string.
+
+Options:
+  -d, --default TEXT  Default value if settings doesn't exist
+  -e, --env TEXT      Filters the env to get the values
+  -u, --unparse       Unparse data by adding markers such as @none, @int etc..
+  --help              Show this message and exit.
+```
+
+Example:
+
+```bash
+export FOO=$(dynaconf get DATABASE_NAME -d 'default')
+```
+
+If the key doesn't exist and no default is provided it will exit with code 1.
 
 ### dynaconf list
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,6 +193,77 @@ export FOO=$(dynaconf get DATABASE_NAME -d 'default')
 
 If the key doesn't exist and no default is provided it will exit with code 1.
 
+### dynaconf debug-info
+
+Prints debug information about the current settings instance
+
+```bash
+dynaconf debug-info --help
+Usage: dynaconf debug-info [OPTIONS]
+
+  Prints debug information about the settings instance.
+
+Options:
+  -k, --key TEXT                  Filters result by key.
+  -v, --verbose                   Increase verbosity of the output.
+  -f, --format [yaml|json|json-compact]
+                                  The output format.
+  --help                          Show this message and exit.
+```
+
+The default format is JSON, and the verbosity levels are
+
+- 0 (default): Include only the count of keys loaded by each loader
+- 1: Include the keys loaded by each loader
+- 2: Include the keys loaded by each loader and the values of each key
+
+
+Sample output in YAML format:
+
+**TIP**: adding `-v` will list the keys and `-vv` will list the keys and values. 
+
+```yaml
+# dynaconf debug-info --format=yaml
+versions:
+  dynaconf: 3.2.8
+  django: 4.2.16
+root_path: /app/settings
+validators: ["Validator("FOO", must_exist=True, eq="bar")"]
+core_loaders: ["dynaconf.loaders.env_loader"]
+loaded_files:
+- /app/settings/defaults.py
+- /app/settings/development_defaults.py
+- /etc/app/settings.yaml
+history:
+- loader: set_method
+  identifier: init_kwargs
+  data: 13
+- loader: set_method
+  identifier: default_settings
+  data: 56
+- loader: settings_loader
+  identifier: /app/settings/defaults
+  data: 256
+- loader: py
+  identifier: /app/settings/development_defaults
+  data: 16
+- loader: set_method
+  identifier: lambda_1933577857047901425@instance
+  data: 2
+- loader: standard_settings_loader
+  identifier: /etc/app/settings.yaml
+  data: 1
+post_hooks:
+- <function <lambda> at 0x716a7b89c900>
+loaded_hooks:
+- hook: lambda_1933577857047901425@instance
+  data: 1
+environments:
+- development
+- production
+loaded_envs: ['development']
+```
+
 ### dynaconf list
 
 List all defined parameters and optionally export to a json file.

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -28,6 +28,7 @@ from dynaconf.utils.inspect import EnvNotFoundError
 from dynaconf.utils.inspect import inspect_settings
 from dynaconf.utils.inspect import KeyNotFoundError
 from dynaconf.utils.inspect import OutputFormatError
+from dynaconf.utils.inspect import print_debug_info
 from dynaconf.utils.parse_conf import parse_conf_data
 from dynaconf.utils.parse_conf import unparse_conf_data
 from dynaconf.validator import ValidationError
@@ -54,7 +55,12 @@ def set_settings(ctx, instance=None):
 
     settings = None
 
-    _echo_enabled = ctx.invoked_subcommand not in ["get", "inspect", None]
+    _echo_enabled = ctx.invoked_subcommand not in [
+        "get",
+        "inspect",
+        "debug-info",
+        None,
+    ]
     if "--json" in click.get_os_args():
         _echo_enabled = False
 
@@ -913,6 +919,27 @@ def inspect(
     except (KeyNotFoundError, EnvNotFoundError, OutputFormatError) as err:
         click.echo(err)
         sys.exit(1)
+
+
+@main.command()
+@click.option("--key", "-k", help="Filters result by key.")
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Increase verbosity of the output.",
+)
+@click.option(
+    "--format",
+    "-f",
+    help="The output format.",
+    default="json",
+    type=click.Choice(INSPECT_FORMATS),
+)
+def debug_info(key, verbose, format):
+    """Prints debug information about the settings instance."""
+    print_debug_info(settings, dumper=format, verbosity=verbose, key=key)
+    click.echo()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -457,6 +457,9 @@ def get_debug_info(
     if settings.get("ENVIRONMENTS_FOR_DYNACONF"):
         data["environments"] = list(settings.get("ENVIRONMENTS_FOR_DYNACONF"))
         data["loaded_envs"] = settings._loaded_envs
+
+    if key:
+        data["current"] = {key: settings.get(key)}
     return data
 
 

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -256,7 +256,9 @@ def test_post_load_hooks(clean_env, tmpdir):
     assert settings.DATABASES.default.VERSION == 42
     assert settings.DATABASES.default.FORCED_INT == 12
     assert settings.BANDS == ["Rush", "Yes", "Anathema"]
-    assert settings._loaded_hooks[str(plugin_hook)] == {
+
+    plugin_hook, settings_hook = list(settings._loaded_hooks.keys())
+    assert settings._loaded_hooks[plugin_hook] == {
         "post": {
             "PLUGIN_NAME": "dummyplugin",
             "COLORS": "@merge blue",
@@ -266,7 +268,7 @@ def test_post_load_hooks(clean_env, tmpdir):
             "BANDS": ["Anathema", "dynaconf_merge"],
         }
     }
-    assert settings._loaded_hooks[str(settings_hook)] == {
+    assert settings._loaded_hooks[settings_hook] == {
         "post": {
             "INSTALLED_APPS": ["dummyplugin"],
         }


### PR DESCRIPTION
To be ported to main

Related #1234 

### dynaconf debug-info

Prints debug information about the current settings instance

```console
$ dynaconf debug-info --help
Usage: dynaconf debug-info [OPTIONS]

  Prints debug information about the settings instance.

Options:
  -k, --key TEXT                  Filters result by key.
  -v, --verbose                   Increase verbosity of the output.
  -f, --format [yaml|json|json-compact]
                                  The output format.
  --help                          Show this message and exit.
```

The default format is JSON, and the verbosity levels are

- 0 (default): Include only the count of keys loaded by each loader
- 1: Include the keys loaded by each loader
- 2: Include the keys loaded by each loader and the values of each key


Sample output in YAML format:

**TIP**: adding `-v` will list the keys and `-vv` will list the keys and values. 

```yaml
# dynaconf debug-info --format=yaml
versions:
  dynaconf: 3.2.8
  django: 4.2.16
root_path: /app/settings
validators: ["Validator("FOO", must_exist=True, eq="bar")"]
core_loaders: ["dynaconf.loaders.env_loader"]
loaded_files:
- /app/settings/defaults.py
- /app/settings/development_defaults.py
- /etc/app/settings.yaml
history:
- loader: set_method
  identifier: init_kwargs
  data: 13
- loader: set_method
  identifier: default_settings
  data: 56
- loader: settings_loader
  identifier: /app/settings/defaults
  data: 256
- loader: py
  identifier: /app/settings/development_defaults
  data: 16
- loader: set_method
  identifier: lambda_1933577857047901425@instance
  data: 2
- loader: standard_settings_loader
  identifier: /etc/app/settings.yaml
  data: 1
post_hooks:
- <function <lambda> at 0x716a7b89c900>
loaded_hooks:
- hook: lambda_1933577857047901425@instance
  data: 1
environments:
- development
- production
loaded_envs: ['development']
```