### PR TITLE
fix: Hotfix hook collector to avoid eager evaluation. (#1255) [port from 3.2.10]

### DIFF
--- a/dynaconf/hooking.py
+++ b/dynaconf/hooking.py
@@ -368,4 +368,11 @@ def post_hook(function: Callable) -> Callable:
         raise TypeError(
             "post_hook decorator must be applied to a function or method."
         )
+    else:
+        # On the same scope where the decorated function is defined we
+        # add a variable with the same name as the function but prefixed
+        # with _dynaconf_hook_ this variable will be used by the loader
+        # to register the function as a post_hook
+        function.__globals__[f"_dynaconf_hook_{function.__name__}"] = function
+
     return function

--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -71,12 +71,12 @@ def load_from_python_object(
                     merge=file_merge,
                     validate=validate,
                 )
-        # if setting is a post_hook function it will be a callable with
-        # the _dynaconf_hook attribute set to True
-        # then we want to add it to the post_hooks list on the obj.
-        elif callable(setting_value) and getattr(
-            setting_value, "_dynaconf_hook", False
-        ):
+        # if setting (name) starts with _dynaconf_hook
+        # and the value is a callable
+        # then we want to add it to the post_hooks list on the obj
+        # we use the name instead checking on an attribute to avoid
+        # loading a lazy object early in the process
+        elif setting.startswith("_dynaconf_hook") and callable(setting_value):
             if setting_value not in obj._post_hooks:
                 obj._post_hooks.append(setting_value)
 

--- a/tests_functional/legacy/django_example/foo/a_plugin_folder/settings.py
+++ b/tests_functional/legacy/django_example/foo/a_plugin_folder/settings.py
@@ -1,3 +1,13 @@
 from __future__ import annotations
 
 BANDS = ["Metallica", "Black Sabbath", "Iron Maiden"]
+
+
+# This is really bad, however there are some running projects using it.
+# namely pulp_ansible <0.24
+from dynaconf import settings
+
+# this must be avoided in favor of lazy format, get a and hooks
+BAD = settings.BEST_BOSS + "/foo"
+# the following is ok
+GOOD = "@format {this.TEST_VALUE}/foo"


### PR DESCRIPTION
Using getattr during load on a value would trigger eager evaluation, changed to use name instead.