### PR TITLE
fix: add DataDict.__deepcopy__ so copy.deepcopy propagates core (#1439)

### DIFF
--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -89,6 +89,17 @@ class DataDict(dict):
     def __copy__(self):
         return self.copy()
 
+    def __deepcopy__(self, memo=None):
+        # Not part of the plain dict API, but needed to propagate core.
+        # Without it, the default deepcopy recurses into __meta__.core and
+        # fails on any non-copyable object the Settings graph holds.
+        out = self.__class__(core=self.__meta__.core)
+        memo = memo or {}
+        memo[id(self)] = out
+        for k, v in super().items():
+            out[copy.deepcopy(k, memo=memo)] = copy.deepcopy(v, memo=memo)
+        return out
+
     def __getitem__(self, item):
         try:
             result = super().__getitem__(item)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import threading
 from collections import namedtuple
 
 import pytest
@@ -105,6 +106,39 @@ def test_get():
 def test_copy_no_cause_inf_recursion():
     ddict.__copy__()
     ddict.copy()
+
+
+def test_deepcopy_datadict_propagates_core_by_reference():
+    """Issue: https://github.com/dynaconf/dynaconf/issues/1439
+
+    Without DataDict.__deepcopy__, the default implementation recurses into
+    __meta__.core and raises on anything the Settings graph holds that cannot
+    be pickled, such as a lock.
+    """
+    core = DynaconfCore("test")
+    core.obj._lock = threading.RLock()
+    data = DataDict({"a": {"b": [1, 2]}}, core=core)
+
+    out = copy.deepcopy(data)
+
+    assert isinstance(out, DataDict)
+    assert out == data
+    assert out.__meta__.core is core
+    assert out["a"].__meta__.core is core
+
+    # values are copied deeply, so mutating the copy leaves the original alone
+    out["a"]["b"].append(3)
+    assert list(data["a"]["b"]) == [1, 2]
+
+
+def test_deepcopy_datadict_handles_cycles():
+    core = DynaconfCore("test")
+    data = DataDict({"x": 1}, core=core)
+    data["self"] = data
+
+    out = copy.deepcopy(data)
+
+    assert out["self"] is out
 
 
 def test_accessing_datadict_inside_datalist_inside_datadict():


### PR DESCRIPTION
Fixes #1439

### Problem

`DataDict` defines `__copy__` but not `__deepcopy__`. Python's default `deepcopy` therefore recurses into `__meta__` → `NodeMetadata.core` → `DynaconfCore` → `Settings`, and raises on any non-copyable object the Settings graph happens to hold:

```python
settings = Dynaconf(settings_files=["settings.yaml"])
settings._lock = threading.RLock()
copy.deepcopy(settings.SERVER)   # TypeError: cannot pickle '_thread.RLock' object
```

`DataList` already solves exactly this, with `__copy__`/`__deepcopy__` that propagate `core` **by reference**. `DataDict` just never got the second half.

### Fix

Mirror the `DataList.__deepcopy__` implementation:

```python
def __deepcopy__(self, memo=None):
    out = self.__class__(core=self.__meta__.core)
    memo = memo or {}
    memo[id(self)] = out
    for k, v in super().items():
        out[copy.deepcopy(k, memo=memo)] = copy.deepcopy(v, memo=memo)
    return out
```

Three things worth calling out:

- **`core` is shared, not copied.** Same contract as `copy()`, `__copy__` and `DataList.__deepcopy__` — the core is process-wide state, so deep-copying it is what caused the bug in the first place.
- **`memo[id(self)] = out` is registered before recursing**, so self-referencing config terminates instead of blowing the stack, and shared sub-nodes stay shared in the copy.
- **`super().items()` reads raw values**, bypassing `DataDict.__getitem__`'s lazy-format evaluation, so a deepcopy doesn't accidentally resolve `@format` tokens. This matches how `copy()` uses `super().copy()`.

### Tests

Two tests added to `tests/test_nodes.py`:

- `test_deepcopy_datadict_propagates_core_by_reference` — reproduces the reported `RLock` crash, then asserts the copy is a `DataDict`, compares equal, shares `core` at both the top level and on the nested node, and that mutating a nested list in the copy leaves the original untouched.
- `test_deepcopy_datadict_handles_cycles` — a `DataDict` that contains itself deep-copies to a structure that contains *itself*, not the original.

Both fail on `master` and pass with the fix. I sanity-checked they aren't vacuous by mutating the patch three ways:

| Mutation | Result |
|---|---|
| remove `__deepcopy__` entirely | `TypeError: cannot pickle '_thread.RLock' object` (the original bug) |
| drop `memo[id(self)] = out` | `RecursionError` on the cycle test |
| deep-copy `core` instead of sharing it | both tests fail |

Full suite run before and after the change produces an identical set of failures (26 either way — all pre-existing collection/env issues on my machine, e.g. `test_vault.py`), so nothing regressed.