### PR TITLE
chore(python): Remove support for EOL python 3.9

### DIFF
--- a/.github/actions/install-from-artifact/action.yml
+++ b/.github/actions/install-from-artifact/action.yml
@@ -16,7 +16,7 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: false
-    default: '3.9'
+    default: '3.10'
 
 runs:
   using: "composite"

--- a/.github/scripts/pyproject.toml
+++ b/.github/scripts/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "dynaconf-release-utility"
 version = "0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["bump-my-version", "git-changelog", "packaging"]
 
 [project.scripts]

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install build dependencies
         run: uv sync --only-group release
       - name: Build wheel

--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install release tools
         run: |
           # Install from master before switching branches so the command survives checkout.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       dist-artifact: ${{ needs.build.outputs.dist-artifact }}
-      python_minimal: '["3.9", "3.13"]'
-      python_full: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+      python_minimal: '["3.10", "3.13"]'
+      python_full: '["3.10", "3.11", "3.12", "3.13"]'
       python_latest: '3.13'
     secrets: inherit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install release tools
         run: |
           # Install the release utility as a package from master so the command

--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install release tools
         run: |
           # Install the release utility as a package from master so the installed

--- a/.github/workflows/release-rolling.yml
+++ b/.github/workflows/release-rolling.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install release tools
         run: |
           # Install the release utility as a package from master so the command

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ on:
         description: 'Minimal set of Python versions to test'
         required: false
         type: string
-        default: '["3.9", "3.13"]'
+        default: '["3.10", "3.13"]'
       python_full:
         description: 'Full set of Python versions to test'
         required: false
         type: string
-        default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13"]'
       python_latest:
         description: 'Latest Python version'
         required: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,6 @@
 ---
 tasks:
   - init: >
-      pyenv install 3.9.12 &&
       pyenv install 3.10.4 &&
       pyenv global 3.10.4 &&
       make install

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -17,7 +17,7 @@ Additional links:
 
 1. Ensure your local environment is set.
     1. Clone your own fork of this repo
-    2. Activate a python3.9+ virtualenv
+    2. Activate a python3.10+ virtualenv
     3. Write the code
 2. Update the `docs/guides/` related to your changes.
 3. Update `tests_functional/` (editing or adding a new one related to your changes)
@@ -39,7 +39,7 @@ git clone git@github.com:{$USER}/dynaconf.git
 git remote add upstream https://github.com/dynaconf/dynaconf.git
 
 # Activate your Python Environment
-python3.9 -m venv venv
+python3.10 -m venv venv
 source venv/bin/activate
 
 # Install dynaconf for development

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -7,6 +7,7 @@ import os
 import re
 import warnings
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import contextmanager
 from contextlib import suppress
 from dataclasses import dataclass
@@ -15,7 +16,6 @@ from functools import lru_cache
 from functools import wraps
 from pathlib import Path
 from typing import Any
-from typing import Callable
 from typing import Optional
 from typing import Union
 

--- a/dynaconf/hooking.py
+++ b/dynaconf/hooking.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
 from typing import Any
-from typing import Callable
 
 from dynaconf.base import Settings
 from dynaconf.loaders.base import SourceMetadata

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import importlib
 import os
+from collections.abc import Callable
 from contextlib import suppress
-from typing import Callable
 from typing import TYPE_CHECKING
 
 from dynaconf import constants as ct

