### PR TITLE
fix: clean up nested dynaconf_merge tokens when parent key is new

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -256,6 +256,15 @@ def handle_metavalues(
                 new[key] = object_merge(
                     old.get(key), new[key], list_merge=list_merge
                 )
+            else:
+                # No merge token on this level, but a nested level may still
+                # carry one - it must be handled (and removed) as well. ref #1210
+                nested_old = old.get(key)
+                handle_metavalues(
+                    nested_old if isinstance(nested_old, dict) else {},
+                    new[key],
+                    list_merge=list_merge,
+                )
 
 
 class FakeCore:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -383,6 +383,22 @@ def test_merge_list_token_when_key_absent_in_old():
     assert new == {"existing": 1, "ports": [8080]}
 
 
+def test_nested_merge_token_is_cleaned_up_when_key_absent_in_old():
+    # A `dynaconf_merge` token nested below a key that does not exist in the
+    # existing data was never consumed, so it leaked into the final settings
+    # as a regular key.  See #1210.
+    old = {}
+    new = {"a": {"nested": {"dynaconf_merge": True, "y": 2}}}
+    object_merge(old, new)
+    assert new == {"a": {"nested": {"y": 2}}}
+
+    # Same for a deeper nesting level.
+    old = {"a": {"other": 1}}
+    new = {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}}
+    object_merge(old, new)
+    assert new == {"a": {"other": 1, "b": {"c": {"y": 2}}}}
+
+
 def test_trimmed_split():
     # No sep
     assert trimmed_split("hello") == ["hello"]


### PR DESCRIPTION
Closes #1210

`handle_metavalues` only recursed into a nested dict when that level itself carried a `dynaconf_merge` token, so a token nested below a key absent from the existing settings was never consumed and leaked through as a regular key (`{"a": {"nested": {"dynaconf_merge": True, "y": 2}}}`). It now recurses regardless, cleaning up every occurrence.

Regression test in `tests/test_utils.py` fails on master (the leftover `dynaconf_merge` key) and passes with the fix.
