### PR TITLE
Fix get_history ignoring its history_limit argument

### DIFF
--- a/dynaconf/utils/inspect.py
+++ b/dynaconf/utils/inspect.py
@@ -297,6 +297,9 @@ def get_history(
         if key and not result:
             raise KeyNotFoundError(f"The requested key was not found: {key!r}")
 
+    if history_limit:
+        result = result[:history_limit]
+
     return result
 
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -208,6 +208,36 @@ def test_get_history_env_false__file_plus_envvar(tmp_path):
     )
 
 
+def test_get_history_history_limit(tmp_path):
+    """
+    Given a history longer than history_limit
+    Should return only the first history_limit entries
+    """
+    file_a = tmp_path / "a.yml"
+    create_file(file_a, "foo: from_file")
+    settings = Dynaconf(settings_file=file_a, environments=False)
+
+    full = get_history(settings)
+    assert len(full) > 1
+
+    limited = get_history(settings, history_limit=1)
+    assert len(limited) == 1
+    assert limited == full[:1]
+
+
+def test_get_history_history_limit_larger_than_history(tmp_path):
+    """
+    Given a history_limit larger than the history
+    Should return the whole history unchanged
+    """
+    file_a = tmp_path / "a.yml"
+    create_file(file_a, "foo: from_file")
+    settings = Dynaconf(settings_file=file_a, environments=False)
+
+    full = get_history(settings)
+    assert get_history(settings, history_limit=len(full) + 10) == full
+
+
 def test_get_history_env_false__val_default_plus_envvar():
     """
     Given environments=False and sources=validation-default+envvar


### PR DESCRIPTION
## Summary

`get_history` declares `history_limit` in its signature and documents it in the docstring — *"history_limit: limits how many entries are shown"* — but the body never reads it, so passing it does nothing:

```python
settings = Dynaconf(settings_file=["a.yml"], environments=False)
len(get_history(settings))                    # 3
len(get_history(settings, history_limit=1))   # 3   <- expected 1
len(get_history(settings, history_limit=2))   # 3   <- expected 2
```

`history_limit` appears exactly twice in the file: the signature (`inspect.py:223`) and the docstring (`:237`). It is referenced nowhere in the function body.

The reason this went unnoticed is that the CLI/`inspect_settings` path does its own slicing (`inspect.py:164-165`) rather than forwarding the argument, so the public `get_history` API is the only place where the parameter is visibly dead. `get_history` is public — exported in `dynaconf/__init__.py` `__all__` and documented in `docs/advanced.md`.

## Fix

Apply the limit before returning, matching the semantics `inspect_settings` already uses (`history[:history_limit]` — first N entries, and falsy/`None` means no limit).

**`inspect_settings` is unaffected**: it does not forward `history_limit` to `get_history`, and applies its own slice *after* `history.reverse()`, so the `new_first` ordering interaction is preserved. No double-slicing is introduced.

## Tests

Two cases added to `tests/test_inspect.py`:
- `history_limit=1` returns exactly the first entry (fails on `master`, passes here).
- a `history_limit` larger than the history returns it unchanged (guards against slicing the wrong end or off-by-one).

`grep -rn history_limit tests/` previously only hit `inspect_settings`/CLI paths — `get_history(history_limit=...)` had no coverage at all, which is why the dead parameter survived.

## Verification

- `pytest tests/test_inspect.py` — 27 passed.
- Full suite: **688 passed**, 9 skipped, 1 xfailed — identical to the pre-change baseline of 686 plus the 2 new tests, no regressions. (`tests/test_cli.py::test_help_dont_require_instance` and `tests/test_validators.py::test_no_reload_on_single_env` fail/error in my sandbox both with and without this change — a subprocess exit-127 and a test-ordering issue respectively; `test_vault`/`test_redis`/`test_release_utility` need live services and were excluded.)
- `ruff check` and `ruff format --check` clean.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the full suite locally and reviewed the diff before opening.