### PR TITLE
fix: avoid crash merging a dynaconf_merge list into a missing key

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -237,7 +237,7 @@ def handle_metavalues(
                     value.remove("dynaconf_merge_unique")
                     unique = True
 
-                for item in old.get(key)[::-1]:
+                for item in (old.get(key) or [])[::-1]:
                     if unique and item in value:
                         continue
                     value.insert(0, item)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -334,6 +334,22 @@ def test_merge_dict_with_meta_values(settings):
     assert new == {"A": 1, "C": 4}
 
 
+def test_merge_list_token_when_key_absent_in_old():
+    # A list carrying the `dynaconf_merge` marker must not crash when the key
+    # holding it is absent from the existing data (there is nothing to merge
+    # into).  The marker is consumed and the provided list is kept as-is.
+    old = {"existing": 1}
+    new = {"ports": [8080, "dynaconf_merge"]}
+    object_merge(old, new)
+    assert new == {"existing": 1, "ports": [8080]}
+
+    # Same for the `dynaconf_merge_unique` marker.
+    old = {"existing": 1}
+    new = {"ports": [8080, "dynaconf_merge_unique"]}
+    object_merge(old, new)
+    assert new == {"existing": 1, "ports": [8080]}
+
+
 def test_trimmed_split():
     # No sep
     assert trimmed_split("hello") == ["hello"]


### PR DESCRIPTION
I hit a `TypeError: 'NoneType' object is not subscriptable` when a list value uses the `dynaconf_merge` marker for a key that only exists in the higher-priority source (so there's no existing list to merge into).

Minimal repro:

```python
from dynaconf import Dynaconf

s = Dynaconf()
s.set("CONFIG", {"existing": 1})
s.set("CONFIG", {"ports": [8080, "dynaconf_merge"]}, merge=True)  # boom
```

It also shows up from settings files when merge is enabled and a nested key with a `dynaconf_merge` list appears in only one env:

```toml
[default.server]
host = "0.0.0.0"

[development.server]
dynaconf_merge = true
ports = [8080, "dynaconf_merge"]
```

In `handle_metavalues`, the list-marker branch iterates `old.get(key)[::-1]`, which blows up when `old.get(key)` is `None`. There's nothing to merge into in that case, so I treat the missing value as an empty list — the marker is consumed and the provided list is kept as-is (`ports == [8080]`). The sibling dict-marker branch already degrades gracefully via `object_merge(old.get(key), ...)`, so this brings the list case in line with it.

Added a unit test in `tests/test_utils.py` covering both `dynaconf_merge` and `dynaconf_merge_unique` when the key is absent in old.