### PR TITLE
fix: allow lazy self-reference to read the previous value

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -35,6 +35,7 @@ from dynaconf.nodes import recursively_evaluate_lazy_format
 from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.utils import BANNER
 from dynaconf.utils import ensure_a_list
+from dynaconf.utils import find_the_correct_casing
 from dynaconf.utils import ensure_upperfied_list
 from dynaconf.utils import ListMergeOptions
 from dynaconf.utils import missing
@@ -1010,6 +1011,22 @@ class Settings:
         for key in keys:
             self.unset(key, force=force)
 
+    def _get_raw_leaf(self, split_keys):
+        """Return the unevaluated value at a dotted path, or `empty`."""
+        node = self.store
+        try:
+            for k in split_keys:
+                if isinstance(node, DataDict):
+                    node = node.get(k, bypass_eval=True)
+                elif isinstance(node, dict):
+                    n_item = find_the_correct_casing(k, tuple(node.keys())) or k
+                    node = node[n_item]
+                else:
+                    return empty
+            return node
+        except (AttributeError, KeyError, TypeError):
+            return empty
+
     def _dotted_set(
         self,
         dotted_key: str,
@@ -1106,6 +1123,11 @@ class Settings:
                         tree[index] = value  # assign value
                 else:  # odd cases like [2]0
                     raise (ValueError("Invalid field:", k))
+
+        if isinstance(value, Lazy):
+            previous = self._get_raw_leaf(split_keys)
+            if previous is not empty:
+                value.previous = previous
 
         if existing_data:
             if config.dynaboxify:
@@ -1217,12 +1239,19 @@ class Settings:
         # Fix for #869 - Evaluating an existing lazy value during set can
         # fail before a complete replacement value is stored.
         existing = None
+        existing_raw = empty
+        with suppress(AttributeError, KeyError):
+            if isinstance(self.store, DataDict):
+                existing_raw = self.store.get(key, bypass_eval=True)
+            else:
+                existing_raw = self.store.get(key)
         if not isinstance(parsed, Lazy):
-            with suppress(AttributeError, KeyError):
-                if isinstance(self.store, DataDict):
-                    existing = self.store.get(key, bypass_eval=True)
-                else:
-                    existing = self.store.get(key)
+            if existing_raw is not empty:
+                existing = existing_raw
+        elif existing_raw is not empty:
+            # Keep the replaced value so a self-referencing formatter
+            # (FOO="@int @jinja {{this.FOO|int}}") can read it (#1425).
+            parsed.previous = existing_raw
 
         if getattr(parsed, "_dynaconf_insert", False):
             # `@insert` calls insert in a list by index

--- a/dynaconf/nodes.py
+++ b/dynaconf/nodes.py
@@ -741,9 +741,16 @@ def recursively_evaluate_lazy_format(value, settings):
         # Check for circular reference
         value_id = id(value)
         if value_id in eval_stack:
+            # A lazy override that reads the same key (e.g. FOO="@int @jinja
+            # {{this.FOO|int}}" after FOO="2015") should see the previous
+            # value, not raise. True A→B→A cycles have no usable previous.
+            previous = getattr(value, "previous", empty)
+            if previous is not empty and not is_lazy(previous):
+                return previous
             raise __import__("dynaconf.utils.parse_conf").DynaconfFormatError(
                 "Circular reference detected in lazy formatting. "
-                "A value is referencing itself directly or indirectly."
+                "A value is referencing itself directly or indirectly: "
+                f"{value!r}"
             )
 
         # Add to stack before evaluation

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -480,6 +480,9 @@ class Lazy:
     ):
         self.value = value
         self.casting = casting
+        # Previous store value this Lazy replaced, if any. Used when a
+        # formatter reads the same key it is defining (#1425).
+        self.previous = empty
         # Sometimes a simple function is passed to the formatter.
         # but on evaluation-time, we may need to access `formatter.token`
         # so we are wrapping the fn to comply with this interface.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1302,6 +1302,41 @@ def test_format_circular_reference(settings):
         settings.A
 
 
+def test_lazy_self_reference_uses_previous_value():
+    """A lazy override may read the key it replaces (#1425)."""
+    settings = Dynaconf(environments=False)
+    settings.set("FOO", "2015")
+    settings.set("FOO", "@int @jinja {{this.FOO | int}}")
+    assert settings.FOO == 2015
+    assert isinstance(settings.FOO, int)
+
+    settings.set("BAR", "hello")
+    settings.set("BAR", "@format {this.BAR} world")
+    assert settings.BAR == "hello world"
+
+
+def test_lazy_self_reference_nested_and_include(tmp_path):
+    """Same-key @jinja via include / dotted set (issue #1425)."""
+    (tmp_path / "settings.toml").write_text('[main]\nstartyear = "2015"\n')
+    (tmp_path / "config_post.toml").write_text(
+        'MAIN__STARTYEAR = "@int @jinja {{this.main.startyear | int}}"\n'
+    )
+    settings = Dynaconf(
+        merge_enabled=True,
+        environments=False,
+        settings_files=[str(tmp_path / "settings.toml")],
+        loaders=["dynaconf.loaders.toml_loader"],
+        includes=[str(tmp_path / "config_post.toml")],
+    )
+    assert settings.main.startyear == 2015
+    assert isinstance(settings.main.startyear, int)
+
+    nested = Dynaconf(environments=False)
+    nested.set("main.startyear", "2015")
+    nested.set("MAIN__STARTYEAR", "@int @jinja {{this.main.startyear | int}}")
+    assert nested.main.startyear == 2015
+
+
 def test_string_utils_with_numbers(settings):
     """Test string utilities with numeric input"""
     settings.set("NUM", "@upper 42")


### PR DESCRIPTION
## Summary

A lazy `@jinja` / `@format` value that overwrites an existing key and then reads that same key (for example `FOO="@int @jinja {{this.FOO | int}}"` after `FOO="2015"`) was reported as a circular reference and raised `DynaconfFormatError`.

That pattern is used to recast or transform a value that was already loaded (issue #1425). The 3.3 circular-reference guard treated the self-read as a cycle because the previous value had already been replaced in the store.

## Change

- When `set()` / dotted set stores a `Lazy` over an existing key, keep the replaced (unevaluated) value on `Lazy.previous`.
- If evaluation re-enters the same `Lazy` object, return that previous value instead of raising.
- True cycles (`A` → `B` → `A`, or a self-ref with no previous value) still raise. The error now includes the lazy value.

## Tests

- Top-level `set()` self-reference with `@int @jinja` and `@format`
- Nested / include reproduction from #1425
- Existing A→B→A circular test still fails as expected

Fixes #1425