### PR TITLE
fix: Fixed 'dynaconf validate' edge cases with validation_file.toml

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -346,11 +346,24 @@ Options:
 
 Starting on version 1.0.1 it is possible to define validators in **TOML** file called **dynaconf_validators.toml** placed in the same folder as your settings files.
 
-`dynaconf_validators.toml` equivalent to program above
+The format depends on whether your settings use [`environments`](configuration.md#environments).
 
-```ini
+**Without environments** (`environments=False`):
+
+Top-level keys are field names. No section headers are needed.
+
+```toml
+version = {must_exist=true}
+name = {must_exist=true}
+password = {must_exist=false}
+```
+
+**With environments** (`environments=True`):
+
+Section headers are environment names. Each section scopes its validators to that environment.
+
+```toml
 [default]
-
 version = {must_exist=true}
 name = {must_exist=true}
 password = {must_exist=false}

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -136,7 +136,7 @@ It is possible to define validators in a `TOML` file called `dynaconf_validators
 
 `dynaconf_validators.toml` is equivalent to the program below:
 
-```ini
+```toml
 [default]
 
 version = {must_exist=true}

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -820,9 +820,9 @@ def validate(path):  # pragma: no cover
         )
         sys.exit(1)
 
-    # guarantee there is an environment
     validation_data = {k.lower(): v for k, v in validation_data.items()}
-    if not validation_data.get("default"):
+    if not settings.ENVIRONMENTS_FOR_DYNACONF:
+        # flat file: top-level keys are field names, not environments
         validation_data = {"default": validation_data}
 
     success = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -465,48 +465,86 @@ host = "test.com"
 """
 
 
-def test_validate(tmpdir):
-    validation_file = tmpdir.join("dynaconf_validators.toml")
-    validation_file.write(VALIDATION)
+class TestValidate:
+    def _run_validate(
+        self,
+        *,
+        settings_mod: str,
+        validation_file: str,
+        env: dict | None = None,
+    ) -> str:
+        return run(
+            ["-i", settings_mod, "validate", "-p", validation_file], env
+        )
 
-    toml_valid = tmpdir.mkdir("valid").join("settings.toml")
-    toml_valid.write(TOML_VALID)
+    def test_basic(self, create_file):
+        validators_toml = create_file("dynaconf_validators.toml", VALIDATION)
+        toml_valid = create_file("settings_valid.toml", TOML_VALID)
+        toml_invalid = create_file("settings_invalid.toml", TOML_INVALID)
 
-    toml_invalid = tmpdir.mkdir("invalid").join("settings.toml")
-    toml_invalid.write(TOML_INVALID)
+        result = self._run_validate(
+            settings_mod="tests.config.settingsenv",
+            validation_file=str(validators_toml),
+            env={"SETTINGS_FILE_FOR_DYNACONF": str(toml_valid)},
+        )
+        assert "Validation success!" in result
 
-    result = run(
+        result = self._run_validate(
+            settings_mod="tests.test_cli.settings",
+            validation_file=str(validators_toml.parent),
+            env={"SETTINGS_FILE_FOR_DYNACONF": str(toml_invalid)},
+        )
+        assert "age must lte 30 but it is 35 in env default" in result
+        assert (
+            "project must eq hello_world but it is This is not hello_world "
+            "in env production" in result
+        )
+        assert (
+            "host must is_not_in ['test.com'] but it is test.com in env "
+            "production" in result
+        )
+        assert "Validation success!" not in result
+
+    @pytest.mark.parametrize(
+        "environments, expected",
         [
-            "-i",
-            "tests.config.settingsenv",
-            "validate",
-            "-p",
-            str(validation_file),
+            pytest.param(True, "Validation error!", id="environments-enabled"),
+            pytest.param(
+                False, "Validation success!", id="environments-disabled"
+            ),
+            # In this last case, 'main' is considered a regular field, and it doesn't have
+            # a validator a must_exist rule. 'staryear' must exist, but if it's
+            # parent "main" (not an env here!) doesnt exist, which is fine, the
+            # validator doesn't apply. This is the most strict interpretation, and
+            # having the 'must_exist' rule propagate, that's it, require 'main' to exist,
+            # can be considered a new feature
         ],
-        {"SETTINGS_FILE_FOR_DYNACONF": str(toml_valid)},
     )
-    assert "Validation success!" in result
+    def test_issue_1368(self, create_file, environments: bool, expected: str):
+        """Section-based validators in dynaconf_validators.toml with a non-default section name.
 
-    result = run(
-        [
-            "-i",
-            "tests.test_cli.settings",
-            "validate",
-            "-p",
-            str(Path(str(validation_file)).parent),
-        ],
-        {"SETTINGS_FILE_FOR_DYNACONF": str(toml_invalid)},
-    )
-    assert "age must lte 30 but it is 35 in env default" in result
-    assert (
-        "project must eq hello_world but it is This is not hello_world "
-        "in env production" in result
-    )
-    assert (
-        "host must is_not_in ['test.com'] but it is test.com in env "
-        "production" in result
-    )
-    assert "Validation success!" not in result
+        https://github.com/dynaconf/dynaconf/issues/1368
+        """
+        module = f"config_{environments}"
+        create_file(
+            f"{module}.py",
+            f"""
+            from dynaconf import Dynaconf
+            settings = Dynaconf(environments={environments})
+            """,
+        )
+        validators_toml = create_file(
+            "dynaconf_validators.toml",
+            """
+            [main]
+            startyear = {must_exist=true}
+            """,
+        )
+        result = self._run_validate(
+            settings_mod=f"{module}.settings",
+            validation_file=str(validators_toml),
+        )
+        assert expected in result
 
 
 def create_file(filename: str | Path, data: str):


### PR DESCRIPTION
Sections like [main] were misidentified as field names, causing their validators to never run. Now 'validate' relies on what whether environments is enabled or not to interpret top-level fields.

Closes #1368.