### PR TITLE
fix: Remove call to deprecated functions on public APIs

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -40,6 +40,7 @@ from dynaconf.utils import missing
 from dynaconf.utils import normalize_kwargs
 from dynaconf.utils import object_merge
 from dynaconf.utils import RENAMED_VARS
+from dynaconf.utils import to_dict
 from dynaconf.utils import upperfy
 from dynaconf.utils.files import find_file
 from dynaconf.utils.files import glob
@@ -502,7 +503,7 @@ class Settings:
         """
         ctx_mgr = suppress() if env is None else self.using_env(env)
         with ctx_mgr:
-            data = self.store.to_dict().copy()
+            data = to_dict(self.store)
             # if not internal remove internal settings
             if not internal:
                 for name in UPPER_DEFAULT_SETTINGS:
@@ -787,7 +788,7 @@ class Settings:
             new_data.update(
                 {
                     key: value
-                    for key, value in self.store.to_dict().copy().items()
+                    for key, value in to_dict(self.store).items()
                     if key.isupper() and key not in RENAMED_VARS
                 }
             )

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -17,6 +17,7 @@ from dynaconf.loaders.base import SourceMetadata
 from dynaconf.nodes import DataDict
 from dynaconf.utils import deduplicate
 from dynaconf.utils import ensure_a_list
+from dynaconf.utils import to_dict
 from dynaconf.utils.files import get_local_filename
 from dynaconf.utils.files import glob
 from dynaconf.utils.files import has_magic
@@ -443,7 +444,7 @@ def write(filename, data, env=None, merge=False):
     if not loader:
         raise OSError(f"{loader_name} cannot be found.")
 
-    data = DataDict(data, box_settings={}).to_dict()
+    data = to_dict(DataDict(data, box_settings={}))
     if loader is not py_loader and env and env not in data:
         data = {env: data}
 

--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -426,6 +426,7 @@ class DataList(list):
         box_deprecation_warning(
             "to_list", "DataList", "Use list(data_list) instead."
         )
+        # to_dict recursively converts to both dicts and lists
         return ut.to_dict(self)
 
     def to_json(

--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -171,15 +171,7 @@ class DataDict(dict):
         box_deprecation_warning(
             "to_dict", "DataDict", "Use dict(data_dict) instead."
         )  # pragma: nocover
-        out_dict = dict(self)
-        for k, v in out_dict.items():
-            if v is self:
-                out_dict[k] = out_dict
-            elif isinstance(v, DataDict):
-                out_dict[k] = v.to_dict()
-            elif isinstance(v, DataList):
-                out_dict[k] = v.to_list()
-        return out_dict
+        return ut.to_dict(self)
 
     def merge_update(self, __m=None, **kwargs):  # pragma: nocover
         """Merge update with another dict"""
@@ -408,20 +400,22 @@ class DataList(list):
         # NOTE: debatable choice: same representation of list
         return f"{list(self)!r}"
 
-    # Box compatibility. Remove in 4.0
-
     def __copy__(self):  # pragma: nocover
-        box_deprecation_warning("__copy__", "DataList")
+        # Not part of the plain list API, but needed to propagate core.
+        # Consider removing in the future if we can
         return self.copy()
 
     def __deepcopy__(self, memo=None):  # pragma: nocover
-        box_deprecation_warning("__deepcopy__", "DataList")
+        # Not part of the plain list API, but needed to propagate core.
+        # Consider removing in the future if we can
         out = self.__class__(core=self.__meta__.core)
         memo = memo or {}
         memo[id(self)] = out
         for k in self:
             out.append(copy.deepcopy(k, memo=memo))
         return out
+
+    # Box compatibility. Remove in 4.0
 
     def to_list(self):  # pragma: nocover
         """
@@ -432,17 +426,7 @@ class DataList(list):
         box_deprecation_warning(
             "to_list", "DataList", "Use list(data_list) instead."
         )
