### PR TITLE
fix(py_loader): re-raise ImportError caused by module content, not just missing modules

### DIFF
--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -121,7 +121,7 @@ def get_module(obj, filename, silent=False):
         mod = importlib.import_module(filename)
         loaded_from = "module"
         mod.is_error = False
-    except (ImportError, TypeError):
+    except (ModuleNotFoundError, TypeError):
         mod = import_from_filename(obj, filename, silent=silent)
         if mod and not mod._is_error:
             loaded_from = "filename"

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+import sys
+import types
 
 import pytest
 
 from dynaconf import default_settings
 from dynaconf import LazySettings
+from dynaconf.loaders.py_loader import get_module
 from dynaconf.loaders.py_loader import load
 from dynaconf.loaders.py_loader import try_to_load_from_py_module_name
 from dynaconf.utils import DynaconfDict
@@ -275,3 +278,37 @@ def test_post_load_hooks(clean_env, tmpdir):
             "INSTALLED_APPS": ["dummyplugin"],
         }
     }
+
+
+def test_get_module_reraises_import_error_from_module_content(tmpdir):
+    """get_module() must propagate ImportError caused by content inside the
+    settings module (e.g. cyclic imports), not just swallow it as 'not found'.
+
+    Regression test for https://github.com/dynaconf/dynaconf/issues/1308
+    """
+    settings = DynaconfDict()
+
+    # Register a fake top-level module whose import triggers an ImportError
+    # from inside its body (simulating a cyclic-import scenario).
+    module_name = "fake_cyclic_settings"
+    fake_mod = types.ModuleType(module_name)
+
+    def broken_getattr(name):
+        raise ImportError("cannot import name 'X' from 'fake_cyclic_settings'")
+
+    fake_mod.__spec__ = None  # make importlib think it's a real module
+    # Patch sys.modules so importlib.import_module finds it, then immediately
+    # raise an ImportError as if the module body has a bad circular import.
+    original = sys.modules.get(module_name)
+
+    import importlib
+    import unittest.mock as mock
+
+    with mock.patch(
+        "importlib.import_module",
+        side_effect=ImportError(
+            "cannot import name 'circular' from 'fake_cyclic_settings'"
+        ),
+    ):
+        with pytest.raises(ImportError):
+            get_module(settings, module_name, silent=False)

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -1,8 +1,7 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import os
 import sys
-import types
 
 import pytest
 
@@ -280,37 +279,46 @@ def test_post_load_hooks(clean_env, tmpdir):
     }
 
 
-def test_get_module_reraises_import_error_from_module_content(create_file, tmp_path):
+@pytest.fixture
+def with_importable_tmp_path(tmp_path):
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    for key in list(sys.modules.keys()):
+        mod = sys.modules[key]
+        if getattr(mod, "__file__", None) and str(tmp_path) in mod.__file__:
+            del sys.modules[key]
+
+
+def test_get_module_reraises_import_error_from_module_content(
+    create_file, with_importable_tmp_path
+):
     """get_module() must propagate ImportError caused by content inside the
     settings module (e.g. cyclic imports), not just swallow it as 'not found'.
 
     Regression test for https://github.com/dynaconf/dynaconf/issues/1308
-    Uses real on-disk modules (via create_file) to exercise the actual import path.
+    Uses real on-disk modules in a genuine A-imports-B / B-imports-A cyclic
+    setup to exercise the actual import path.
     """
-    # A helper module that is importable but missing the requested name.
+    # Module A imports from B, and B imports from A — a real cyclic import.
+    # Python raises: ImportError: cannot import name 'X' from partially
+    # initialized module 'Y' (most likely due to a circular import)
     create_file(
-        "cyclic_helper.py",
+        "cyclic_a.py",
         """
-        READY = True
+        from cyclic_b import B_VALUE
+        A_VALUE = 1
         """,
     )
-
-    # The settings module tries to import a name that does not exist -
-    # exactly the ImportError Python raises in a real cyclic-import scenario.
     create_file(
-        "cyclic_settings.py",
+        "cyclic_b.py",
         """
-        from cyclic_helper import DOES_NOT_EXIST
+        from cyclic_a import A_VALUE
+        B_VALUE = 2
         """,
     )
 
     settings = DynaconfDict()
 
