### PR TITLE
Run CI test against distribution wheel

### DIFF
--- a/.github/actions/install-from-wheel/action.yml
+++ b/.github/actions/install-from-wheel/action.yml
@@ -1,0 +1,55 @@
+name: 'Install from wheel'
+description: 'Setup Python and install Dynaconf wheel with optional dependencies'
+
+inputs:
+  dependencies:
+    description: 'Optional dependencies to install with the wheel'
+    required: false
+    default: ''
+  os:
+    description: 'Operating system (Windows, Linux, macOS)'
+    required: false
+    default: 'Linux'
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.9'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Upgrade PIP
+      shell: bash
+      run: pip install --user --upgrade pip
+      continue-on-error: ${{ inputs.os == 'Windows' }}
+
+    - name: Download wheel
+      uses: actions/download-artifact@v4
+      with:
+        name: dynaconf_dist
+        path: dist/
+
+    - name: Install from wheel (Unix)
+      if: inputs.os != 'Windows'
+      shell: bash
+      run: |
+        PACKAGE=$(ls dist/*.whl)
+        if [ -n "${{ inputs.dependencies }}" ]; then
+          pip install "$PACKAGE[${{ inputs.dependencies }}]"
+        else
+          pip install "$PACKAGE"
+        fi
+
+    - name: Install from wheel (Windows)
+      if: inputs.os == 'Windows'
+      shell: pwsh
+      run: |
+        $PACKAGE = (Get-ChildItem dist/*.whl).FullName
+        if ("${{ inputs.dependencies }}" -ne "") {
+          pip install --use-deprecated=legacy-resolver "$PACKAGE[${{ inputs.dependencies }}]"
+        } else {
+          pip install --use-deprecated=legacy-resolver "$PACKAGE"
+        }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,24 +29,42 @@ concurrency:
 
 jobs:
   linter:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
       - name: Upgrade PIP
         run: pip install --user --upgrade pip
       - name: Install and lint
         run: make clean install run-pre-commit
 
-  install_test:
+  build:
     needs: linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Upgrade PIP
+        run: pip install --user --upgrade pip
+      - name: Install build dependencies
+        run: pip install --user .[release]
+      - name: Build wheel
+        run: make dist
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+          if-no-files-found: "error"
+          overwrite: true
+          retention-days: 1
+
+  install_test:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -54,12 +72,21 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install project
-        run: make ciinstall
+      - name: Download dynaconf wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: pip install dist/*.whl
+        if: runner.os != 'Windows'
+      - name: Install from wheel (Windows)
+        run: pip install (Get-ChildItem dist/*.whl).FullName
+        if: runner.os == 'Windows'
+        shell: pwsh
       - name: Install project and test cli
         run: |
           dynaconf init -v FOO=running_on_ci -y
@@ -83,8 +110,22 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
         run: pip install --user --upgrade pip
-      - name: Install project
-        run: make ciinstall
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: |
+          PACKAGE=$(ls dist/*.whl)
+          pip install "$PACKAGE[test]"
+        if: runner.os != 'Windows'
+      - name: Install from wheel (Windows)
+        run: |
+          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
+          pip install "$PACKAGE[test]"
+        if: runner.os == 'Windows'
+        shell: pwsh
       - name: Run tests
         run: make citest
       - name: Publish Junit Test Results
@@ -142,8 +183,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
         run: pip install --user --upgrade pip
-      - name: Install project
-        run: make ciinstall
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: |
+          PACKAGE=$(ls dist/*.whl)
+          pip install "$PACKAGE[test]"
       - name: Run functional tests
         run: make test_functional
 
@@ -163,8 +211,16 @@ jobs:
       - name: Install Pip
         run: pip install --user --upgrade pip
         continue-on-error: true
-      - name: Install project
-        run: pip install --use-deprecated=legacy-resolver .[test]
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel (Windows)
+        run: |
+          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
+          pip install --use-deprecated=legacy-resolver "$PACKAGE[test]"
+        shell: pwsh
       - name: run tests
         run: py.test -v -l tests --junitxml=junit/test-results.xml -m "not integration"
 
@@ -184,8 +240,15 @@ jobs:
       - name: Install Pip
         continue-on-error: true
         run: pip install --user --upgrade pip
-      - name: Install project
-        run: pip install --use-deprecated=legacy-resolver .[test]
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: |
+          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
+          pip install --use-deprecated=legacy-resolver "$PACKAGE[test]"
       - name: run tests
         run: python tests_functional/runtests.py
 
@@ -209,8 +272,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
         run: pip install --user --upgrade pip
-      - name: Install project
-        run: make ciinstall
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: |
+          PACKAGE=$(ls dist/*.whl)
+          pip install "$PACKAGE[test]"
       - name: Run functional tests
         run: make test_redis
 
@@ -237,8 +307,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
         run: pip install --user --upgrade pip
-      - name: Install project
-        run: make ciinstall
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dynaconf_dist
+          path: dist/
+      - name: Install from wheel
+        run: |
+          PACKAGE=$(ls dist/*.whl)
+          pip install "$PACKAGE[test]"
       - name: Run functional tests
         run: make test_vault
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,21 +72,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Download dynaconf wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel
-        run: pip install dist/*.whl
-        if: runner.os != 'Windows'
-      - name: Install from wheel (Windows)
-        run: pip install (Get-ChildItem dist/*.whl).FullName
-        if: runner.os == 'Windows'
-        shell: pwsh
+          os: ${{ runner.os }}
       - name: Install project and test cli
         run: |
           dynaconf init -v FOO=running_on_ci -y
@@ -105,27 +96,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP
-        run: pip install --user --upgrade pip
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel
-        run: |
-          PACKAGE=$(ls dist/*.whl)
-          pip install "$PACKAGE[test]"
-        if: runner.os != 'Windows'
-      - name: Install from wheel (Windows)
-        run: |
-          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
-          pip install "$PACKAGE[test]"
-        if: runner.os == 'Windows'
-        shell: pwsh
+          dependencies: test
+          os: linux
       - name: Run tests
         run: make citest
       - name: Publish Junit Test Results
@@ -156,13 +132,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP
-        run: pip install --user --upgrade pip
-      - name: Install project
-        run: make ciinstall
+          dependencies: test
+          os: macos
       - name: Run tests
         run: py.test -v --cov-config .coveragerc --cov=dynaconf -l tests/ --junitxml=junit/test-results.xml -m "not integration"
 
@@ -178,20 +153,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP
-        run: pip install --user --upgrade pip
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel
-        run: |
-          PACKAGE=$(ls dist/*.whl)
-          pip install "$PACKAGE[test]"
+          dependencies: test
+          os: linux
       - name: Run functional tests
         run: make test_functional
 
@@ -205,22 +172,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Pip
-        run: pip install --user --upgrade pip
-        continue-on-error: true
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel (Windows)
-        run: |
-          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
-          pip install --use-deprecated=legacy-resolver "$PACKAGE[test]"
-        shell: pwsh
+          dependencies: test
+          os: windows
       - name: run tests
         run: py.test -v -l tests --junitxml=junit/test-results.xml -m "not integration"
 
@@ -234,21 +191,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Pip
-        continue-on-error: true
-        run: pip install --user --upgrade pip
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel
-        run: |
-          $PACKAGE = (Get-ChildItem dist/*.whl).FullName
-          pip install --use-deprecated=legacy-resolver "$PACKAGE[test]"
+          dependencies: test
+          os: windows
       - name: run tests
         run: python tests_functional/runtests.py
 
@@ -267,20 +215,12 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install from wheel
+        uses: ./.github/actions/install-from-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP
-        run: pip install --user --upgrade pip
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
-      - name: Install from wheel
-        run: |
-          PACKAGE=$(ls dist/*.whl)
-          pip install "$PACKAGE[test]"
+          dependencies: test
+          os: linux
       - name: Run functional tests
         run: make test_redis
 
@@ -305,17 +245,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP
-        run: pip install --user --upgrade pip
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: dynaconf_dist
-          path: dist/
       - name: Install from wheel
-        run: |
-          PACKAGE=$(ls dist/*.whl)
-          pip install "$PACKAGE[test]"
+        uses: ./.github/actions/install-from-wheel
+        with:
+          python-version: ${{ matrix.python-version }}
+          dependencies: test
+          os: linux
       - name: Run functional tests
         run: make test_vault
 

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,6 @@ run-tox:
 	rm -rf .tox
 
 minify_vendor:
-	# Ensure vendor is source and cleanup vendor_src backup folder
-	ls dynaconf/vendor/source && rm -rf dynaconf/vendor_src
-
-	# Backup dynaconf/vendor folder as dynaconf/vendor_src
-	mv dynaconf/vendor dynaconf/vendor_src
-
 	# create a new dynaconf/vendor folder with minified files
 	./minify.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ release = [
     "twine",
     "git-changelog",
     "bump-my-version",
+    "python-minifier",
 ]
 
 misc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "tox",
     "django-debug-toolbar~=4.3.0",
     "boto3",
+    "ipython",
 ]
 
 lint = [
@@ -80,7 +81,8 @@ lint = [
 ]
 
 release = [
-    "wheel",
+    "build",
+    "toml",
     "twine",
     "git-changelog",
     "bump-my-version",

--- a/tests_functional/issues/685_disable_dotted_lookup/app.py
+++ b/tests_functional/issues/685_disable_dotted_lookup/app.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import yaml
-
 from dynaconf import Dynaconf
 
 settings = Dynaconf(


### PR DESCRIPTION
This PR:
* Adds missing build/release dependencies: `python-minifier` and `build`.
* Makes CI use (as installation source) the distribution wheel we expect to release
* Adds check to the `minify.sh` script to ensure we are using our lowerbound python, as it may create incompatible changes to the vendored code otherwise. (as reported by Bruno!)