### PR TITLE
fix: don't treat a string sharing a converter prefix as a cast

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -761,7 +761,7 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
         castenabled
         and data
         and isinstance(data, str)
-        and data.startswith(tuple(converters.keys()))
+        and data.partition(" ")[0] in converters
     ):
         # Check combination token is used
         comb_token = re.match(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,6 +128,39 @@ def test_casting_str(settings):
     assert isinstance(res, str) and res == "7"
 
 
+def test_string_starting_with_converter_prefix_is_not_cast(settings):
+    """A plain string that merely shares a prefix with a converter token
+    (e.g. ``@interface`` starts with ``@int``) must be kept verbatim, not
+    treated as a cast. Previously this raised ``KeyError``.
+    """
+    # these all start with a real converter token as a *prefix* only
+    for value in (
+        "@interface",  # @int
+        "@integer",  # @int
+        "@formatter",  # @format
+        "@gettext",  # @get
+        "@uppercase",  # @upper
+        "@stringify",  # @str
+        "@noneofthat",  # @none
+    ):
+        assert parse_conf_data(value, box_settings=settings) == value
+        assert (
+            parse_conf_data(value, tomlfy=True, box_settings=settings) == value
+        )
+
+    # a prefix collision followed by more words must also pass through
+    assert (
+        parse_conf_data("@formatter blah", tomlfy=True, box_settings=settings)
+        == "@formatter blah"
+    )
+
+    # real converter tokens must still cast (regression guard)
+    assert parse_conf_data("@int 5", box_settings=settings) == 5
+    assert parse_conf_data("@none", box_settings=settings) is None
+    settings.set("value", 5)
+    assert parse_conf_data("@int @format {this.value}")(settings) == 5
+
+
 def test_casting_int(settings):
     res = parse_conf_data("@int 2")
     assert isinstance(res, int) and res == 2


### PR DESCRIPTION
While looking at how values starting with `@` get parsed, I found that an ordinary string crashes Dynaconf if it merely *starts with* a converter token's characters:

```python
from dynaconf import Dynaconf
settings = Dynaconf()
settings.set("HANDLE", "@interface")   # KeyError: '@interface'
```

`@interface` starts with `@int`, so the cast detection in `_parse_conf_data` (`data.startswith(tuple(converters.keys()))`) treats it as a cast and then looks up `converters["@interface"]`, which raises `KeyError`. The same happens for `@formatter` (vs `@format`), `@gettext` (vs `@get`), and so on, and it triggers through every entry point: env vars, settings files, and `set()`.

The detection should match a whole token, not a prefix, so I check whether the first whitespace-delimited token is actually a registered converter. If it isn't, the value is parsed as plain data. Real casts and combination tokens like `@int @format ...` are unaffected since their first token is still a converter.

Added a regression test in `tests/test_utils.py`. The full non-integration suite, mypy and ruff all pass locally.
