### PR TITLE
[3.2] perf: add lru caching to `find_the_correct_casing` function

### DIFF
--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -17,7 +17,8 @@ class DynaBox(Box):
         try:
             result = super().__getattr__(item, *args, **kwargs)
         except (AttributeError, KeyError):
-            n_item = find_the_correct_casing(item, self) or item
+            all_keys = tuple(self.keys())
+            n_item = find_the_correct_casing(item, all_keys) or item
             result = super().__getattr__(n_item, *args, **kwargs)
         return self.__evaluate_lazy__(result)
 
@@ -25,7 +26,8 @@ class DynaBox(Box):
         try:
             result = super().__getitem__(item, *args, **kwargs)
         except (AttributeError, KeyError):
-            n_item = find_the_correct_casing(item, self) or item
+            all_keys = tuple(self.keys())
+            n_item = find_the_correct_casing(item, all_keys) or item
             result = super().__getitem__(n_item, *args, **kwargs)
         return self.__evaluate_lazy__(result)
 
@@ -34,14 +36,16 @@ class DynaBox(Box):
     ) -> Any:
         # _TODO(pbrochad): refactor all these getter methods to make consistency easier
         if not bypass_eval:
-            n_item = find_the_correct_casing(item, self) or item
+            all_keys = tuple(self.keys())
+            n_item = find_the_correct_casing(item, all_keys) or item
             result = super().get(n_item, empty, *args, **kwargs)
             result = result if result is not empty else default
             return self.__evaluate_lazy__(result)
         try:
             return super().__getitem__(item, *args, **kwargs)
         except (AttributeError, KeyError):
-            n_item = find_the_correct_casing(item, self) or item
+            all_keys = tuple(self.keys())
+            n_item = find_the_correct_casing(item, all_keys) or item
             return super().__getitem__(n_item, *args, **kwargs)
 
     def __evaluate_lazy__(self, result):


### PR DESCRIPTION
As shown in the Box replacement PR (https://github.com/dynaconf/dynaconf/pull/1325), the cache can improve access performance and it's pretty low risk.

The required change is making the function arguments immutable. We passed a whole dictionary before, which is mutable, but all the function needs is the set of keys, so we pass them in a tuple.