### PR TITLE
Pin vault and redis docker images

### DIFF
--- a/.github/workflows/main__test.yml
+++ b/.github/workflows/main__test.yml
@@ -176,7 +176,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       redis:
-        image: redis
+        image: redis:8.6-alpine
         ports:
           - 6379:6379
     steps:
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       vault:
-        image: hashicorp/vault:latest
+        image: hashicorp/vault:1.21
         ports:
           - 8200:8200
         env:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,11 +1,10 @@
-version: "3"
 services:
     redis:
-        image: redis:alpine
+        image: redis:8.6-alpine
         ports:
             - 6379:6379
     vault:
-        image: hashicorp/vault:latest
+        image: hashicorp/vault:1.21
         ports:
             - 8200:8200
         environment:

--- a/tests_functional/test_vault.sh
+++ b/tests_functional/test_vault.sh
@@ -3,7 +3,7 @@ docker run --rm \
     --name dynaconf_with_vault -d \
     -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
     -p 8200:8200 \
-    hashicorp/vault:latest \
+    hashicorp/vault:1.21 \
     || true
 sleep 5
 cd tests_functional/legacy/vault

--- a/tests_functional/test_vault_userpass.sh
+++ b/tests_functional/test_vault_userpass.sh
@@ -3,7 +3,7 @@ docker run --rm \
     --name dynaconf_with_vault -d \
     -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
     -p 8200:8200 \
-    hashicorp/vault:latest \
+    hashicorp/vault:1.21 \
     || true
 sleep 5
 cd tests_functional/vault_userpass


### PR DESCRIPTION
We are using `vault:latest`, but this can unexpectedly break in a hard to debug way.

Ideally we should have a bot (dependabot?) to bump these on separate PRs, so we can know exactly the cause of a bump error and apply the appropriate fix. #1376 

## Context

In this specific case, vault 2.0.0 is a regression.
If we really wanna say we support vault 2.0.0, we need to dig into the [changelog](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#200) and understand what this means and how we should adapt our tests.

```bash
docker run --rm hashicorp/vault:1.20 vault version
# Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK
# Vault v1.20.4 ...

docker run --rm hashicorp/vault:1.21 vault version
# Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK
# Vault v1.21.4 ...

# Fails — set -e now kills the script when setcap fails
docker run --rm hashicorp/vault:2.0 vault version
# unable to set CAP_SETFCAP effective capability: Operation not permitted
# exit code 1
```