-        new_list = []
-        for x in self:
-            if x is self:
-                new_list.append(new_list)
-            elif isinstance(x, DataDict):
-                new_list.append(x.to_dict())
-            elif isinstance(x, DataList):
-                new_list.append(x.to_list())
-            else:
-                new_list.append(x)
-        return new_list
+        return ut.to_dict(self)
 
     def to_json(
         self,

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -634,6 +634,15 @@ def prepare_json(data: Any) -> Any:
     return data
 
 
+def to_dict(obj: Any) -> Any:
+    """Recursively convert dict/list subclasses to plain Python types."""
+    if isinstance(obj, dict):
+        return {k: to_dict(obj[k]) for k in obj}
+    elif isinstance(obj, list):
+        return [to_dict(x) for x in obj]
+    return obj
+
+
 def container_items(container: dict | list):
     if isinstance(container, dict):
         return container.items()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ from dynaconf.base import LazySettings
 @pytest.fixture
 def no_deprecations():
     with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+        warnings.filterwarnings(
+            "error", category=DeprecationWarning, module="dynaconf"
+        )
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import copy
 import os
 import sys
+import warnings
 from pathlib import Path
 from textwrap import dedent
 
 import pytest
 
 from dynaconf.base import LazySettings
+
+
+@pytest.fixture
+def no_deprecations():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        yield
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -14,7 +14,10 @@ from dynaconf.loaders import yaml_loader
 from dynaconf.nodes import DataDict
 from dynaconf.nodes import DataList
 from dynaconf.strategies.filtering import PrefixFilter
+from dynaconf.utils import to_dict
 from dynaconf.utils.parse_conf import true_values
+
+pytestmark = pytest.mark.usefixtures("no_deprecations")
 
 
 def test_deleted_raise(settings):
@@ -151,15 +154,12 @@ def test_populate_obj_convert_to_dict(settings):
     settings.populate_obj(obj)
     assert isinstance(obj.ADICT, DataDict)
     assert isinstance(obj.ALIST, DataList)
-    assert isinstance(obj.ADICT.to_yaml(), str)
 
     # now make sure convert_to_dict=True brings in dict and list
     obj = Obj()
     settings.populate_obj(obj, convert_to_dict=True)
     assert isinstance(obj.ADICT, dict)
     assert isinstance(obj.ALIST, list)
-    with pytest.raises(AttributeError):
-        assert isinstance(obj.ADICT.to_yaml(), str)
 
 
 def test_call_works_as_get(settings):
@@ -878,14 +878,14 @@ def test_dotted_set(settings):
     settings.set("nested_1.nested_2.nested_3.nested_4", "secret")
 
     assert settings.NESTED_1.NESTED_2.NESTED_3.NESTED_4 == "secret"
-    assert settings.NESTED_1.NESTED_2.NESTED_3.to_dict() == {
+    assert to_dict(settings.NESTED_1.NESTED_2.NESTED_3) == {
         "nested_4": "secret"
     }
-    assert settings.NESTED_1.NESTED_2.to_dict() == {
+    assert to_dict(settings.NESTED_1.NESTED_2) == {
         "nested_3": {"nested_4": "secret"}
     }
 
-    assert settings.get("nested_1").to_dict() == {
+    assert to_dict(settings.get("nested_1")) == {
         "nested_2": {"nested_3": {"nested_4": "secret"}}
     }
 
@@ -897,14 +897,14 @@ def test_dotted_set(settings):
 
     settings.set("nested_1.nested_2.nested_3.nested_4", "Updated Secret")
     assert settings.NESTED_1.NESTED_2.NESTED_3.NESTED_4 == "Updated Secret"
-    assert settings.NESTED_1.NESTED_2.NESTED_3.to_dict() == {
+    assert to_dict(settings.NESTED_1.NESTED_2.NESTED_3) == {
         "nested_4": "Updated Secret"
     }
-    assert settings.NESTED_1.NESTED_2.to_dict() == {
+    assert to_dict(settings.NESTED_1.NESTED_2) == {
         "nested_3": {"nested_4": "Updated Secret"}
     }
 
-    assert settings.get("nested_1").to_dict() == {
+    assert to_dict(settings.get("nested_1")) == {
         "nested_2": {"nested_3": {"nested_4": "Updated Secret"}},
         "nested_2_0": "Hello",
     }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -158,8 +158,8 @@ def test_populate_obj_convert_to_dict(settings):
     # now make sure convert_to_dict=True brings in dict and list
     obj = Obj()
     settings.populate_obj(obj, convert_to_dict=True)
-    assert isinstance(obj.ADICT, dict)
-    assert isinstance(obj.ALIST, list)
+    assert type(obj.ADICT) is dict
+    assert type(obj.ALIST) is list
 
 
 def test_call_works_as_get(settings):

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -6,8 +6,11 @@ from contextlib import nullcontext
 
 import pytest
 
+from dynaconf.utils import to_dict
 from dynaconf.utils.parse_conf import DynaconfFormatError
 from dynaconf.utils.parse_conf import DynaconfParseError
+
+pytestmark = pytest.mark.usefixtures("no_deprecations")
 
 
 def test_end_to_end(settings):
@@ -87,7 +90,7 @@ def test_359_jinja_interpolation():
 
     expected = {"main": "hello world"}
     assert settings.get("a.main") == "hello world"
-    assert settings.get("a").to_dict() == expected
+    assert to_dict(settings.get("a")) == expected
 
 
 def test_392_interpolation_inside_list():

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -12,6 +12,8 @@ from dynaconf.loaders.env_loader import load
 from dynaconf.loaders.env_loader import load_from_env
 from dynaconf.loaders.env_loader import write
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 # GLOBAL ENV VARS
 environ["DYNACONF_HOSTNAME"] = "host.com"
 environ["DYNACONF_PORT"] = "@int 5000"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -21,6 +21,8 @@ from dynaconf.utils.inspect import KeyNotFoundError
 from dynaconf.utils.inspect import OutputFormatError
 from dynaconf.validator import Validator
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 
 def create_file(filename: str, data: str) -> str:
     with open(filename, "w") as f:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -5,6 +5,8 @@ import pytest
 
 from dynaconf import Dynaconf
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 
 @pytest.fixture
 def file_factory(tmp_path: Path):

--- a/tests/test_nested_loading.py
+++ b/tests/test_nested_loading.py
@@ -4,6 +4,8 @@ import pytest
 
 from dynaconf.base import LazySettings
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 TOML = """
 [default]
 dynaconf_include = ["plugin1.toml", "plugin2.toml", "plugin2.toml"]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -17,6 +17,8 @@ from dynaconf.utils import data_print
 from dynaconf.utils.boxing import DynaBox
 from dynaconf.vendor.box import BoxList
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 # DynaBox compatibility tests
 # Copied from tests/test_dynabox.py
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -447,7 +447,7 @@ class TestBoxCompatibility:
             method = getattr(DataList, method_name)
             assert method(filename=filename) == test_data
 
-    def test_box_list_copying(self, deprecated_context):
+    def test_box_list_copying(self):
         test_data = [{"a": [1, 2, 3]}, {"a": [4, 5, 6]}]
         datalist_origin = DataList(test_data)
         boxlist_origin = BoxList(test_data)

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -14,6 +14,8 @@ from dynaconf.typed import Options
 from dynaconf.typed import ValidationError
 from dynaconf.typed import Validator
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 
 def test_immediate_validation():
     class Settings(Dynaconf):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -11,6 +11,8 @@ from dynaconf import ValidationError
 from dynaconf import Validator
 from dynaconf.validator import ValidatorList
 
+pytestmark = pytest.mark.usefixtures("no_deprecations")
+
 TOML = """
 [default]
 EXAMPLE = true


### PR DESCRIPTION
* Add fixture to catch that our tests using public API don't emit deprecation themselves
* Fix deprecations being called for indirect deprecated method calls

Closes: #1393