### PR TITLE
fix: raise TypeError in load_file when path is not a string or PathLike

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1500,6 +1500,19 @@ class Settings:
         core = self.__core__
         config = core.config
 
+        # Validate path type to prevent silent failures
+        if path is not None:
+            valid = isinstance(path, (str, os.PathLike))
+            if not valid and isinstance(path, (list, tuple, set)):
+                valid = all(
+                    isinstance(p, (str, os.PathLike)) for p in path
+                )
+            if not valid:
+                raise TypeError(
+                    f"load_file 'path' must be a string, os.PathLike, "
+                    f"or list thereof, got {type(path).__name__}"
+                )
+
         files = ensure_a_list(path)
         if not files:  # a glob pattern may return empty
             return


### PR DESCRIPTION
Fixes #1299

## Problem

`settings.load_file(some_module_object)` silently does nothing. The non-string value is wrapped into a list by `ensure_a_list`, then used as a filename which fails silently (since `silent=True` by default).

```python
from foo import module_object
settings.load_file(module_object)  # silently does nothing
```

## Fix

Add type validation at the top of `load_file` that raises a clear `TypeError` when `path` is not a `str`, `os.PathLike`, or list/tuple/set thereof:

```
TypeError: load_file 'path' must be a string, os.PathLike, or list thereof, got module
```

This catches the mistake immediately instead of silently swallowing it.