### PR TITLE
fix(nodes): Improve converage of DataList and DataDict

### DIFF
--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -54,10 +54,10 @@ class DataDict(dict):
         convert_containers(self, self.items(), core)
 
     def update(self, data):
-        super().update(ensure_containers(data, self.__meta__.core))
+        super().update(data)
 
     def setdefault(self, k, v):
-        return super().setdefault(k, ensure_containers(v, self.__meta__.core))
+        return super().setdefault(k, v)
 
     def copy(self, bypass_eval=False):
         if not bypass_eval:
@@ -121,8 +121,7 @@ class DataDict(dict):
             )
 
     def __setitem__(self, k, v):
-        result = ensure_containers(v, self.__meta__.core)
-        super().__setitem__(k, result)
+        super().__setitem__(k, v)
 
     def __setattr__(self, k, v):
         # NOTE: We shouldnt use setattr to store items. If an item was assigned with setatttr
@@ -410,27 +409,9 @@ class DataList(list):
     def copy(self):
         return DataList((x for x in self), core=self.__meta__.core)
 
-    def append(self, v):
-        super().append(ensure_containers(v, self.__meta__.core))
-
-    def insert(self, i, v):
-        super().insert(i, ensure_containers(v, self.__meta__.core))
-
-    def extend(self, data):
-        super().extend(ensure_containers(data, self.__meta__.core))
-
     def __getitem__(self, index):
         result = super().__getitem__(index)
         return recursively_evaluate_lazy_format(result, self.__meta__.core)
-
-    def __setitem__(self, k, v):
-        super().__setitem__(k, ensure_containers(v, self.__meta__.core))
-
-    def __add__(self, v):
-        return super().__add__(ensure_containers(v, self.__meta__.core))
-
-    def __iadd__(self, v):
-        return super().__iadd__(ensure_containers(v, self.__meta__.core))
 
     def __repr__(self):
         # NOTE: debatable choice: same representation of list
@@ -802,17 +783,6 @@ def recursively_evaluate_lazy_format(value, settings):
 
     return value
 
