### PR TITLE
Fix index merge padding scalar lists with nested empty lists

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1086,10 +1086,17 @@ class Settings:
                     and isinstance(tree, list)
                 ):  # accessing index of a list
                     index = int(k.replace("[", "").replace("]", ""))
-                    extended_list = [
-                        next_default.copy()
-                        for _ in range(index + 1)  # type: ignore[attr-defined]
-                    ]
+                    # Pad missing positions so we can assign any index.
+                    # On the last segment the slot holds the value itself, so
+                    # gaps should be empty (None) instead of a copy of
+                    # `next_default`, which still refers to the previous level.
+                    if is_not_end:
+                        extended_list = [
+                            next_default.copy()  # type: ignore[attr-defined]
+                            for _ in range(index + 1)
+                        ]
+                    else:
+                        extended_list = [None] * (index + 1)
                     # This makes sure we can assign any arbitrary index
                     tree.extend(extended_list)
                     if is_not_end:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1853,6 +1853,25 @@ class TestIndexMerge:
         settings.set("nested_5.nested_6_0", "World")
         assert settings.NESTED_5.NESTED_6_0 == "World"
 
+    def test_dotted_set_scalar_list_pads_with_none(self, settings):
+        settings.set("INDEX_SEPARATOR_FOR_DYNACONF", "___")
+
+        # Assigning an index of a plain list should leave the skipped
+        # positions empty (None), not nested empty containers.
+        settings.set("ports[2]", 9090)
+        assert list(settings.PORTS) == [None, None, 9090]
+
+        # Nesting is preserved: only the leaf gap becomes None, the outer
+        # list still pads with an empty list.
+        settings.set("matrix[1][1]", "x")
+        assert list(settings.MATRIX) == [[], [None, "x"]]
+
+    def test_environ_dunder_set_scalar_list_pads_with_none(self):
+        os.environ["DYNACONF_PORTS___2"] = "9090"
+        settings = Dynaconf(INDEX_SEPARATOR_FOR_DYNACONF="___")
+        assert list(settings.PORTS) == [None, None, 9090]
+        del os.environ["DYNACONF_PORTS___2"]
+
     def test_environ_dunder_set_with_index_merge_disabled(self):
         os.environ["DYNACONF_NESTED_A__nested_1__nested_2"] = "new_conf"
         os.environ[


### PR DESCRIPTION
With `INDEX_SEPARATOR_FOR_DYNACONF` enabled, setting an index of a plain list of scalars fills the skipped positions with empty lists instead of leaving them empty. For example:

```python
settings = Dynaconf(INDEX_SEPARATOR_FOR_DYNACONF="___")
settings.set("ports[2]", 9090)
# settings.PORTS == [[], [], 9090]   # expected [None, None, 9090]
```

Same via env vars (`DYNACONF_PORTS___2=9090`). You end up with nested empty lists where you only wanted to assign one element.

The padding in `_dotted_set` reused `next_default`, which is only recomputed for non-final path segments, so on the leaf index it still referenced the parent level's container default. I pad the gaps with `None` when the index is the last segment; nested (non-leaf) lists are untouched and still pad with their proper container type, e.g. `matrix[1][1]` stays `[[], [None, "x"]]`.

Added two tests under `TestIndexMerge` covering the `.set` and dunder-env paths.
