### PR TITLE
chore(build): switch to hatchling and finish the uv dev-environment migration

### DIFF
--- a/.github/actions/install-from-artifact/action.yml
+++ b/.github/actions/install-from-artifact/action.yml
@@ -24,22 +24,11 @@ runs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'pip'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v8.2.0
       with:
         enable-cache: true
-
-    - name: Upgrade PIP
-      if: inputs.os != 'Windows'
-      shell: bash
-      run: pip install --user --upgrade pip
-
-    - name: Upgrade PIP (Windows)
-      if: inputs.os == 'Windows'
-      shell: bash
-      run: python.exe -m pip install --user --upgrade pip
 
     - name: Download wheel
       uses: actions/download-artifact@v8
@@ -53,10 +42,9 @@ runs:
       run: |
         PACKAGE=$(ls dist/*.whl)
         if [ -n "${{ inputs.dependencies }}" ]; then
-          uv export --no-hashes --only-group ${{ inputs.dependencies }} > requirements-tmp.txt
-          pip install "$PACKAGE" -r requirements-tmp.txt
+          uv pip install --system "$PACKAGE" --group ${{ inputs.dependencies }}
         else
-          pip install "$PACKAGE"
+          uv pip install --system "$PACKAGE"
         fi
 
     - name: Install from wheel (Windows)
@@ -65,8 +53,7 @@ runs:
       run: |
         $PACKAGE = (Get-ChildItem dist/*.whl).FullName
         if ("${{ inputs.dependencies }}" -ne "") {
-          uv export  --no-hashes --only-group ${{ inputs.dependencies }} > requirements-tmp.txt
-          pip install --use-deprecated=legacy-resolver --user "$PACKAGE" -r requirements-tmp.txt 
+          uv pip install --user "$PACKAGE" --group ${{ inputs.dependencies }}
         } else {
-          pip install --use-deprecated=legacy-resolver --user "$PACKAGE"
+          uv pip install --user "$PACKAGE"
         }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include *.md
-include *.png
-include LICENSE
-include VERSION
-include dynaconf/VERSION
-recursive-include vendor_licenses **
-prune dynaconf/vendor_src

--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,13 @@ citest:
 	make coverage-report
 
 ciinstall:
-	uv export --no-hashes --group ci > /tmp/requirements-ci.txt  # lets move all uv soon
-	python -m pip install --upgrade pip
-	python -m pip install -r /tmp/requirements-ci.txt
+	uv pip install --upgrade -e . --group ci
 
 test_all: test_functional test_integration test_redis test_vault test
 	@coverage html
 
 install:
-	uv export --no-hashes --group dev > /tmp/requirements-dev.txt  # lets move all uv soon
-	python -m pip install -r /tmp/requirements-dev.txt
+	uv pip install -e . --group dev
 
 run-pre-commit:
 	rm -rf .tox/

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -31,6 +31,10 @@ Additional links:
 
 #### Prepare your environment
 
+This project uses [uv](https://docs.astral.sh/uv/) to manage the development
+environment and dependencies. Install it first if you don't have it — see the
+[uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
+
 ```bash
 # clone your fork of this repo
 git clone git@github.com:{$USER}/dynaconf.git
@@ -38,9 +42,9 @@ git clone git@github.com:{$USER}/dynaconf.git
 # Add the upstream remote
 git remote add upstream https://github.com/dynaconf/dynaconf.git
 
-# Activate your Python Environment
-python3.10 -m venv venv
-source venv/bin/activate
+# Create and activate your Python environment with uv
+uv venv
+source .venv/bin/activate
 
 # Install dynaconf for development
 make all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "dynaconf"
@@ -11,6 +11,7 @@ authors = [
     {name = "Bruno Rocha", email = "rochacbruno@gmail.com"},
 ]
 license = {text = "MIT"}
+license-files = ["LICENSE", "vendor_licenses/*"]
 requires-python = ">=3.10,<3.15"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -52,36 +53,59 @@ configobj = ["configobj"]
 [project.scripts]
 dynaconf = "dynaconf.cli:main"
 
-# SETUPTOOLS
-# ==========
+# HATCHLING
+# =========
 
-[tool.setuptools]
-include-package-data = true
-zip-safe = false
-platforms = ["any"]
-license-files = ["LICENSE", "vendor_licenses/*"]
+[tool.hatch.version]
+path = "dynaconf/VERSION"
+pattern = "(?P<version>.+)"
 
-[tool.setuptools.dynamic]
-version = {file = "dynaconf/VERSION"}
-
-[tool.setuptools.packages.find]
+[tool.hatch.build.targets.wheel]
+packages = ["dynaconf"]
 exclude = [
-    "tests",
-    "tests.*",
-    "tests_functional",
-    "tests_functional.*",
-    "docs",
-    "scripts",
-    "scripts.*",
-    "legacy_docs",
-    "legacy_docs.*",
-    "docs.*",
-    "build",
-    "build.*",
-    "dynaconf.vendor_src",
     "dynaconf/vendor_src",
-    "dynaconf.vendor_src.*",
-    "dynaconf/vendor_src/*",
+    "dynaconf/vendor_src/**",
+    # packaging cruft from vendored deps (own README/LICENSE/setup.cfg/etc) —
+    # not part of the setuptools build either; vendor_licenses/ is the single
+    # source of truth for vendored-code license text.
+    "dynaconf/vendor/vendor.txt",
+    "dynaconf/vendor/vendor_history",
+    "dynaconf/vendor/toml/DEPRECATION.txt",
+    "dynaconf/vendor/ruamel/yaml/PKG-INFO",
+    "dynaconf/vendor/ruamel/yaml/LICENSE",
+    "dynaconf/vendor/ruamel/yaml/CHANGES",
+    "dynaconf/vendor/ruamel/yaml/MANIFEST.in",
+    "dynaconf/vendor/ruamel/yaml/setup.cfg",
+    "dynaconf/vendor/ruamel/yaml/README.rst",
+]
+
+[tool.hatch.build.targets.wheel.force-include]
+"vendor_licenses" = "vendor_licenses"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/dynaconf",
+    "/tests",
+    "/vendor_licenses",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/CONTRIBUTING.md",
+    "/CONTRIBUTORS.md",
+    "/RELEASING.md",
+    "/SECURITY.md",
+    "/LICENSE",
+]
+exclude = [
+    "/dynaconf/vendor_src",
+    "/dynaconf/vendor/vendor.txt",
+    "/dynaconf/vendor/vendor_history",
+    "/dynaconf/vendor/toml/DEPRECATION.txt",
+    "/dynaconf/vendor/ruamel/yaml/PKG-INFO",
+    "/dynaconf/vendor/ruamel/yaml/LICENSE",
+    "/dynaconf/vendor/ruamel/yaml/CHANGES",
+    "/dynaconf/vendor/ruamel/yaml/MANIFEST.in",
+    "/dynaconf/vendor/ruamel/yaml/setup.cfg",
+    "/dynaconf/vendor/ruamel/yaml/README.rst",
 ]
 
 # TYPOS


### PR DESCRIPTION
Finishes the remaining scope from #1276, following up on [my comment there](https://github.com/dynaconf/dynaconf/issues/1276#issuecomment-5023292885).

## What was already done (before this PR)

Dependency groups (`[dependency-groups]`: dev/ci/docs/lint/test/release) and `[tool.uv.sources]` already existed on `master` — that part of the original scope comment was already handled separately.

## What this PR adds

- **Build backend: setuptools → hatchling.** Version is still read from `dynaconf/VERSION` via `[tool.hatch.version]` (regex pattern matching the raw file content, same as the old `[tool.setuptools.dynamic]` setup). I built both the old and new backend side by side and diffed the wheel and sdist file listings to check for regressions:
  - Wheel: identical contents except a legacy setuptools-only `dist-info/top_level.txt`, which pip/`importlib.metadata` don't need.
  - Sdist: identical except `.gitignore` (harmless) and — this one's actually a fix — `tests/.env`, `conftest.py`, and `docker-compose.yml` are now correctly included. The old MANIFEST.in-based setup was silently shipping an incomplete `tests/` dir that couldn't actually run.
  - Also installed the built wheel into a scratch venv and confirmed `import dynaconf` and the `dynaconf` CLI both work.
- **Makefile: finish the "lets move all uv soon" TODO.** `install`/`ciinstall` used to `uv export` to a temp `requirements.txt` and fall back to `pip install -r` — literally flagged in a comment as temporary. Both now call `uv pip install --group` directly, no pip involved.
- **CI composite action** (`install-from-artifact`): same export-then-pip fallback, replaced with `uv pip install --system`/`--user` + `--group`. Dropped the now-unneeded "upgrade pip" steps.
- **Removed `MANIFEST.in`** — unused under hatchling; sdist inclusion is now explicit in `[tool.hatch.build.targets.sdist]`.
- **`docs/development/contributing.md`**: documents `uv venv` instead of `python3.10 -m venv venv` for environment setup, plus a link to install uv.

## Left out of scope

`smoke-test.yml`'s `pip3 install tox` — that workflow tests dynaconf against a third-party consumer repo (`galaxy_ng`), not dynaconf's own dev tooling, so it felt like a separate concern from what this issue is about. Also left the tox/mask/poethepoet task-runner question alone, as noted in my scoping comment — that seemed like a separate follow-up, not this issue.

## Testing

All run locally end to end, starting from a clean `uv venv`:

```
uv venv && source .venv/bin/activate
make install       # uv pip install -e . --group dev
make test_only      # 744 passed, 9 skipped, coverage 95.43% (required: 95%)
make mypy            # Success: no issues found in 40 source files
ruff check .          # All checks passed!

rm -rf .venv && uv venv && source .venv/bin/activate
make ciinstall        # uv pip install --upgrade -e . --group ci
make citest            # 749 passed; only failures are redis/vault integration
                        # tests needing docker services (CI provides these via
                        # service containers; I don't have them locally — unrelated
                        # to this change)
```

I wasn't able to test the Windows path of the composite action locally (no Windows environment) — the `uv pip install --user` change there is based on `uv pip install --help` documentation matching the original `pip install --user` semantics, but CI running on this PR will be the real confirmation.

Fixes #1276