### PR TITLE
fix: `-k` must exit code 1 when key do not exist

### DIFF
--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -320,7 +320,7 @@ def init(ctx, fileformat, path, env, _vars, _secrets, wg, y, django):
             "app = Flask(__name__)\n"
             "FlaskDynaconf(app)\n"
         )
-        exit(1)
+        sys.exit(1)
 
     path = Path(path)
 
@@ -650,7 +650,7 @@ def _list(
 
         if value is empty:
             click.secho("Key not found", bg="red", fg="white", err=True)
-            return
+            sys.exit(1)
 
         if not _json:
             click.echo(format_setting(key, value))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,25 @@ def test_list(testdir):
     assert "TEST_KEY<str> 'test_value'" in result
 
 
+@pytest.mark.parametrize("cmd", ["list", "inspect", "get"])
+def test_not_found_key_exit_error(cmd, testdir):
+    """Test error code when key not found"""
+    if cmd == "get":
+        command = [cmd, "DONTEXIST"]
+    else:
+        command = [cmd, "-k", "DONTEXIST"]
+
+    result = run(
+        command,
+        env={
+            "ROOT_PATH_FOR_DYNACONF": testdir,
+            "INSTANCE_FOR_DYNACONF": "tests.config.settings",
+        },
+        attr="exit_code",
+    )
+    assert result == 1
+
+
 def test_get(testdir):
     """Tests get command"""
     result = run(


### PR DESCRIPTION
fix #1235