### PR TITLE
chore(ci): Fix netlify deploy command on publish workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ jobs:
           name: ${{ needs.build-docs.outputs.docs-artifact }}
           path: site
       - name: Deploy to Netlify
-        run: npx netlify-cli deploy --prod --dir=site --message "Deploy from GitHub Actions"
+        run: npx netlify-cli deploy --prod --no-build --dir=site --message "Deploy from GitHub Actions"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
neflify-cli deploy command automatically tries to build the docs, but in our case we are just passing already built docs to it.