### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -111,7 +111,7 @@ def set_debugging_database_url(settings):
 
 Dynaconf will collect the decorated functions and execute them after the settings file is loaded.
 
-The hook decorator can only be applied to functions that are defined withing the same settings file, in the
+The hook decorator can only be applied to functions that are defined within the same settings file, in the
 need to use external functions, wrap it in a local decorated function.
 
 When using `load_file` to load a python file, hooks will also be collected and immediately executed after the file is loaded, unless the `run_hooks` argument is set to `False`, this is useful when calling `load_file` multiple times and have the hooks to be all executed together at a certain point later.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,7 +279,7 @@ Usage: dynaconf list [OPTIONS]
   Lists user defined settings or all (including internal configs).
 
   By default, shows only user defined. If `--all` is passed it also shows
-  dynaconf internal variables aswell.
+  dynaconf internal variables as well.
 
 Options:
   -e, --env TEXT     Filters the env to get the values

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -266,7 +266,7 @@ NOTES:
 
 - You must define the logic of each hook, dynaconf just calls it
 - You must take care of caching and caching invalidation
-- This may introduce overhead dependending on how the hook function is
+- This may introduce overhead depending on how the hook function is
     implemented
 
 To register an access hook, you need to wrap the `Dynaconf` instance with

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -575,7 +575,7 @@ def _list(
     Lists user defined settings or all (including internal configs).
 
     By default, shows only user defined. If `--all` is passed it also shows
-    dynaconf internal variables aswell.
+    dynaconf internal variables as well.
     """
     if env:
         env = env.strip()

--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -337,7 +337,7 @@ def _get_data_by_key(
         key_dotted_path = key_dotted_path.replace(sep, ".")
 
     def handle_repr(value):
-        # lazy values shouldnt be evaluated for inspecting
+        # lazy values shouldn't be evaluated for inspecting
         if isinstance(value, Lazy):
             return value._dynaconf_encode()
         return value

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -142,8 +142,8 @@ class Validator:
 
         # in the case that:
         # * default is a Lazy object AND
-        # * there isnt any validate operation to perform (that would require knowing the lazy value)
-        # Then we shouldnt trigger the Lazy evaluation
+        # * there isn't any validate operation to perform (that would require knowing the lazy value)
+        # Then we shouldn't trigger the Lazy evaluation
         self.should_call_lazy = not all(
             (
                 default,

--- a/dynaconf/validator_conditions.py
+++ b/dynaconf/validator_conditions.py
@@ -65,7 +65,7 @@ def identity(value, other) -> bool:
 
 def is_type_of(value, other) -> bool:
     """Type check that performs lookup on parameterized generic types.
-    For singular primary types this check is very fast ans just
+    For singular primary types this check is very fast and just
     calls isinstance.
     For SpecialForm annotations like Union and Parametrized types like T[T]
     or T[T, T] then this is a bit more costly.

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -566,7 +566,7 @@ def tests_get_history_with_variable_interpolation():
     https://github.com/dynaconf/dynaconf/issues/1180
 
     The original issue was about an exception being raised when there was
-    variable interpolation involved. But in the end, the get_history shouldnt
+    variable interpolation involved. But in the end, the get_history shouldn't
     evaluate the interpolations:
 
     - History should accurately inform the order and content of what the user loaded.

--- a/tests/test_typed.py
+++ b/tests/test_typed.py
@@ -704,7 +704,7 @@ def test_extracted_validators_from_annotated(monkeypatch):
     ids=lambda value: str(value),
 )
 def test_some_arguments_forbid_on_validators(invalid_arg):
-    """these arguments doesnt make sense on a typed dynaconf"""
+    """these arguments don't make sense on a typed dynaconf"""
     with pytest.raises(TypeError):
         Validator(**invalid_arg)
 

--- a/tests_functional/issues/946_flask_cli/myapp.py
+++ b/tests_functional/issues/946_flask_cli/myapp.py
@@ -1,5 +1,5 @@
 """
-CLI wouldnt recognize FLASK_APP "entrypoint" path (foo.bar:app)
+CLI wouldn't recognize FLASK_APP "entrypoint" path (foo.bar:app)
 
 https://github.com/dynaconf/dynaconf/issues/946
 """

