### PR TITLE
fix: preserve nested dict key order when object_merge merges old into new

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -141,6 +141,16 @@ def object_merge(
                         full_path=full_path[1:] if full_path else None,
                         list_merge=list_merge,
                     )
+
+            # Restore old key order: keys that exist in old keep old's
+            # relative order; keys that are new-only come last.
+            old_keys = list(safe_items(old))
+            old_key_set = {k for k, _ in old_keys}
+            new_only = [k for k in new if k not in old_key_set]
+            ordered = [k for k, _ in old_keys if k in new] + new_only
+            for k in ordered:
+                new[k] = new.pop(k)
+
         handle_metavalues(old, new, list_merge=list_merge)
 
     return new

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -305,6 +305,25 @@ def test_merge_existing_dict():
     assert new == {"host": "localhost", "port": 666, "user": "admin"}
 
 
+def test_merge_dict_preserves_old_key_order():
+    # When merging old into new (which contains only a subset of old's keys),
+    # the resulting dict must retain old's key order.  Previously, keys that
+    # existed in new were kept at the front while old-only keys were appended,
+    # causing sibling keys to be reordered.  See #1183.
+    old = {"a": 1, "b": 2, "c": 3}
+    new = {"b": 99}  # only the middle key is updated
+    object_merge(old, new)
+    assert list(new.keys()) == ["a", "b", "c"]
+    assert new == {"a": 1, "b": 99, "c": 3}
+
+    # Keys genuinely new to `new` (not in old) are placed at the end.
+    old2 = {"x": 10, "y": 20}
+    new2 = {"z": 30, "x": 99}
+    object_merge(old2, new2)
+    assert list(new2.keys()) == ["x", "y", "z"]
+    assert new2 == {"x": 99, "y": 20, "z": 30}
+
+
 def test_merge_dict_with_meta_values(settings):
     existing = {"A": 1, "B": 2, "C": 3}
     new = {


### PR DESCRIPTION
## What

Fixes #1183.

When `settings.set("parent.child_key", value)` is called (e.g. from within `validators.validate_all()`), `_dotted_set` builds a new dict containing only the targeted leaf and then calls `object_merge(old=existing_data, new=new_data)`.  Inside `object_merge`, sibling keys that already existed in `old` but were absent from `new` were **appended** to `new` after the merge loop.  Because each validator call re-runs `_dotted_set` for its specific dotted key, the final ordering of sibling keys in the merged dict ended up being determined by the order validators were registered—not the original file order.

Minimal repro:

```python
from dynaconf import Dynaconf, Validator
# settings.yaml contains:  03_key: {01_nested_key: …, 02_nested_key: …, 03_nested_key: {…}}

settings = Dynaconf(settings_file="settings.yaml")
print(list(settings.get("03_key").keys()))
# ['01_nested_key', '02_nested_key', '03_nested_key']

settings.validators.register(
    Validator("03_key.01_nested_key", condition=lambda v: True),
    Validator("03_key.02_nested_key", condition=lambda v: True),
    Validator("03_key.03_nested_key.01_nested_nested_key", condition=lambda v: True),
    # …
)
settings.validators.validate_all()

print(list(settings.get("03_key").keys()))
# before fix: ['03_nested_key', '02_nested_key', '01_nested_key']  ← reversed
# after fix:  ['01_nested_key', '02_nested_key', '03_nested_key']  ← preserved
```

## How

After the merge loop in `object_merge`, the keys of `new` are reordered so that keys found in `old` appear in `old`'s original sequence; any keys that are genuinely new to `new` (not present in `old`) are placed at the end.  The change is a 9-line reorder step that only runs when `should_merge` is `True`.

## Tests

- Added `test_merge_dict_preserves_old_key_order` to `tests/test_utils.py` that directly verifies `object_merge` key ordering.
- All existing tests in `test_utils.py`, `test_validators.py`, `test_base.py`, and `test_nodes.py` continue to pass (the only pre-existing failures are due to optional `jinja2` / `ini` dependencies not being installed in the test environment).

---

This pull request was prepared with the assistance of AI, under my direction and review.