### PR TITLE
fix: prevent RecursionError in from_env with validate_on_update

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -880,8 +880,9 @@ class Settings:
             return self.MAIN_ENV_FOR_DYNACONF.lower()
 
         if self.FORCE_ENV_FOR_DYNACONF is not None:
-            self.ENV_FOR_DYNACONF = self.FORCE_ENV_FOR_DYNACONF
-            return self.FORCE_ENV_FOR_DYNACONF
+            forced = self.FORCE_ENV_FOR_DYNACONF
+            self.set("ENV_FOR_DYNACONF", forced, validate=False)
+            return forced
 
         try:
             return self.loaded_envs[-1]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -921,3 +921,19 @@ def test_validation_after_setenv_or_from_env(tmp_path):
     with pytest.raises(ValidationError):
         other_settings = settings.from_env("production")
         other_settings.validators.validate_all()
+
+
+def test_from_env_with_validate_on_update_does_not_recurse():
+    """from_env must not infinitely recurse via current_env -> validation."""
+    from dynaconf import Dynaconf
+    from dynaconf import Validator
+
+    settings = Dynaconf(
+        environments=True,
+        validate_on_update=True,
+        validators=[Validator("FOO", default="bar")],
+    )
+
+    # Before the fix this raised RecursionError.
+    other_settings = settings.from_env("development")
+    assert other_settings.current_env.lower() == "development"


### PR DESCRIPTION
With `validate_on_update=True`, `settings.from_env(...)` reads `current_env`, which rebinds `ENV_FOR_DYNACONF` to the forced env. That triggers validation, validation reads `current_env` again, and that causes the loop.

Fix: when `current_env` updates `ENV_FOR_DYNACONF` from the forced env, skip validation for that update (`validate=False`).

Fixes #1408