### PR TITLE
fix: keep sibling keys that share a dotted path leaf name

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -125,6 +125,7 @@ def object_merge(
                 # but the new value on the end of full path is the same
                 if (
                     existing_value is not None
+                    and len(full_path) == 1
                     and old_key.lower() == full_path[-1].lower()
                     and existing_value is value
                 ):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -937,3 +937,23 @@ def test_from_env_with_validate_on_update_does_not_recurse():
     # Before the fix this raised RecursionError.
     other_settings = settings.from_env("development")
     assert other_settings.current_env.lower() == "development"
+
+
+def test_sibling_key_sharing_leaf_name_survives_validation():
+    """Nested keys sharing a leaf name must all survive validation. See #974"""
+    from dynaconf import Dynaconf
+    from dynaconf import Validator
+
+    settings = Dynaconf()
+    settings.validators.register(
+        Validator("foo.bar.value", must_exist=True, is_type_of=bool)
+    )
+    settings.set("foo.value", True)
+    settings.set("foo.bar.value", True)
+
+    settings.validators.validate()
+
+    assert settings.foo.bar.value is True
+    # Before the fix `foo.value` was dropped, because the sibling key shared
+    # the leaf name of the dotted path being set.
+    assert settings.foo.value is True


### PR DESCRIPTION
Closes #974

`object_merge` skips copying an old key when its name matches the last segment of `full_path` and it is the same object as `recursive_get(old, full_path)`. That guard is only meaningful at the level where the dotted path terminates, but it was evaluated at every recursion level — so `settings.set("foo.bar.value", ...)` (which validation re-issues) dropped an unrelated sibling `foo.value` holding the same object.

Restricting the guard to the terminating level (`len(full_path) == 1`) fixes it. The new test in `tests/test_validators.py` is the issue's reproduction verbatim; it fails on master with `AccessError: 'value'` and passes with the fix. Rest of the suite is unchanged (665 passed both before and after; the 23 failures are pre-existing, from optional deps missing locally).
