### PR TITLE
fix: @json cast leaks AttributeError on non-string values

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -587,8 +587,10 @@ def _safe_json_parse(value):
         return json.loads(value)
 
     # Try extracting JSON objects with boolean/None normalization
-    # This handles single-quoted JSON and Python-style booleans
-    with suppress(json.JSONDecodeError, ValueError, TypeError):
+    # This handles single-quoted JSON and Python-style booleans.
+    # AttributeError guards against non-string input (e.g. None), where
+    # the string replacement below has no `.replace` to call.
+    with suppress(json.JSONDecodeError, ValueError, TypeError, AttributeError):
         json_objects = list(
             extract_json_objects(
                 multi_replace(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1399,6 +1399,31 @@ def test_safe_json_parse_complete_failure():
         _safe_json_parse("not valid { json or python }")
 
 
+def test_safe_json_parse_non_string_input():
+    """_safe_json_parse must raise DynaconfParseError on non-string input.
+
+    A non-string value can't be JSON parsed, so it should fail the same way
+    @int/@float do (DynaconfParseError), instead of leaking a raw
+    AttributeError from the internal string replacement step.
+    """
+    from dynaconf.utils.parse_conf import _safe_json_parse
+
+    for value in (None, 123, 1.5, ["a"], {"key": "value"}, True):
+        with pytest.raises(DynaconfParseError, match="Cannot parse as JSON"):
+            _safe_json_parse(value)
+
+
+def test_json_cast_on_missing_key_raises_parse_error(settings):
+    """get(key, cast="@json") on a missing key raises DynaconfParseError.
+
+    The value is None, so the cast fails - but it should fail with the same
+    DynaconfParseError that cast="@int"/cast="@float" raise, not a raw
+    AttributeError.
+    """
+    with pytest.raises(DynaconfParseError, match="Cannot parse as JSON"):
+        settings.get("THIS_KEY_DOES_NOT_EXIST", cast="@json")
+
+
 def test_parse_conf_data_tomlfy_filter_none(settings):
     """Test parse_conf_data with tomlfy_filter=None"""
     # When tomlfy_filter is None, in_tomlfy_filter should return False


### PR DESCRIPTION
Calling `settings.get("SOME_MISSING_KEY", cast="@json")` blows up with `AttributeError: 'NoneType' object has no attribute 'replace'` instead of a clean dynaconf error. It happens whenever `@json` is asked to cast a non-string (a missing key resolves to `None`, but an existing dict/list/int hits it too).

The cause is in `_safe_json_parse`: its first strategy already swallows `json.loads`'s `TypeError` for non-strings, but the second strategy runs the value through a string `.replace()` and that `AttributeError` isn't caught, so it escapes before the function can raise its intended `DynaconfParseError`. `@int` and `@float` already raise `DynaconfParseError` for the same inputs, so `@json` was the odd one out.

I added `AttributeError` to that suppress block so a non-string falls through to the existing `DynaconfParseError`, and added tests covering `_safe_json_parse` directly and via `get(..., cast="@json")`.