--- a/dynaconf/typed/compat.py
+++ b/dynaconf/typed/compat.py
@@ -1,22 +1,5 @@
-import sys
-
-
-def _get_annotations_for_python_39(schema_cls) -> dict:
-    if isinstance(schema_cls, type):
-        return schema_cls.__dict__.get("__annotations__", {})
-    else:
-        return getattr(schema_cls, "__annotations__", {})
-
-
-if sys.version_info < (3, 10):
-    from typing import Union
-
-    UnionType = Union
-    get_annotations = _get_annotations_for_python_39
-else:
-    from inspect import get_annotations
-    from types import UnionType
-
+from inspect import get_annotations
+from types import UnionType
 
 __all__ = [
     "get_annotations",

--- a/dynaconf/typed/main.py
+++ b/dynaconf/typed/main.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 # WARNING: remove the import above when debugging on Python 3.12
 # otherwise type annotations will be stringified.
-import sys
 from dataclasses import asdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 from typing import cast
 
 from dynaconf.base import LazySettings
@@ -20,10 +18,7 @@ from . import types as ty
 from . import utils as ut
 from .compat import get_annotations
 
-if sys.version_info < (3, 10):
-    dclass_args: dict[str, Any] = {}
-else:
-    dclass_args = {"kw_only": True}
+dclass_args = {"kw_only": True}
 
 
 @dataclass(**dclass_args)

--- a/dynaconf/typed/types.py
+++ b/dynaconf/typed/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # WARNING: remove this when debugging
 
+from types import NoneType
 from typing import Annotated
 from typing import TypeVar
 from typing import Union
@@ -71,7 +72,6 @@ Str = str
 Int = int
 Float = float
 Bool = bool
-NoneType = type(None)  # python 3.9 doesn't have types.NoneType
 List = list
 Tuple = tuple
 Dict = dict

--- a/dynaconf/typed/utils.py
+++ b/dynaconf/typed/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations  # WARNING: remove this when debugging
 
+from collections.abc import Callable
 from typing import Annotated
-from typing import Callable
 from typing import get_args
 from typing import get_origin
 from typing import Union

--- a/dynaconf/typed/validators.py
+++ b/dynaconf/typed/validators.py
@@ -1,8 +1,8 @@
 from __future__ import annotations  # WARNING: remove this when debugging
 
+from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
-from typing import Callable
 
 from dynaconf.utils.functional import Empty
 from dynaconf.utils.functional import empty

--- a/dynaconf/utils/files.py
+++ b/dynaconf/utils/files.py
@@ -137,10 +137,11 @@ def glob(
 ):
     """Redefined std glob assuming some defaults.
     and fallback for diffente python versions."""
-    glob_args = {"recursive": recursive}
-    if sys.version_info >= (3, 10):
-        glob_args["root_dir"] = root_dir
-        glob_args["dir_fd"] = dir_fd
+    glob_args = {
+        "recursive": recursive,
+        "root_dir": root_dir,
+        "dir_fd": dir_fd,
+    }
     if sys.version_info >= (3, 11):
         glob_args["include_hidden"] = include_hidden
     return python_glob(pathname, **glob_args)

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from contextlib import suppress
 from functools import partial
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 from pathlib import PosixPath
 from typing import Any
-from typing import Callable
 from typing import Literal
 from typing import Protocol
 from typing import TextIO

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
 from collections.abc import Sequence
 from contextlib import suppress
 from copy import deepcopy
 from itertools import chain
 from types import MappingProxyType
 from typing import Any
-from typing import Callable
 from typing import get_args
 from typing import TYPE_CHECKING
 

--- a/dynaconf/validator_conditions.py
+++ b/dynaconf/validator_conditions.py
@@ -6,16 +6,10 @@ Implement basic assertions to be used in assertion action
 from __future__ import annotations
 
 import re
+from types import UnionType
 from typing import get_args
 from typing import get_origin
 from typing import Union
-
-# NOTE: Remove when dropping 3.9
-try:
-    from types import UnionType  # type: ignore
-except ImportError:
-    UnionType = Union  # type: ignore
-# /NOTE
 
 
 def eq(value, other) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Bruno Rocha", email = "rochacbruno@gmail.com"},
 ]
 license = {text = "MIT"}
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -101,7 +100,7 @@ ba = "ba"
 # ====
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 79
 exclude = ["dynaconf/vendor*"]
 
@@ -256,7 +255,7 @@ optional_value = "final"
 # ===
 
 [tool.tox]
-envlist = ["py39", "py310", "py311", "py312", "py313"]
+envlist = ["py310", "py311", "py312", "py313"]
 whitelist_externals = ["make"]
 
 [tool.tox.testenv]

--- a/scripts/bench_tool.py
+++ b/scripts/bench_tool.py
@@ -7,7 +7,7 @@ Scenarios are auto-discovered from the scripts/scenarios/ directory.
 
 Requirements (uv will resolve these from comments):
 # /// script
-# requires-python = ">=3.9"
+# requires-python = ">=3.10"
 # dependencies = [
 #     "pyinstrument>=4.0.0",
 #     "dynaconf",

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -7,7 +7,7 @@ Create box plots from TSV benchmark data.
 
 Requirements (uv will resolve these from comments):
 # /// script
-# requires-python = ">=3.9"
+# requires-python = ">=3.10"
 # dependencies = [
 #     "pandas>=2.0.0",
 #     "matplotlib>=3.5.0",

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Annotated
 from typing import Optional
 from typing import Union
@@ -143,7 +142,6 @@ def test_union_type_validates(monkeypatch):
             Settings()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="not supported on 3.9")
 def test_new_union_validates(monkeypatch):
     class Settings(Dynaconf):
         number: int | float | bool
@@ -976,7 +974,6 @@ def test_list_enclosed_type_annotated_with_union():
         Settings(colors=[])
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="not supported on 3.9")
 def test_list_enclosed_type_annotated_with_new_union():
     # Annotated and Unionized
     class Settings(Dynaconf):

--- a/tests_functional/issues/982_wildcard/app.py
+++ b/tests_functional/issues/982_wildcard/app.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
-
-# If python version is <  3.10 skip test
-# glob on that version of Python doesnt have root_dir param
-if sys.version_info < (3, 10):
-    print("Skip test")
-    sys.exit(0)
 
 from dynaconf import Dynaconf
 


### PR DESCRIPTION
As the title says, it's EOL for some time by now: https://devguide.python.org/versions/

Partial closes #1395 