-
-def ensure_containers(data, core):
-    # NOTE: this is to ensure that the nodes nested dict and lists are always
-    # converted to DataDict and DataList. However, that change is not compatible
-    # with what we had with DynaBox/BoxList. Leaving here for awareness.
-    #
-    # if data.__class__ is dict:
-    #     return DataDict(data, core=core)
-    # elif data.__class__ is list:
-    #     return DataList(data, core=core)
-    return data
 
 
 def box_deprecation_warning(

--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -115,7 +115,10 @@ class DataDict(dict):
     def items(self, bypass_eval=False):
         if not bypass_eval:
             yield from super().items()
-        yield from ((k, self.get(k, bypass_eval=True)) for k in self.keys())
+        else:
+            yield from (
+                (k, self.get(k, bypass_eval=True)) for k in self.keys()
+            )
 
     def __setitem__(self, k, v):
         result = ensure_containers(v, self.__meta__.core)
@@ -424,7 +427,7 @@ class DataList(list):
         super().__setitem__(k, ensure_containers(v, self.__meta__.core))
 
     def __add__(self, v):
-        super().__add__(ensure_containers(v, self.__meta__.core))
+        return super().__add__(ensure_containers(v, self.__meta__.core))
 
     def __iadd__(self, v):
         return super().__iadd__(ensure_containers(v, self.__meta__.core))

--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -53,12 +53,6 @@ class DataDict(dict):
         self.__meta__ = NodeMetadata(core=core)
         convert_containers(self, self.items(), core)
 
-    def update(self, data):
-        super().update(data)
-
-    def setdefault(self, k, v):
-        return super().setdefault(k, v)
-
     def copy(self, bypass_eval=False):
         if not bypass_eval:
             return self.__class__(
@@ -119,9 +113,6 @@ class DataDict(dict):
             yield from (
                 (k, self.get(k, bypass_eval=True)) for k in self.keys()
             )
-
-    def __setitem__(self, k, v):
-        super().__setitem__(k, v)
 
     def __setattr__(self, k, v):
         # NOTE: We shouldnt use setattr to store items. If an item was assigned with setatttr
@@ -782,7 +773,6 @@ def recursively_evaluate_lazy_format(value, settings):
         )
 
     return value
-
 
 
 def box_deprecation_warning(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 import pytest
 
 from dynaconf.base import DynaconfCore
+from dynaconf.nodes import AccessError
 from dynaconf.nodes import DataDict
 from dynaconf.nodes import DataList
 from dynaconf.nodes import DynaconfNotInitialized
@@ -188,57 +189,129 @@ DataDict and Datalist. We may wanna do that, but it breaks behavior.
 """
 
 
-@pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
-def test_dict_methods():
-    core = DynaconfCore("test")
-    di = DataDict(core=core)
+class TestDataDict:
+    @pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
+    def test_dict_methods(self):
+        core = DynaconfCore("test")
+        di = DataDict(core=core)
 
-    data0 = {"a": [1, {"b": [2]}]}
-    data1 = {"c": [3, {"d": [4]}]}
+        data0 = {"a": [1, {"b": [2]}]}
+        data1 = {"c": [3, {"d": [4]}]}
 
-    def assert_fn(container):
-        assert container.__class__ in (DataDict, DataList)
-        assert get_core(container) == core
+        def assert_fn(container):
+            assert container.__class__ in (DataDict, DataList)
+            assert get_core(container) == core
 
-    di["a"] = data0["a"]
-    recursive_walk(di, assert_fn)
+        di["a"] = data0["a"]
+        recursive_walk(di, assert_fn)
 
-    di.update(data1)
-    recursive_walk(di, assert_fn)
+        di.update(data1)
+        recursive_walk(di, assert_fn)
 
-    popped = di.pop("a")
-    assert isinstance(popped, DataList)
+        popped = di.pop("a")
+        assert isinstance(popped, DataList)
 
-    d_copy = di.copy()
-    assert isinstance(d_copy, DataDict)
-    di.clear()
-    assert len(di) == 0
+        d_copy = di.copy()
+        assert isinstance(d_copy, DataDict)
+        di.clear()
+        assert len(di) == 0
+
+    def test_items(self):
+        di = DataDict({"a": 1, "b": 2})
+        assert len(list(di.items())) == 2
+        assert len(list(di.items(bypass_eval=True))) == 2
+        assert dict(di.items(bypass_eval=True)) == {"a": 1, "b": 2}
+
+    def test_delitem(self):
+        di = DataDict({"a": 1, "b": 2})
+        del di["a"]
+        assert "a" not in di
+        assert len(di) == 1
+
+    def test_delitem_case_insensitive(self):
+        di = DataDict({"FOO": 1})
+        del di["foo"]
+        assert len(di) == 0
+
+    def test_delattr(self):
+        di = DataDict({"a": 1})
+        del di.a
+        assert len(di) == 0
+
+    def test_contains(self):
+        di = DataDict({"FOO": 1, "bar": 2})
+        assert "FOO" in di
+        assert "foo" in di
+        assert "BAR" in di
+        assert "missing" not in di
+
+    def test_getattr_missing_raises(self):
+        di = DataDict({"a": 1})
+        with pytest.raises(AccessError):
+            _ = di.nonexistent_key
 
 
-@pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
-def test_list_methods():
-    li = DataList()
+class TestDataList:
+    @pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
+    def test_list_methods(self):
+        li = DataList()
 
-    li.append({"x": 1})
-    assert isinstance(li[0], DataDict)
+        li.append({"x": 1})
+        assert isinstance(li[0], DataDict)
 
-    li.extend([{"y": 2}, [1, 2]])
-    assert isinstance(li[1], DataDict)
-    assert isinstance(li[2], DataList)
+        li.extend([{"y": 2}, [1, 2]])
+        assert isinstance(li[1], DataDict)
+        assert isinstance(li[2], DataList)
 
-    li.insert(0, {"z": 3})
-    assert isinstance(li[0], DataDict)
+        li.insert(0, {"z": 3})
+        assert isinstance(li[0], DataDict)
 
-    popped = li.pop()
-    assert isinstance(popped, DataList)
+        popped = li.pop()
+        assert isinstance(popped, DataList)
 
-    li[1:1] = [{"w": 4}]
-    assert isinstance(li[1], DataDict)
+        li[1:1] = [{"w": 4}]
+        assert isinstance(li[1], DataDict)
 
-    d_copy = li.copy()
-    assert isinstance(d_copy, DataList)
-    li.clear()
-    assert len(li) == 0
+        d_copy = li.copy()
+        assert isinstance(d_copy, DataList)
+        li.clear()
+        assert len(li) == 0
+
+    def test_append(self):
+        li = DataList()
+        li.append(1)
+        assert list(li) == [1]
+
+    def test_insert(self):
+        li = DataList([1, 3])
+        li.insert(1, 2)
+        assert list(li) == [1, 2, 3]
+
+    def test_extend(self):
+        li = DataList([1])
+        li.extend([2, 3])
+        assert list(li) == [1, 2, 3]
+
+    def test_copy(self):
+        li = DataList([1, 2, 3])
+        li_copy = li.copy()
+        assert isinstance(li_copy, DataList)
+        assert list(li_copy) == [1, 2, 3]
+        assert li_copy is not li
+
+    def test_setitem(self):
+        li = DataList([1, 2, 3])
+        li[1] = 99
+        assert li[1] == 99
+
+    def test_add(self):
+        x = DataList(["a"])
+        assert list(x + ["b"]) == ["a", "b"]
+
+    def test_iadd(self):
+        li = DataList([1])
+        li += [2, 3]
+        assert list(li) == [1, 2, 3]
 
 
 def test_nested_structures():

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -183,38 +183,16 @@ def test_data_containers_init(input):
     recursive_walk(data, assert_fn)
 
 
-CAST_ON_INITIALIZATION_ASSUMPTION = """
-This assumes the DataDict will recursively transform nested dict/list in
-DataDict and Datalist. We may wanna do that, but it breaks behavior.
-"""
-
-
 class TestDataDict:
-    @pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
-    def test_dict_methods(self):
-        core = DynaconfCore("test")
-        di = DataDict(core=core)
+    def test_init_converts_nested(self):
+        di = DataDict({"a": {"b": [1, 2]}})
+        assert isinstance(di["a"], DataDict)
+        assert isinstance(di["a"]["b"], DataList)
 
-        data0 = {"a": [1, {"b": [2]}]}
-        data1 = {"c": [3, {"d": [4]}]}
-
-        def assert_fn(container):
-            assert container.__class__ in (DataDict, DataList)
-            assert get_core(container) == core
-
-        di["a"] = data0["a"]
-        recursive_walk(di, assert_fn)
-
-        di.update(data1)
-        recursive_walk(di, assert_fn)
-
-        popped = di.pop("a")
-        assert isinstance(popped, DataList)
-
-        d_copy = di.copy()
-        assert isinstance(d_copy, DataDict)
-        di.clear()
-        assert len(di) == 0
+    def test_mutation_does_not_convert(self):
+        di = DataDict()
+        di["a"] = {"x": 1}
+        assert type(di["a"]) is dict
 
     def test_items(self):
         di = DataDict({"a": 1, "b": 2})
@@ -252,30 +230,15 @@ class TestDataDict:
 
 
 class TestDataList:
-    @pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
-    def test_list_methods(self):
+    def test_init_converts_nested(self):
+        li = DataList([{"a": 1}, [2, 3]])
+        assert isinstance(li[0], DataDict)
+        assert isinstance(li[1], DataList)
+
+    def test_mutation_does_not_convert(self):
         li = DataList()
-
         li.append({"x": 1})
-        assert isinstance(li[0], DataDict)
-
-        li.extend([{"y": 2}, [1, 2]])
-        assert isinstance(li[1], DataDict)
-        assert isinstance(li[2], DataList)
-
-        li.insert(0, {"z": 3})
-        assert isinstance(li[0], DataDict)
-
-        popped = li.pop()
-        assert isinstance(popped, DataList)
-
-        li[1:1] = [{"w": 4}]
-        assert isinstance(li[1], DataDict)
-
-        d_copy = li.copy()
-        assert isinstance(d_copy, DataList)
-        li.clear()
-        assert len(li) == 0
+        assert type(li[0]) is dict
 
     def test_append(self):
         li = DataList()
@@ -341,28 +304,6 @@ def test_method_preservation():
     li = DataList([{"x": 2}, {"x": 1}])
     li.sort(key=lambda x: x["x"])
     assert li[0]["x"] == 1
-
-
-@pytest.mark.skip(CAST_ON_INITIALIZATION_ASSUMPTION)
-def test_mutable_operations():
-    di = DataDict()
-    # Test setdefault
-    item = di.setdefault("a", {"x": 1})
-    assert isinstance(item, DataDict)
-
-    # Test dict comprehension conversion
-    di = DataDict({k: {"val": v} for k, v in [("a", 1), ("b", 2)]})
-    assert all(isinstance(v, DataDict) for v in di.values())
-    assert all(isinstance(v, DataDict) for k, v in di.items())
-
-    # Test list concatenation
-    li = DataList()
-    li += [{"x": 1}]
-    assert isinstance(li[0], DataDict)
-
-    # Test multiply
-    li = DataList([{"x": 1}]) * 2
-    assert isinstance(li[0], DataDict) and isinstance(li[1], DataDict)
 
 
 def test_repr():


### PR DESCRIPTION
* Adds the missing `return` to DataList.__add__ so list concatenation returns the result instead of None.
* Missing else meant both branches executed when bypass_eval=False, emitting 2n items for a dict of size n.
* Adds test coverage for DataDict.__delitem__, __delattr__, __contains__, items(bypass_eval=True), AccessError from __getattr__, and DataList append, insert, extend, copy, __setitem__, __iadd__.
* Remove no-opt function and unnecessary dict/list overrides

Fixes #1402