### PR TITLE
feat: Add `@read_file` converter

### DIFF
--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -166,6 +166,81 @@ other_number = "@get number @int 12"
 The `@get` is lazily evaluated and subject to `DynaconfFormatError` in case of
 malformed expression, it is recommended to add validators.
 
+## Reading from files
+
+You can read from text files using the `@read_file` token. This token will read the file
+and return its content as a string. The file path can be absolute or relative to the current working directory.
+
+Example:
+
+```toml
+SECRET_KEY = "@read_file /path/to/secret_key"
+```
+```bash
+echo "my_secret_key" > /path/to/secret_key
+```
+
+```py
+from dynaconf import Dynaconf
+settings = Dynaconf(settings_files=["settings.toml"])
+assert settings.SECRET_KEY == "my_secret_key"
+```
+
+### Combining with other tokens
+
+You can combine the `@read_file` with other interpolation tokens like `@format` or `@jinja` and `@get` to read files with dynamic paths or content.
+
+Example:
+
+```toml
+FILENAME = "secret_key"
+DIRECTORY = "/path/to"
+
+
+SECRET_KEY = "@read_file @format {this.DIRECTORY}/{this.FILENAME}"
+SECRET_KEY = "@read_file @jinja {{ this.DIRECTORY }}/{{ this.FILENAME }}"
+
+
+COMPLETE_PATH = "@format {this.DIRECTORY}/{this.FILENAME}"
+SECRET_KEY = "@read_file @get COMPLETE_PATH"
+```
+
+### Combining with string utils
+
+If the file needs stripping or other string manipulations, you can combine the `@read_file` with the string utils tokens
+
+```toml
+SECRET_KEY = "@strip @read_file /path/to/secret_key"
+```
+
+## String utils
+
+Dynaconf provides some string utils to manipulate strings. The following utils are available:
+
+```py
+"@upper foo" == "FOO"
+"@lower FOO" == "foo"
+"@title foo bar" == "Foo Bar"
+"@capitalize foo bar" == "Foo bar"
+"@strip foo bar \n" == "foo bar"
+"@lstrip foo bar \n" == "foo bar \n"
+"@rstrip foo bar \n" == " foo bar"
+"@split foo bar" == ["foo", "bar"]
+"@casefold Foo BAR" == "foo bar"
+"@swapcase Foo BAR" == "fOO bar"
+```
+
+- `@upper`: Converts the string to uppercase.
+- `@lower`: Converts the string to lowercase.
+- `@title`: Converts the string to title case.
+- `@capitalize`: Capitalizes the first character of the string.
+- `@strip`: Removes leading and trailing whitespace from the string.
+- `@lstrip`: Removes leading whitespace from the string.
+- `@rstrip`: Removes trailing whitespace from the string.
+- `@split`: Splits the string into a list of words.
+- `@casefold`: Converts the string to casefolded form (for case-insensitive comparisons).
+- `@swapcase`: Swaps the case of all characters in the string.
+
 
 ## Access Hooks
 

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -186,6 +186,17 @@ settings = Dynaconf(settings_files=["settings.toml"])
 assert settings.SECRET_KEY == "my_secret_key"
 ```
 
+You can also specify a default value in case the file does not exist or isn't readable.
+
+Example:
+
+```toml
+SECRET_KEY = "@read_file /path/to/secret_key default_value"
+```
+
+If the file does not exist and there is no default value, a `FileNotFoundError` will be raised upon access.
+
+
 ### Combining with other tokens
 
 You can combine the `@read_file` with other interpolation tokens like `@format` or `@jinja` and `@get` to read files with dynamic paths or content.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -614,7 +614,7 @@ def test_read_file_notfound_error(tmp_path):
         settings = Dynaconf(
             settings_file=settings_file,
         )
-        assert settings.SECRET_KEY == "FOOBAR"
+        settings.SECRET_KEY
 
 
 @pytest.mark.skipif(
@@ -657,7 +657,7 @@ def test_read_file_syntax_error(tmp_path):
         settings = Dynaconf(
             settings_file=settings_file,
         )
-        assert settings.SECRET_KEY == "FOOBAR"
+        settings.SECRET_KEY
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
closes: #1279

No Backport, this is for 3.3.0

## Reading from files

You can read from text files using the `@read_file` token. This token will read the file
and return its content as a string. The file path can be absolute or relative to the current working directory.

Example:

```toml
SECRET_KEY = "@read_file /path/to/secret_key"
```
```bash
echo "my_secret_key" > /path/to/secret_key
```

```py
from dynaconf import Dynaconf
settings = Dynaconf(settings_files=["settings.toml"])
assert settings.SECRET_KEY == "my_secret_key"
```

### Combining with other tokens

You can combine the `@read_file` with other interpolation tokens like `@format` or `@jinja` and `@get` to read files with dynamic paths or content.

Example:

```toml
FILENAME = "secret_key"
DIRECTORY = "/path/to"
SECRET_KEY = "@read_file @format {this.DIRECTORY}/{this.FILENAME}"
SECRET_KEY = "@read_file @jinja {{ this.DIRECTORY }}/{{ this.FILENAME }}"
COMPLETE_PATH = "@format {this.DIRECTORY}/{this.FILENAME}"
SECRET_KEY = "@read_file @get COMPLETE_PATH"
```

### Combining with string utils

If the file needs stripping or other string manipulations, you can combine the `@read_file` with the string utils tokens

```toml
SECRET_KEY = "@strip @read_file /path/to/secret_key"
```

## String utils

Dynaconf provides some string utils to manipulate strings. The following utils are available:

```py
"@upper foo" == "FOO"
"@lower FOO" == "foo"
"@title foo bar" == "Foo Bar"
"@capitalize foo bar" == "Foo bar"
"@strip foo bar \n" == "foo bar"
"@lstrip foo bar \n" == "foo bar \n"
"@rstrip foo bar \n" == " foo bar"
"@split foo bar" == ["foo", "bar"]
"@casefold Foo BAR" == "foo bar"
"@swapcase Foo BAR" == "fOO bar"
```

- `@upper`: Converts the string to uppercase.
- `@lower`: Converts the string to lowercase.
- `@title`: Converts the string to title case.
- `@capitalize`: Capitalizes the first character of the string.
- `@strip`: Removes leading and trailing whitespace from the string.
- `@lstrip`: Removes leading whitespace from the string.
- `@rstrip`: Removes trailing whitespace from the string.
- `@split`: Splits the string into a list of words.
- `@casefold`: Converts the string to casefolded form (for case-insensitive comparisons).
- `@swapcase`: Swaps the case of all characters in the string.