### PR TITLE
fix: prevent RecursionError on dotted set with bracket in first segment

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1107,11 +1107,17 @@ class Settings:
                 full_path=split_keys,
                 list_merge=list_merge,  # when to use deep / shallow replace?
             )
+        # `new_data` is keyed by the already-resolved top level key
+        # (`split_keys[0]`). With index merge disabled a bracket is a literal
+        # key, so that key can still contain `[` (e.g. `servers[0]`). Writing
+        # it with dotted_lookup on would route it back into `_dotted_set` and
+        # recurse forever, so set the resolved keys literally.
         self.update(
             data=new_data,
             tomlfy=tomlfy,
             validate=validate,
             tomlfy_filter=tomlfy_filter,
+            dotted_lookup=False,
             **kwargs,
         )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1828,6 +1828,20 @@ class TestIndexMerge:
         with pytest.raises(AttributeError):
             settings.nested_a.nested_b
 
+    def test_dotted_set_bracket_first_segment_disabled(self):
+        # With index merge disabled a bracket is a literal key. When the
+        # bracket is in the first (top-level) segment the resolved key still
+        # holds the `[` and used to be re-routed into _dotted_set, recursing
+        # forever. It should just be stored as a literal key.
+        settings = Dynaconf()
+        assert bool(settings.get("INDEX_SEPARATOR_FOR_DYNACONF")) is False
+
+        settings.set("a[1]", "v")
+        assert settings.get("a[1]") == "v"
+
+        settings.set("servers[0].name", "web1")
+        assert settings.get("servers[0]") == {"name": "web1"}
+
     def test_dotted_set(self, settings):
         settings.set("MERGE_ENABLED_FOR_DYNACONF", False)
         settings.set("INDEX_SEPARATOR_FOR_DYNACONF", "___")


### PR DESCRIPTION
`settings.set("a[1]", "x")` blows up with `RecursionError: maximum recursion depth exceeded`. Same thing for any dotted key whose first segment carries a bracket, e.g. `settings.set("servers[0].name", "web1")`. This is with index merge disabled, which is the default (`INDEX_SEPARATOR_FOR_DYNACONF` unset).

With index merge off a bracket is just part of a literal key — `test_dotted_set_with_index_merge_disabled` already documents that `nested_a.nested_b[2][1]...` stores `nested_b[2][1]` as a plain key. The crash only happens when the bracket lands in the first segment: `_dotted_set` writes the resolved tree back through `self.update`, and the top-level key it produces (`split_keys[0]`) still contains `[`, so `update` routes it straight back into `_dotted_set` (any `[` is treated as a dotted path) and it loops.

I pass `dotted_lookup=False` on that final `update` so the already-resolved keys are written literally instead of being re-parsed. Non-first-segment literal keys and the index-merge path are unchanged.

Added a regression test in `TestIndexMerge`; it raises RecursionError before the change and passes after.