### PR TITLE
fix: get/get_fresh with dotted keys stops working after first call

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -635,8 +635,16 @@ class Settings:
             return default
 
         if (
-            fresh or config.fresh or key in config.fresh_vars
-        ) and key not in UPPER_DEFAULT_SETTINGS:
+            (fresh or config.fresh or key in config.fresh_vars)
+            and key not in UPPER_DEFAULT_SETTINGS
+            and parent is None
+        ):
+            # `parent` is only set when resolving a child segment of a
+            # dotted key against an already-fetched nested container
+            # (see `_dotted_get`). Such a `key` is not a real top-level
+            # setting, so it must not be unset/reloaded here: doing so
+            # would mark it as deleted permanently and break every
+            # future lookup of the dotted key.
             self.unset(key)
             self.execute_loaders(key=key)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -872,6 +872,42 @@ def test_dotted_traversal_access(settings):
     assert settings.get("ME__NUMBER") == "42"
 
 
+def test_dotted_get_fresh(tmpdir):
+    """Regression test for issue #1187.
+
+    `get`/`get_fresh` with a dot separated key must keep returning the
+    value on repeated calls, reloading it fresh from the source every
+    time instead of returning None after the first call.
+    """
+    settings_file = tmpdir.join("settings.toml")
+    toml_loader.write(str(settings_file), {"foo": {"bar": "baz"}}, merge=False)
+    settings = LazySettings(settings_file="settings.toml")
+
+    assert settings.get("foo.bar", fresh=True) == "baz"
+    # second and third calls used to return None (issue #1187)
+    assert settings.get("foo.bar", fresh=True) == "baz"
+    assert settings.get("foo.bar", fresh=True) == "baz"
+
+    assert settings.get_fresh("foo.bar") == "baz"
+    assert settings.get_fresh("foo.bar") == "baz"
+
+    # fresh must actually reload the value from the source
+    toml_loader.write(
+        str(settings_file), {"foo": {"bar": "changed"}}, merge=False
+    )
+    assert settings.get("foo.bar", fresh=True) == "changed"
+
+    # deeper nesting keeps working across repeated fresh calls too
+    toml_loader.write(
+        str(tmpdir.join("settings2.toml")),
+        {"foo": {"baz": {"qux": "v1"}}},
+        merge=False,
+    )
+    settings2 = LazySettings(settings_file="settings2.toml")
+    assert settings2.get("foo.baz.qux", fresh=True) == "v1"
+    assert settings2.get("foo.baz.qux", fresh=True) == "v1"
+
+
 def test_dotted_set(settings):
     settings.set("MERGE_ENABLED_FOR_DYNACONF", False)
 


### PR DESCRIPTION
## Problem

`settings.get("foo.bar", fresh=True)` (and the `get_fresh` shortcut) returns the correct value on the first call, but returns `None` on every call after that. Reported in #1187 with a Redis-backed reproduction.

## Root cause

Dotted lookups resolve one path segment at a time, recursing through `get()` for each segment. Once the top-level segment (`"foo"`) is reloaded, the recursive call that resolves the child segment (`"bar"`) against the already-fetched nested container also goes through the `fresh` unset/reload branch.

`"bar"` is not actually a top-level setting, so `unset("bar")` marks it as permanently deleted in `config.deleted`. Every later lookup of `"bar"` (including the one implicit inside `"foo.bar"`) then short-circuits to the default value before it can reach the store, since `config.deleted` is never cleared for that name.

## Fix

The fresh reload only makes sense once, on the real top-level key. Skip the unset/reload branch in `get()` when resolving a child segment against an already-loaded `parent` container (this only ever happens from `_dotted_get`'s recursion).

## Testing

Added `test_dotted_get_fresh` covering `get(..., fresh=True)`, `get_fresh`, deeper (3-level) nesting, and that fresh reload still genuinely picks up changed values from the source. Verified the new test fails without the fix and passes with it. Full non-integration suite passes.