### PR TITLE
fix: convert dict/list subclasses to data nodes

### DIFF
--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -702,9 +702,9 @@ def get_core(node, raises=True) -> DynaconfCore:
 
 def convert_containers(data: dict | list | DataNode, iter, core):
     for key, value in iter:
-        if value.__class__ is dict:
+        if isinstance(value, dict) and not isinstance(value, DataDict):
             data[key] = DataDict(value, core=core)
-        if value.__class__ is list:
+        elif isinstance(value, list) and not isinstance(value, DataList):
             data[key] = DataList(value, core=core)
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -288,6 +288,28 @@ def test_nested_structures():
     assert isinstance(di["b"]["c"], DataList)
 
 
+def test_nested_dict_and_list_subclasses_are_converted():
+    """Subclasses of dict/list must become data-nodes too.
+
+    Regression for #1430: an identity check on ``__class__`` skipped
+    dict/list subclasses (e.g. ``OrderedDict``, ``box.Box``), so nested
+    values kept plain-container behavior and lost case-insensitive
+    reading and lazy-format evaluation.
+    """
+
+    class MyDict(dict):
+        pass
+
+    class MyList(list):
+        pass
+
+    di = DataDict({"a": MyDict({"x": 1}), "b": MyList([{"y": 2}])})
+
+    assert isinstance(di["a"], DataDict)
+    assert isinstance(di["b"], DataList)
+    assert isinstance(di["b"][0], DataDict)
+
+
 def test_method_preservation():
     di = DataDict()
     di["a"] = {"x": 1}


### PR DESCRIPTION
Closes #1430

`convert_containers` used an identity check (`value.__class__ is dict`), so subclasses of `dict`/`list` -- `OrderedDict`, external `box.Box`, or any user subclass -- were never converted to `DataDict`/`DataList`. Those plain containers do not do case-insensitive lookup and do not evaluate lazy values, so nested settings reaching them lose `lowercase_read` and keep `@format`/`@jinja` directives as raw strings.

Switched to `isinstance()`, skipping values that are already data nodes.

Regression test `test_nested_dict_and_list_subclasses_are_converted` fails on the original check and passes with the fix.
