### PR TITLE
chore: add py314 in toxList and up some test packages to full support…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,7 @@ optional_value = "final"
 # ===
 
 [tool.tox]
-envlist = ["py310", "py311", "py312", "py313"]
+envlist = ["py310", "py311", "py312", "py313", "py314"]
 whitelist_externals = ["make"]
 
 [tool.tox.testenv]
@@ -319,17 +319,17 @@ test = [
     "flask>=1.0",
     "hvac>=1.1.0",
     "ipython>=8.12.1",
-    "pytest>=8.4.2",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=7.0.0",
-    "pytest-docker>=3.2.3",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=0.26.0",
+    "pytest-cov>=7.1.0",
+    "pytest-docker>=3.2.5",
     "pytest-mock>=3.15.1",
     "pytest-xdist>=3.8.0",
-    "python-dotenv>=1.2.1",
+    "python-dotenv>=1.2.2",
     "radon>=6.0.1",
     "redis>=7.0.1",
     "toml>=0.10.2",
-    "tox>=4.30.3",
+    "tox>=4.58.0",
     "ipdb>=0.13.13",
     "ipython<=8.12.1",
     "pdbr[ipython]>=0.9.2",


### PR DESCRIPTION
Hello

In his PR:
1) add py314 in local tox list (add able run python3.14 in local)
2) up packages for pytest and tox (for full support python3.14)