### PR TITLE
fix: Fix regression on override precedence with proper dynaconf-token cleanup

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -181,6 +181,15 @@ def recursive_get(
     return recursive_get(result, tail)
 
 
+def _strip_merge_tokens(data: dict) -> None:
+    """Remove dynaconf_merge tokens from a dict tree without merging."""
+    for key in list(data.keys()):
+        if isinstance(data[key], dict):
+            data[key].pop("dynaconf_merge", None)
+            data[key].pop("dynaconf_merge_unique", None)
+            _strip_merge_tokens(data[key])
+
+
 def handle_metavalues(
     old: DataDict | dict[str, int] | dict[str, str | int],
     new: Any,
@@ -257,15 +266,8 @@ def handle_metavalues(
                 new[key] = object_merge(
                     old.get(key), new[key], list_merge=list_merge
                 )
-            else:
-                # No merge token on this level, but a nested level may still
-                # carry one - it must be handled (and removed) as well. ref #1210
-                nested_old = old.get(key)
-                handle_metavalues(
-                    nested_old if isinstance(nested_old, dict) else {},
-                    new[key],
-                    list_merge=list_merge,
-                )
+            elif key not in old:
+                _strip_merge_tokens(new[key])
 
 
 class FakeCore:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -383,20 +383,66 @@ def test_merge_list_token_when_key_absent_in_old():
     assert new == {"existing": 1, "ports": [8080]}
 
 
-def test_nested_merge_token_is_cleaned_up_when_key_absent_in_old():
-    # A `dynaconf_merge` token nested below a key that does not exist in the
-    # existing data was never consumed, so it leaked into the final settings
-    # as a regular key.  See #1210.
-    old = {}
-    new = {"a": {"nested": {"dynaconf_merge": True, "y": 2}}}
+@pytest.mark.parametrize(
+    "old, new, expected",
+    [
+        pytest.param(
+            {},
+            {"a": {"nested": {"dynaconf_merge": True, "y": 2}}},
+            {"a": {"nested": {"y": 2}}},
+            id="absent_key_level_1",
+        ),
+        pytest.param(
+            {"a": {"other": 1}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2}}}},
+            id="absent_key_level_2",
+        ),
+        pytest.param(
+            {"m": {"other": 1}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"b": {"c": {"y": 2}}}, "m": {"other": 1}},
+            id="absent_key_level_2_different_root",
+        ),
+        pytest.param(
+            {"a": {"other": 1, "b": {}}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2}}}},
+            id="absent_key_level_2_with_existing_empty_parent",
+        ),
+        pytest.param(
+            {"a": {"other": 1, "b": {"b_child": 3}}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2}, "b_child": 3}}},
+            id="absent_key_level_2_with_existing_nonempty_parent",
+        ),
+        pytest.param(
+            {"a": {"other": 1, "b": {"c": {}}}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2}}}},
+            id="absent_key_level_2_with_existing_empty_sibling",
+        ),
+        pytest.param(
+            {"a": {"other": 1, "b": {"c": {"z": 3}}}},
+            {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2, "z": 3}}}},
+            id="absent_key_level_2_with_existing_nonempty_sibling",
+        ),
+        pytest.param(
+            {"a": {"other": 1, "b": {"c": {"z": 3}}}},
+            {"a": {"b": {"c": {"dynaconf_merge": False, "y": 2}}}},
+            {"a": {"other": 1, "b": {"c": {"y": 2}}}},
+            id="absent_key_level_2_with_existing_nonempty_sibling_merge_false",
+        ),
+    ],
+)
+def test_nested_merge_token_is_cleaned_up_when_key_absent_in_old(
+    old, new, expected
+):
+    """See #1210. Merge token nested below an absent key must be stripped
+    so it doesn't leak into the final settings."""
     object_merge(old, new)
-    assert new == {"a": {"nested": {"y": 2}}}
-
-    # Same for a deeper nesting level.
-    old = {"a": {"other": 1}}
-    new = {"a": {"b": {"c": {"dynaconf_merge": True, "y": 2}}}}
-    object_merge(old, new)
-    assert new == {"a": {"other": 1, "b": {"c": {"y": 2}}}}
+    assert new == expected
 
 
 def test_trimmed_split():

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -578,3 +578,38 @@ def test_empty_yaml_key_overriding(tmpdir):
             _settings.level1.key6
             _settings.level1.key7
             _settings.level1.KEY8
+
+
+def test_nested_format_does_not_drop_env_override(create_file, clean_env):
+    """Regression test for #1437.
+
+    With environments=True + merge_enabled=True, a nested @format value
+    two or more levels deep caused the environment override of a sibling
+    key to be silently dropped (reverted to the default value).
+    """
+    settings_file = create_file(
+        "settings.yaml",
+        """\
+        default:
+          database:
+            name: "default_schema"
+            tables:
+              users:
+                name: "users"
+                full_name: "@format {this.database.name}.{this.database.tables.users.name}"
+
+        production:
+          database:
+            name: "prod_schema"
+        """,
+    )
+
+    settings = LazySettings(
+        settings_files=[str(settings_file)],
+        environments=True,
+        merge_enabled=True,
+        env="production",
+    )
+
+    assert settings.database.name == "prod_schema"
+    assert settings.database.tables.users.full_name == "prod_schema.users"


### PR DESCRIPTION
Added a proper cleanup function for the edge case, instead of calling handle_metavalue just for cleanup (which has side-effects).

Closes: #1437