--- a/tests_functional/issues/982_wildcard/app.py
+++ b/tests_functional/issues/982_wildcard/app.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 # If python version is <  3.10 skip test
-# glob on that version of Python doesnt have root_dir param
+# glob on that version of Python doesn't have root_dir param
 if sys.version_info < (3, 10):
     print("Skip test")
     sys.exit(0)

--- a/tests_functional/legacy/yaml_example_multidoc/app.py
+++ b/tests_functional/legacy/yaml_example_multidoc/app.py
@@ -22,24 +22,24 @@ print(settings.AGE)
 print(settings.ENABLED)
 print(settings.CUSTOM)
 
-print("* Switiching to production")
+print("* Switching to production")
 # using [production] env values for context
 with settings.using_env("PRODUCTION"):
     print(settings.CUSTOM)
     print(settings.HOST)
 
-print("* Switiching to development")
+print("* Switching to development")
 # back to default [development] env
 print(settings.get("CUSTOM"))
 print(settings.HOST)
 
-print("* Switiching to production")
+print("* Switching to production")
 # set env to [production]:
 settings.setenv("production")
 print(settings.HOST)
 print(settings.CUSTOM)
 
-print("* Switiching to development")
+print("* Switching to development")
 # back to [development] env again
 settings.setenv()
 print(settings.HOST)

--- a/tests_functional/legacy/yaml_example_settings_file/app.py
+++ b/tests_functional/legacy/yaml_example_settings_file/app.py
@@ -18,24 +18,24 @@ print(settings.AGE)
 print(settings.ENABLED)
 print(settings.CUSTOM)
 
-print("* Switiching to production")
+print("* Switching to production")
 # using [production] env values for context
 with settings.using_env("PRODUCTION"):
     print(settings.CUSTOM)
     print(settings.HOST)
 
-print("* Switiching to development")
+print("* Switching to development")
 # back to default [development] env
 print(settings.get("CUSTOM"))
 print(settings.HOST)
 
-print("* Switiching to production")
+print("* Switching to production")
 # set env to [production]:
 settings.setenv("production")
 print(settings.HOST)
 print(settings.CUSTOM)
 
-print("* Switiching to development")
+print("* Switching to development")
 # back to [development] env again
 settings.setenv()
 print(settings.HOST)

--- a/tests_functional/runtests.py
+++ b/tests_functional/runtests.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         "--filter",
         dest="test_filter",
         action="append",
-        help="limt tests to those that contain a substring",
+        help="limit tests to those that contain a substring",
     )
     args = parser.parse_args()
     run_tests(show_list=args.show_list, test_filter=args.test_filter)


### PR DESCRIPTION
Fix several spelling mistakes found in comments, docstrings, and documentation:

- `tests_functional/runtests.py:136` - `limt` -> `limit`
- `tests_functional/legacy/yaml_example_multidoc/app.py:25,31,36,42` - `Switiching` -> `Switching`
- `tests_functional/legacy/yaml_example_settings_file/app.py:21,27,32,38` - `Switiching` -> `Switching`
- `tests_functional/issues/946_flask_cli/myapp.py:2` - `wouldnt` -> `wouldn't`
- `tests_functional/issues/982_wildcard/app.py:7` - `doesnt` -> `doesn't`
- `tests/test_inspect.py:569` - `shouldnt` -> `shouldn't`
- `tests/test_typed.py:707` - `doesnt` -> `doesn't`
- `docs/advanced.md:114` - `withing` -> `within`
- `docs/cli.md:282` - `aswell` -> `as well`
- `docs/dynamic.md:269` - `dependending` -> `depending`
- `dynaconf/cli.py:578` - `aswell` -> `as well`
- `dynaconf/validator.py:145` - `isnt` -> `isn't`
- `dynaconf/validator.py:146` - `shouldnt` -> `shouldn't`
- `dynaconf/validator_conditions.py:68` - `ans` -> `and`
- `dynaconf/utils/inspect.py:340` - `shouldnt` -> `shouldn't`