### PR TITLE
fix(nodes): convert container subclasses

### DIFF
--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -702,9 +702,9 @@ def get_core(node, raises=True) -> DynaconfCore:
 
 def convert_containers(data: dict | list | DataNode, iter, core):
     for key, value in iter:
-        if value.__class__ is dict:
+        if isinstance(value, dict) and not isinstance(value, DataDict):
             data[key] = DataDict(value, core=core)
-        if value.__class__ is list:
+        if isinstance(value, list) and not isinstance(value, DataList):
             data[key] = DataList(value, core=core)
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -15,6 +15,7 @@ from dynaconf.nodes import init_core
 from dynaconf.utils import container_items
 from dynaconf.utils import data_print
 from dynaconf.utils.boxing import _DynaBox
+from dynaconf.vendor.box import Box
 from dynaconf.vendor.box import BoxList
 
 pytestmark = pytest.mark.usefixtures("no_deprecations")
@@ -183,6 +184,27 @@ def test_data_containers_init(input):
         assert get_core(container) == core
 
     recursive_walk(data, assert_fn)
+
+
+def test_data_containers_init_converts_subclasses_without_rewrapping_nodes():
+    data_dict = DataDict({"value": 1})
+    data_list = DataList([1])
+
+    data = DataDict(
+        {
+            "dict_subclass": Box({"nested": {"value": 1}}),
+            "list_subclass": BoxList([{"value": 1}]),
+            "data_dict": data_dict,
+            "data_list": data_list,
+        }
+    )
+
+    assert type(data["dict_subclass"]) is DataDict
+    assert type(data["dict_subclass"]["nested"]) is DataDict
+    assert type(data["list_subclass"]) is DataList
+    assert type(data["list_subclass"][0]) is DataDict
+    assert dict.__getitem__(data, "data_dict") is data_dict
+    assert dict.__getitem__(data, "data_list") is data_list
 
 
 class TestDataDict:


### PR DESCRIPTION
## Summary

`convert_containers()` only recognized exact `dict` and `list` instances, so compatible subclasses such as `Box` and `BoxList` remained outside Dynaconf's `DataDict` / `DataList` model.

Use `isinstance()` for container detection while explicitly preserving existing `DataDict` and `DataList` nodes to avoid wrapping them again. Regression coverage verifies recursive conversion of Box containers and identity preservation for existing Dynaconf nodes.

Fixes #1430

## Tests

- `uv run pytest tests/test_nodes.py -q` — 41 passed
- `uv run pytest -m 'not integration' --no-cov -q tests/` — 739 passed, 29 skipped, 19 deselected, 1 xfailed
- `uv run coverage report` — 95%
- `uv run mypy dynaconf/ --exclude '^dynaconf/vendor*'` — passed
- `uv run pre-commit run --all-files` — passed

The functional-test runner was attempted but could not start on this workstation because GNU Make is unavailable; CI runs it on supported environments.