### PR TITLE
Avoid evaluating lazy values during env overrides

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1200,10 +1200,12 @@ class Settings:
             tomlfy_filter=tomlfy_filter,
         )
 
-        # Fix for #869 - The call to getattr trigger early evaluation
-        existing = (
-            self.store.get(key, None) if not isinstance(parsed, Lazy) else None
-        )
+        # Fix for #869 - Evaluating an existing lazy value during set can
+        # fail before a complete replacement value is stored.
+        existing = None
+        if not isinstance(parsed, Lazy):
+            with suppress(AttributeError, KeyError):
+                existing = self.store.get(key, bypass_eval=True)
 
         if getattr(parsed, "_dynaconf_insert", False):
             # `@insert` calls insert in a list by index

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -1205,7 +1205,10 @@ class Settings:
         existing = None
         if not isinstance(parsed, Lazy):
             with suppress(AttributeError, KeyError):
-                existing = self.store.get(key, bypass_eval=True)
+                if isinstance(self.store, DataDict):
+                    existing = self.store.get(key, bypass_eval=True)
+                else:
+                    existing = self.store.get(key)
 
         if getattr(parsed, "_dynaconf_insert", False):
             # `@insert` calls insert in a list by index

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1076,6 +1076,49 @@ def test_from_env_method(clean_env, tmpdir):
     assert settings.A_DEFAULT == "From default env"
 
 
+def test_env_override_nested_lazy_value_from_included_file(
+    clean_env, monkeypatch, tmpdir
+):
+    data_1 = {
+        "default": {
+            "from_1": "from 1",
+            "nested_from_1": {"from_1": "nested from 1"},
+        }
+    }
+    data_2 = {
+        "default": {
+            "dynaconf_include": ["configuration_1.yaml"],
+            "with_jinja_from_1": "@jinja hello {{this.from_1}}",
+            "with_jinja_from_nested_1": (
+                "@jinja hello {{this.nested_from_1.from_1}}"
+            ),
+        }
+    }
+    yaml_loader.write(str(tmpdir.join("configuration_1.yaml")), data_1)
+    yaml_loader.write(str(tmpdir.join("configuration_2.yaml")), data_2)
+
+    settings = Dynaconf(
+        settings_files=["configuration_2.yaml"],
+        environments=True,
+        root_path=str(tmpdir),
+        settings_file_required=True,
+    )
+    assert settings.with_jinja_from_1 == "hello from 1"
+    assert settings.with_jinja_from_nested_1 == "hello nested from 1"
+
+    monkeypatch.setenv(
+        "DYNACONF_with_jinja_from_nested_1", "complete override"
+    )
+    settings = Dynaconf(
+        settings_files=["configuration_2.yaml"],
+        environments=True,
+        root_path=str(tmpdir),
+        settings_file_required=True,
+    )
+
+    assert settings.with_jinja_from_nested_1 == "complete override"
+
+
 def test_envless_load_file(tmpdir):
     """Ensure passing settings.load_file accepts env argument.
 


### PR DESCRIPTION
## Summary

Fixes #1356.

Environment overrides should be able to replace a lazy `@jinja` value without evaluating the old value first. `Settings.set()` was using the normal store getter for merge bookkeeping, which could evaluate the existing lazy value before the replacement was stored and raise `UndefinedError` for nested include references that were no longer needed.

## Changes

- Use the raw store lookup for the existing value during `Settings.set()` bookkeeping so plain overrides do not evaluate stale lazy values.
- Add regression coverage for overriding a nested `@jinja` value loaded through `dynaconf_include`.

## Testing

- `uv run pytest tests/test_base.py::test_env_override_nested_lazy_value_from_included_file -q`
- `uv run ruff check dynaconf/base.py tests/test_base.py`
- `LOAD_DOTENV_FOR_DYNACONF=true DOTENV_PATH_FOR_DYNACONF=tests/.env uv run pytest tests/test_base.py -q`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.