### PR TITLE
chore(ci): remove unnecessary uv install from workflows

### DIFF
--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -33,7 +33,6 @@ jobs:
           python-version: "3.9"
       - name: Install release tools
         run: |
-          uv sync --only-group release --no-lock
           # Install from master before switching branches so the command survives checkout.
           uv pip install .github/scripts/
       - name: Set up git identity

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
           python-version: "3.9"
       - name: Install release tools
         run: |
-          uv sync --only-group release --no-lock
           # Install the release utility as a package from master so the command
           # is always the canonical version regardless of how the workflow was triggered.
           uv pip install .github/scripts/

--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -30,7 +30,6 @@ jobs:
           python-version: "3.9"
       - name: Install release tools
         run: |
-          uv sync --only-group release --no-lock
           # Install the release utility as a package from master so the installed
           # command is unaffected by the backport branch checkout that follows.
           uv pip install .github/scripts/

--- a/.github/workflows/release-rolling.yml
+++ b/.github/workflows/release-rolling.yml
@@ -30,7 +30,6 @@ jobs:
           python-version: "3.9"
       - name: Install release tools
         run: |
-          uv sync --only-group release --no-lock
           # Install the release utility as a package from master so the command
           # is always the canonical version regardless of how the workflow was triggered.
           uv pip install .github/scripts/


### PR DESCRIPTION
All the dependencies are already declared in the release_utility package under scripts...