### PR TITLE
fix: use sys.argv instead of click.get_os_args

### DIFF
--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -65,7 +65,7 @@ def set_settings(ctx, instance=None):
         "debug-info",
         None,
     ]
-    if "--json" in click.get_os_args():
+    if "--json" in sys.argv:
         _echo_enabled = False
 
     if instance is not None:
@@ -111,7 +111,7 @@ def set_settings(ctx, instance=None):
             )
 
     if settings is None:
-        if instance is None and "--help" not in click.get_os_args():
+        if instance is None and "--help" not in sys.argv:
             if ctx.invoked_subcommand and ctx.invoked_subcommand not in [
                 "init",
             ]:


### PR DESCRIPTION
fix #1283