-    sys.path.insert(0, str(tmp_path))
-    try:
-        with pytest.raises(ImportError):
-            get_module(settings, "cyclic_settings", silent=False)
-    finally:
-        sys.path.remove(str(tmp_path))
-        for mod in ("cyclic_settings", "cyclic_helper"):
-            sys.modules.pop(mod, None)
+    with pytest.raises(ImportError):
+        get_module(settings, "cyclic_a", silent=False)

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import os
 import sys
@@ -280,35 +280,37 @@ def test_post_load_hooks(clean_env, tmpdir):
     }
 
 
-def test_get_module_reraises_import_error_from_module_content(tmpdir):
+def test_get_module_reraises_import_error_from_module_content(create_file, tmp_path):
     """get_module() must propagate ImportError caused by content inside the
     settings module (e.g. cyclic imports), not just swallow it as 'not found'.
 
     Regression test for https://github.com/dynaconf/dynaconf/issues/1308
+    Uses real on-disk modules (via create_file) to exercise the actual import path.
     """
+    # A helper module that is importable but missing the requested name.
+    create_file(
+        "cyclic_helper.py",
+        """
+        READY = True
+        """,
+    )
+
+    # The settings module tries to import a name that does not exist -
+    # exactly the ImportError Python raises in a real cyclic-import scenario.
+    create_file(
+        "cyclic_settings.py",
+        """
+        from cyclic_helper import DOES_NOT_EXIST
+        """,
+    )
+
     settings = DynaconfDict()
 
-    # Register a fake top-level module whose import triggers an ImportError
-    # from inside its body (simulating a cyclic-import scenario).
-    module_name = "fake_cyclic_settings"
-    fake_mod = types.ModuleType(module_name)
-
-    def broken_getattr(name):
-        raise ImportError("cannot import name 'X' from 'fake_cyclic_settings'")
-
-    fake_mod.__spec__ = None  # make importlib think it's a real module
-    # Patch sys.modules so importlib.import_module finds it, then immediately
-    # raise an ImportError as if the module body has a bad circular import.
-    original = sys.modules.get(module_name)
-
-    import importlib
-    import unittest.mock as mock
-
-    with mock.patch(
-        "importlib.import_module",
-        side_effect=ImportError(
-            "cannot import name 'circular' from 'fake_cyclic_settings'"
-        ),
-    ):
+    sys.path.insert(0, str(tmp_path))
+    try:
         with pytest.raises(ImportError):
-            get_module(settings, module_name, silent=False)
+            get_module(settings, "cyclic_settings", silent=False)
+    finally:
+        sys.path.remove(str(tmp_path))
+        for mod in ("cyclic_settings", "cyclic_helper"):
+            sys.modules.pop(mod, None)


### PR DESCRIPTION
When loading a settings module by name, `get_module()` calls
`importlib.import_module()` and catches `ImportError` broadly to fall back
to file-based loading. This has a subtle flaw: any `ImportError` raised
*inside* the module body (cyclic imports, missing transitive dependencies,
bad `from x import y` statements) is also caught and silently swallowed,
even when `silent=False`.

The caller ends up with `(None, None)` instead of an exception, so
dynaconf silently loads no settings and the user has no indication
anything went wrong.

**Root cause**

```python
# before
except (ImportError, TypeError):   # catches ALL ImportErrors
    mod = import_from_filename(...)
```

The `ImportError` catch is only needed to distinguish "this name is not an
importable module" from "this name is a file path". Python 3.6 introduced
`ModuleNotFoundError` (a subclass of `ImportError`) which is raised
*only* when the module itself cannot be located — not when an error occurs
inside it. Using it here preserves the fallback behaviour for missing
modules while letting real import errors propagate.

**Fix**

```python
# after
except (ModuleNotFoundError, TypeError):   # only catches "module not found"
    mod = import_from_filename(...)
```

`ModuleNotFoundError` is available on Python 3.6+ (dynaconf already
requires Python 3.8+), so there is no compatibility concern.

A regression test is added to `tests/test_py_loader.py` that patches
`importlib.import_module` to raise a plain `ImportError` (simulating a
cyclic-import inside the settings file) and asserts it propagates when
`silent=False`.

Closes #1308