### PR TITLE
Support list values for env (#1278)

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -383,12 +383,16 @@ def normalize_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
                 if c_new == new:
                     kwargs[c_old] = kwargs[new]
 
-    # `env` (aliased to ENV_FOR_DYNACONF) selects a single environment and must
-    # be a string. A non-string value (e.g. a list) would otherwise fail later
-    # with a cryptic ``'...' object has no attribute 'upper'`` error. See #1278.
+    # A list passed as `env` is the programmatic equivalent of the
+    # comma-separated ENV_FOR_DYNACONF environment variable. Normalize it here
+    # so all loaders can use their existing multi-environment handling. #1278
     env = kwargs.get("ENV_FOR_DYNACONF")
-    if env is not None and not isinstance(env, str):
-        raise TypeError(f"'env' must be a string, not {type(env).__name__}")
+    if isinstance(env, list):
+        if not all(isinstance(item, str) for item in env):
+            raise TypeError("'env' must be a string or a list of strings")
+        kwargs["ENV_FOR_DYNACONF"] = ",".join(env)
+    elif env is not None and not isinstance(env, str):
+        raise TypeError("'env' must be a string or a list of strings")
 
     return kwargs
 

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -382,6 +382,14 @@ def normalize_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
             for c_old, c_new in RENAMED_VARS.items():
                 if c_new == new:
                     kwargs[c_old] = kwargs[new]
+
+    # `env` (aliased to ENV_FOR_DYNACONF) selects a single environment and must
+    # be a string. A non-string value (e.g. a list) would otherwise fail later
+    # with a cryptic ``'...' object has no attribute 'upper'`` error. See #1278.
+    env = kwargs.get("ENV_FOR_DYNACONF")
+    if env is not None and not isinstance(env, str):
+        raise TypeError(f"'env' must be a string, not {type(env).__name__}")
+
     return kwargs
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -307,9 +307,10 @@ def test_env_kwarg_accepts_a_list(create_file, env_kwarg):
     assert settings.issue_1278_from_dev is True
 
 
-def test_env_kwarg_rejects_a_list_with_non_strings():
+@pytest.mark.parametrize("env", [["test", 1], 1])
+def test_env_kwarg_rejects_invalid_values(env):
     with pytest.raises(TypeError, match="string or a list of strings"):
-        Dynaconf(environments=True, env=["test", 1])
+        Dynaconf(environments=True, env=env)
 
 
 def test_env_should_allow_underline(settings):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -277,6 +277,21 @@ def test_env_should_be_string(settings):
         settings.setenv(123456)
 
 
+def test_env_kwarg_must_be_a_string():
+    # A non-string ``env`` (e.g. a list) used to fail later with a cryptic
+    # ``'DataList' object has no attribute 'upper'``. See #1278.
+    with pytest.raises(TypeError, match="'env' must be a string"):
+        Dynaconf(environments=True, env=["test", "dev"])
+    # The ENV_FOR_DYNACONF alias is validated too.
+    with pytest.raises(TypeError, match="'env' must be a string"):
+        Dynaconf(environments=True, ENV_FOR_DYNACONF=["test"])
+    # A string env still works.
+    assert (
+        Dynaconf(environments=True, env="production").current_env
+        == "production"
+    )
+
+
 def test_env_should_allow_underline(settings):
     settings.setenv("COOL_env")
     assert settings.current_env == "COOL_ENV"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -282,17 +282,17 @@ def test_env_kwarg_accepts_a_list(create_file, env_kwarg):
     settings_file = create_file(
         "settings.toml",
         """
-[default]
-issue_1278_value = "default"
+        [default]
+        issue_1278_value = "default"
 
-[test]
-issue_1278_value = "test"
-issue_1278_from_test = true
+        [test]
+        issue_1278_value = "test"
+        issue_1278_from_test = true
 
-[dev]
-issue_1278_value = "dev"
-issue_1278_from_dev = true
-""",
+        [dev]
+        issue_1278_value = "dev"
+        issue_1278_from_dev = true
+        """,
     )
 
     settings = Dynaconf(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -277,19 +277,39 @@ def test_env_should_be_string(settings):
         settings.setenv(123456)
 
 
-def test_env_kwarg_must_be_a_string():
-    # A non-string ``env`` (e.g. a list) used to fail later with a cryptic
-    # ``'DataList' object has no attribute 'upper'``. See #1278.
-    with pytest.raises(TypeError, match="'env' must be a string"):
-        Dynaconf(environments=True, env=["test", "dev"])
-    # The ENV_FOR_DYNACONF alias is validated too.
-    with pytest.raises(TypeError, match="'env' must be a string"):
-        Dynaconf(environments=True, ENV_FOR_DYNACONF=["test"])
-    # A string env still works.
-    assert (
-        Dynaconf(environments=True, env="production").current_env
-        == "production"
+@pytest.mark.parametrize("env_kwarg", ["env", "ENV_FOR_DYNACONF"])
+def test_env_kwarg_accepts_a_list(tmp_path, env_kwarg):
+    settings_file = tmp_path / "settings.toml"
+    settings_file.write_text(
+        """
+[default]
+issue_1278_value = "default"
+
+[test]
+issue_1278_value = "test"
+issue_1278_from_test = true
+
+[dev]
+issue_1278_value = "dev"
+issue_1278_from_dev = true
+"""
     )
+
+    settings = Dynaconf(
+        settings_files=[settings_file],
+        environments=True,
+        **{env_kwarg: ["test", "dev"]},
+    )
+
+    assert settings.current_env == "test,dev"
+    assert settings.issue_1278_value == "dev"
+    assert settings.issue_1278_from_test is True
+    assert settings.issue_1278_from_dev is True
+
+
+def test_env_kwarg_rejects_a_list_with_non_strings():
+    with pytest.raises(TypeError, match="string or a list of strings"):
+        Dynaconf(environments=True, env=["test", 1])
 
 
 def test_env_should_allow_underline(settings):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -278,9 +278,9 @@ def test_env_should_be_string(settings):
 
 
 @pytest.mark.parametrize("env_kwarg", ["env", "ENV_FOR_DYNACONF"])
-def test_env_kwarg_accepts_a_list(tmp_path, env_kwarg):
-    settings_file = tmp_path / "settings.toml"
-    settings_file.write_text(
+def test_env_kwarg_accepts_a_list(create_file, env_kwarg):
+    settings_file = create_file(
+        "settings.toml",
         """
 [default]
 issue_1278_value = "default"
@@ -292,7 +292,7 @@ issue_1278_from_test = true
 [dev]
 issue_1278_value = "dev"
 issue_1278_from_dev = true
-"""
+""",
     )
 
     settings = Dynaconf(


### PR DESCRIPTION
Fixes #1278.

## Problem

Dynaconf already supports activating multiple environments through a comma-separated `ENV_FOR_DYNACONF` value, but the equivalent constructor form failed:

```python
Dynaconf(environments=True, env=["test", "dev"])
# AttributeError: 'DataList' object has no attribute 'upper'
```

As discussed in #1278, the list form should be the programmatic equivalent of `ENV_FOR_DYNACONF=test,dev`: load and merge `test`, then `dev`.

## Fix

Normalize a list supplied through either `env` or `ENV_FOR_DYNACONF` to the existing comma-separated representation in `normalize_kwargs()`. This lets all existing multi-environment loader behavior remain unchanged. Lists containing non-string items still raise a clear `TypeError`.

## Testing

- Added regression coverage for both constructor aliases.
- Verified values from both environments are loaded and the later environment wins for overlapping scalar values.
- Core suite: `748 passed, 9 skipped, 19 deselected, 1 xfailed`.
- Focused tests pass on Python 3.10, 3.13, and 3.14.
- Ruff check and format checks pass.

---

*Disclosure: this change was prepared with AI assistance. I reproduced the issue, implemented and verified the fix and tests, and take responsibility for the contribution and review follow-up.*