### PR TITLE
fix: skip non-str keys when resolving key casing

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -617,7 +617,7 @@ def find_the_correct_casing(
 ) -> str | None:
     """Given a key, find the proper casing in data.
 
-    Return 'None' for non-str key types.
+    Non-str keys in data are skipped.
 
     Arguments:
         key {str} -- A key to be searched in data
@@ -630,7 +630,7 @@ def find_the_correct_casing(
         return key
     for k in data_keys:
         if not isinstance(k, str):
-            return None
+            continue
         if k.lower() == key.lower():
             return k
         if k.replace(" ", "_").lower() == key.lower():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ from dynaconf.utils import build_env_list
 from dynaconf.utils import ensure_a_list
 from dynaconf.utils import ensure_upperfied_list
 from dynaconf.utils import extract_json_objects
+from dynaconf.utils import find_the_correct_casing
 from dynaconf.utils import isnamedtupleinstance
 from dynaconf.utils import Missing
 from dynaconf.utils import missing
@@ -355,6 +356,18 @@ def test_merge_dict_preserves_old_key_order():
     object_merge(old2, new2)
     assert list(new2.keys()) == ["x", "y", "z"]
     assert new2 == {"x": 99, "y": 20, "z": 30}
+
+
+def test_find_the_correct_casing_skips_non_str_keys():
+    assert find_the_correct_casing("timeout", (1, 2, "TIMEOUT")) == "TIMEOUT"
+    assert find_the_correct_casing("timeout", (1, 2)) is None
+
+
+def test_merge_existing_dict_with_non_str_keys():
+    existing = {1: "fast", 2: "slow", "TIMEOUT": 30}
+    new = {"timeout": 60}
+    object_merge(existing, new)
+    assert new == {1: "fast", 2: "slow", "TIMEOUT": 60}
 
 
 def test_merge_dict_with_meta_values(settings):


### PR DESCRIPTION
`find_the_correct_casing` returns on the first non-str key in the data, so a non-str key disables case-insensitive matching for the keys after it.

`settings.yaml`:

```yaml
default:
  RETRY:
    1: fast
    2: slow
    TIMEOUT: 30
```

`settings.local.yaml`:

```yaml
default:
  RETRY:
    timeout: 60
```

```python
from dynaconf import Dynaconf

s = Dynaconf(settings_files=["settings.yaml", "settings.local.yaml"],
             environments=True, merge_enabled=True)
print("RETRY =", dict(s.RETRY))
print("RETRY.TIMEOUT =", s.RETRY.TIMEOUT)
```

On master:

```
RETRY = {1: 'fast', 2: 'slow', 'TIMEOUT': 30, 'timeout': 60}
RETRY.TIMEOUT = 30
```

The override is dropped and a duplicate key appears; the same two files with `A:`/`B:` instead of `1:`/`2:` give `{'A': 'fast', 'B': 'slow', 'TIMEOUT': 60}`. The same lookup also backs `__getitem__`, `__getattr__`, `__contains__` and `get`.

The guard is there to avoid `k.lower()` on a non-str key, and `continue` does that without aborting the scan. A dict whose keys are all non-str still resolves to `None`, now at the end of the loop.

Two tests in `tests/test_utils.py`; I verified both fail without the one-line change. Unit and functional suites pass, mypy and pre-commit clean.
