### PR TITLE
Re-structure Makefile, uv usage and  CI/dev consistency

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # False positives on client-id/app-id
+      # See: https://github.com/rhysd/actionlint/issues/669
+      - "actions/create-github-app-token@v3"

--- a/.github/actions/install-from-artifact/action.yml
+++ b/.github/actions/install-from-artifact/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Optional dependencies to install with the wheel'
     required: false
     default: ''
-  os:
-    description: 'Operating system (Windows, Linux, macOS)'
-    required: false
-    default: 'Linux'
   python-version:
     description: 'Python version to use'
     required: false
@@ -21,25 +17,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-
     - name: Install uv
       uses: astral-sh/setup-uv@v8.2.0
       with:
         enable-cache: true
-
-    - name: Upgrade PIP
-      if: inputs.os != 'Windows'
-      shell: bash
-      run: pip install --user --upgrade pip
-
-    - name: Upgrade PIP (Windows)
-      if: inputs.os == 'Windows'
-      shell: bash
-      run: python.exe -m pip install --user --upgrade pip
 
     - name: Download wheel
       uses: actions/download-artifact@v8
@@ -47,26 +28,10 @@ runs:
         name: ${{ inputs.artifact_in }}
         path: dist/
 
-    - name: Install from wheel (Unix)
-      if: inputs.os != 'Windows'
+    - name: Install from wheel
       shell: bash
       run: |
-        PACKAGE=$(ls dist/*.whl)
-        if [ -n "${{ inputs.dependencies }}" ]; then
-          uv export --no-hashes --only-group ${{ inputs.dependencies }} > requirements-tmp.txt
-          pip install "$PACKAGE" -r requirements-tmp.txt
-        else
-          pip install "$PACKAGE"
-        fi
-
-    - name: Install from wheel (Windows)
-      if: inputs.os == 'Windows'
-      shell: pwsh
-      run: |
-        $PACKAGE = (Get-ChildItem dist/*.whl).FullName
-        if ("${{ inputs.dependencies }}" -ne "") {
-          uv export  --no-hashes --only-group ${{ inputs.dependencies }} > requirements-tmp.txt
-          pip install --use-deprecated=legacy-resolver --user "$PACKAGE" -r requirements-tmp.txt 
-        } else {
-          pip install --use-deprecated=legacy-resolver --user "$PACKAGE"
-        }
+        make install \
+          WHEEL=dist/*.whl \
+          GROUP=${{ inputs.dependencies }} \
+          PYTHON=${{ inputs.python-version }}

--- a/.github/scripts/dist-health-check.sh
+++ b/.github/scripts/dist-health-check.sh
@@ -2,17 +2,11 @@
 
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
+
 echo "Checking dist build health"
 
-venv="$(mktemp --directory)"
-python3 -m venv "${venv}"
-source "${venv}/bin/activate"
-
 for dist in dist/*; do
-    pip install --quiet "${dist}"
-    dynaconf list --help 1>/dev/null
+    uv run --isolated --with "${dist}" -- dynaconf list --help 1>/dev/null
 done
 
-deactivate
-rm -rf "${venv}"
 echo "Done"

--- a/.github/scripts/release_utility.py
+++ b/.github/scripts/release_utility.py
@@ -107,6 +107,9 @@ HELP_FORMATTER = argparse.RawDescriptionHelpFormatter
 
 _DEBUG = True
 
+# Network git ops (fetch, ls-remote) shouldn't hang forever on a bad connection.
+GIT_TIMEOUT_SECONDS = 10
+
 
 def debug(label: str, value: object) -> None:
     if _DEBUG:
@@ -122,12 +125,18 @@ class Repository:
 
     def _git(self, *args) -> tuple[str, str]:
         result = subprocess.run(
-            ["git", *args], check=True, capture_output=True, text=True
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
         )
         return result.stdout.strip(), result.stderr.strip()
 
     def _git_ok(self, *args) -> bool:
-        result = subprocess.run(["git", *args], capture_output=True)
+        result = subprocess.run(
+            ["git", *args], capture_output=True, timeout=GIT_TIMEOUT_SECONDS
+        )
         return result.returncode == 0
 
     # --- read-only ---

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -19,16 +19,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release-tag || github.ref }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-        with:
-          python-version: "3.10"
-      - name: Install build dependencies
-        run: uv sync --only-group release
+
       - name: Build wheel
-        run: uv run make dist
-      - name: Run health check
-        run: .github/scripts/dist-health-check.sh
+        run: make build
+
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
 
+      - name: Install dependencies
+        run: make install GROUP=docs
+
       - name: Build documentation
-        run: uv run make docs
+        run: make docs-build
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -32,22 +32,19 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install release tools
-        run: |
-          # Install from master before switching branches so the command survives checkout.
-          uv sync --only-group release
-          uv pip install .github/scripts/
+        run: make install GROUP=release
       - name: Set up git identity
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
       - name: Create sync PRs
         run: |
-          BRANCHES=$(uv run release-utility get backport-branches)
+          BRANCHES=$(release-utility get backport-branches)
           for BRANCH in $BRANCHES; do
             SYNC_BRANCH="bot/ci_update/$BRANCH"
             # Create or force-reset the sync branch to the remote backport branch tip.
             git checkout -B "$SYNC_BRANCH" "origin/$BRANCH"
-            if ! uv run release-utility update-github; then
+            if ! release-utility update-github; then
               echo "No .github/ changes for $BRANCH, skipping"
               continue
             fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-          cache: 'pip'
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-        with:
-          enable-cache: true
-      - name: Install and lint
-        run: make clean ciinstall run-pre-commit
+
+      - name: Lint
+        run: make lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,33 +25,36 @@ jobs:
           fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-        with:
-          python-version: "3.10"
+
       - name: Install release tools
-        run: |
-          # Install the release utility as a package from master so the command
-          # is always the canonical version regardless of how the workflow was triggered.
-          uv sync --only-group release
-          uv pip install .github/scripts/
+        run: make install GROUP=release
+
       - name: Detect release type
         id: release-type
         run: |
-          TYPE=$(uv run release-utility get release-type "${{ inputs.release-tag || github.ref_name }}")
+          INPUT_TAG="${{ inputs.release-tag || github.ref_name }}"
+          TYPE=$(release-utility get release-type "$INPUT_TAG")
           echo "value=$TYPE" >> "$GITHUB_OUTPUT"
+
       - name: Check out release tag
         run: |
-          git checkout "${{ inputs.release-tag || github.ref_name }}"
+          INPUT_TAG="${{ inputs.release-tag || github.ref_name }}"
+          git checkout "$INPUT_TAG"
+
       - name: Validate release
         run: |
+          INPUT_TAG="${{ inputs.release-tag || github.ref_name }}"
           if [[ "${{ steps.release-type.outputs.value }}" == "backport" ]]; then
-            uv run release-utility validate --pre-publish --backport "${{ inputs.release-tag || github.ref_name }}"
+            release-utility validate --pre-publish --backport "$INPUT_TAG"
           else
-            uv run release-utility validate --pre-publish "${{ inputs.release-tag || github.ref_name }}"
+            release-utility validate --pre-publish "$INPUT_TAG"
           fi
+
       - name: Check if latest release
         id: is-latest
         run: |
-          VALUE=$(uv run release-utility get is-latest "${{ inputs.release-tag || github.ref_name }}")
+          INPUT_TAG="${{ inputs.release-tag || github.ref_name }}"
+          VALUE=$(release-utility get is-latest "$INPUT_TAG")
           echo "value=$VALUE" >> "$GITHUB_OUTPUT"
 
   build-dist:
@@ -76,6 +79,7 @@ jobs:
         with:
           name: ${{ needs.build-dist.outputs.dist-artifact }}
           path: dist
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -92,8 +96,10 @@ jobs:
           ref: ${{ inputs.release-tag || github.ref_name }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+
       - name: Generate release notes
-        run: uv run --with git-changelog git-changelog --release-notes > release-notes.md
+        run: make release-notes > release-notes.md
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -19,39 +19,41 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
           ref: master
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.10"
+
       - name: Install release tools
-        run: |
-          # Install the release utility as a package from master so the installed
-          # command is unaffected by the backport branch checkout that follows.
-          uv sync --only-group release
-          uv pip install .github/scripts/
+        run: make install GROUP=release
+
       - name: Resolve backport branch
         id: branch
         run: |
-          BRANCH=$(uv run release-utility get backport-branch "${{ inputs.expected-release }}")
+          BRANCH=$(release-utility get backport-branch "${{ inputs.expected-release }}")
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
       - name: Check out backport branch
-        run: |
-          git checkout "${{ steps.branch.outputs.name }}"
+        run: git checkout "${{ steps.branch.outputs.name }}"
+
       - name: Set up git identity
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+
       - name: Validate release
-        run: |
-          uv run release-utility validate "${{ inputs.expected-release }}" --backport
+        run: release-utility validate "${{ inputs.expected-release }}" --backport
+
       - name: Create backport release commits
-        run: |
-          uv run release-utility backport-release -y
+        run: release-utility backport-release -y
+
       - name: Push backport release
         run: |
           # --atomic ensures both refs land together or none do.

--- a/.github/workflows/release-rolling.yml
+++ b/.github/workflows/release-rolling.yml
@@ -19,35 +19,37 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
           ref: master
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.10"
       - name: Install release tools
-        run: |
-          # Install the release utility as a package from master so the command
-          # is always the canonical version regardless of how the workflow was triggered.
-          uv sync --only-group release
-          uv pip install .github/scripts/
+        run: make install GROUP=release
+
       - name: Set up git identity
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+
       - name: Validate release
         run: |
-          uv run release-utility validate "${{ inputs.expected-release }}"
+          release-utility validate "${{ inputs.expected-release }}"
+
       - name: Create release commits
         id: release
         run: |
           # For new minor releases (X.Y.0), sets the 'backport-branch' output with the
           # name of the X.(Y-1) maintenance branch created locally (e.g. '3.5' after 3.6.0).
           # Not set for patch releases.
-          uv run release-utility rolling-release -y
+          release-utility rolling-release -y
+
       - name: Push release
         run: |
           # --atomic ensures all refs land together or none do.
@@ -58,4 +60,5 @@ jobs:
           if [[ -n "${{ steps.release.outputs.backport-branch }}" ]]; then
             REFS="$REFS ${{ steps.release.outputs.backport-branch }}"
           fi
-          git push --atomic origin $REFS  # intentional word-splitting on space-separated refs
+          # shellcheck disable=SC2086  # intentional word-splitting on space-separated refs
+          git push --atomic origin $REFS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           artifact_in: ${{ inputs.dist-artifact }}
           python-version: ${{ matrix.python-version }}
-          os: ${{ runner.os }}
       - name: Install project and test cli
         run: |
           dynaconf init -v FOO=running_on_ci -y
@@ -47,13 +46,12 @@ jobs:
           dynaconf -i config.settings list | grep -c Hello_CI
           dynaconf --version
 
-  unit_tests_linux:
-    needs: install_test
+  unit_tests:
     strategy:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -63,19 +61,28 @@ jobs:
           artifact_in: ${{ inputs.dist-artifact }}
           python-version: ${{ matrix.python-version }}
           dependencies: test
-          os: ${{ runner.os }}
-      - name: Run tests
-        run: make citest
+
+      - name: Run unit tests
+        shell: bash
+        run: make test
+
+      # Linux only: Windows and macOS runners don't have Docker available
+      # for the redis/vault fixtures these tests depend on.
+      - name: Run integration tests
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: make test-integration
+
       - name: Publish Junit Test Results
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: EnricoMi/publish-unit-test-result-action@v2
         continue-on-error: true
-        if: always()
         with:
           files: junit/**/*.xml
           check_name: Test Results (Python ${{ matrix.python-version }})
 
       - name: "Upload coverage to Codecov"
-        if: ${{ matrix.python-version == inputs.python_latest }}
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.python_latest
         uses: codecov/codecov-action@v7
         continue-on-error: true
         env:
@@ -84,13 +91,13 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: true
 
-  unit_tests_mac:
-    needs: install_test
+  functional_tests:
+    needs: [install_test, unit_tests]
     strategy:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -100,85 +107,18 @@ jobs:
           artifact_in: ${{ inputs.dist-artifact }}
           python-version: ${{ matrix.python-version }}
           dependencies: test
-          os: ${{ runner.os }}
-      - name: Run tests
-        run: py.test -v --cov-config .coveragerc --cov=dynaconf -l tests/ --junitxml=junit/test-results.xml -m "not integration"
-
-  functional_tests_linux_mac:
-    needs:
-      - unit_tests_linux
-      - unit_tests_mac
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install from wheel
-        uses: ./.github/actions/install-from-artifact
-        with:
-          artifact_in: ${{ inputs.dist-artifact }}
-          python-version: ${{ matrix.python-version }}
-          dependencies: test
-          os: ${{ runner.os }}
       - name: Run functional tests
-        run: make test_functional
+        shell: bash
+        run: make test-functional
 
-  unit_tests_windows:
-    needs: install_test
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install from wheel
-        uses: ./.github/actions/install-from-artifact
-        with:
-          artifact_in: ${{ inputs.dist-artifact }}
-          python-version: ${{ matrix.python-version }}
-          dependencies: test
-          os: ${{ runner.os }}
-      - name: run tests
-        run: py.test -v -l tests --junitxml=junit/test-results.xml -m "not integration"
-
-  functional_tests_windows:
-    needs: unit_tests_windows
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install from wheel
-        uses: ./.github/actions/install-from-artifact
-        with:
-          artifact_in: ${{ inputs.dist-artifact }}
-          python-version: ${{ matrix.python-version }}
-          dependencies: test
-          os: ${{ runner.os }}
-      - name: run tests
-        run: python tests_functional/runtests.py
-
-  redis:
-    needs: functional_tests_linux_mac
+  integration_test:
+    needs: [install_test, unit_tests]
     strategy:
       fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python_minimal) }}
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    services:
-      redis:
-        image: redis:8.6-alpine
-        ports:
-          - 6379:6379
     steps:
       - uses: actions/checkout@v7
       - name: Install from wheel
@@ -187,37 +127,7 @@ jobs:
           artifact_in: ${{ inputs.dist-artifact }}
           python-version: ${{ matrix.python-version }}
           dependencies: test
-          os: ${{ runner.os }}
-      - name: Run functional tests
-        run: make test_redis
-
-  vault:
-    needs: functional_tests_linux_mac
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.python_minimal) }}
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    services:
-      vault:
-        image: hashicorp/vault:1.21
-        ports:
-          - 8200:8200
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: myroot
-
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install from wheel
-        uses: ./.github/actions/install-from-artifact
-        with:
-          artifact_in: ${{ inputs.dist-artifact }}
-          python-version: ${{ matrix.python-version }}
-          dependencies: test
-          os: ${{ runner.os }}
-      - name: Run functional tests
-        run: make test_vault
+      - name: Run Redis functional tests
+        run: make test-redis
+      - name: Run Vault functional tests
+        run: make test-vault

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,7 @@ repos:
     hooks:
       - id: typos
         args: []  # Overrides default to write changes.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/Makefile
+++ b/Makefile
@@ -1,90 +1,69 @@
 SHELL := /bin/bash
-.PHONY: all check-releases citest clean mypy dist docs install publish run-pre-commit run-tox setup-pre-commit test test_functional test_only test_redis test_vault help coverage-report watch_test bench
+
+# Override with e.g. `make install PYTHON=3.11` to pick the interpreter version.
+PYTHON_FLAG := $(if $(PYTHON),--python $(PYTHON))
+
+# Use for running things that requires the project installed
+#
+# Note: in CI, the install target exports the venv as the default venv, so the
+# the workflow can use it without calling uv.
+RUN := $(if $(CI),,uv run --no-sync $(PYTHON_FLAG))
+
+# Use for running things independent of project state. Usage: $(call RUN_TOOL,<group>)
+RUN_TOOL = uv run --isolated $(PYTHON_FLAG) $(if $(1),--only-group $(1))
+
+# Lowest Python version we support (pyproject.toml's requires-python) - minification
+# must run on it for the resulting bytecode to stay compatible with all supported versions.
+PYTHON_LOWERBOUND := 3.10
+
+# Windows and macOS are excluded: their integration tests' docker fixtures
+# aren't reliable there (macOS GitHub-hosted runners have no Docker at all).
+CITEST_FULL := $(if $(CI),$(if $(filter Windows macOS,$(RUNNER_OS)),,1))
+
+# Pytest flags
+PYTEST_COV := --cov-config pyproject.toml --cov=dynaconf
+SHORT_TB := --tb=short
+
+# Override with e.g. `make test k=test_something` to run a single test by name/expression.
+K_FILTER = $(if $(k),-k "$(k)")
+# This outcome is a report on what test failed, succeeded, etc
+OUTCOME_REPORT = --junitxml=junit/$(1)-results.xml
+
+ifeq ($(RUNNER_OS),Windows)
+VENV_BIN := .venv/Scripts
+else
+VENV_BIN := .venv/bin
+endif
+
+.PHONY: help
 help:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+	@python scripts/makefile_doc.py < $(MAKEFILE_LIST)
 
-all: clean install run-pre-commit test test_functional coverage-report
 
-test_functional:
-	./tests_functional/runtests.py
+# ---------------------------------------------------------------------------
+# General
+# ---------------------------------------------------------------------------
 
-test_vault:
-	./tests_functional/test_vault.sh
-	./tests_functional/test_vault_userpass.sh
+.PHONY: all tips lint docs docs-build
 
-test_redis:
-	./tests_functional/test_redis.sh
+#: Clean, install dev deps, lint, and run the full test suite
+all: clean install lint test test-functional
+	$(RUN) coverage report
 
-bench:
-	rm -rf tmp-bench
-	@scripts/bench.sh depth2_getitem
-	@scripts/bench.sh depth2_getattr
-	@scripts/bench.sh depth1_getattr
-	@scripts/bench.sh depth1_setattr
+#: Lint and format the code
+lint:
+	$(call RUN_TOOL,lint) pre-commit run --all-files
 
-watch:
-	ls **/**.py | entr py.test -m "not integration" -s -vvv -l --tb=long --maxfail=1 tests/
+#: Serve the documentation site locally with live-reload
+docs: _check-venv
+	$(RUN) mkdocs serve
 
-watch_test:
-	# make watch_test ARGS="tests/test_typed.py -k union"
-	ls **/**.py | entr py.test --showlocals -sx -vv --disable-warnings --tb=short $(ARGS)
+#: Build the documentation site
+docs-build: _check-venv
+	rm -rf site
+	$(RUN) mkdocs build --clean
 
-watch_django:
-	ls {**/**.py,~/.virtualenvs/dynaconf/**/**.py,.venv/**/**.py} | PYTHON_PATH=. DJANGO_SETTINGS_MODULE=foo.settings entr tests_functional/django_example/manage.py test polls -v 2
-
-watch_coverage:
-	ls {**/**.py,~/.virtualenvs/dynaconf/**/**.py} | entr -s "make test;coverage html"
-
-test_only:
-	py.test -m "not integration" -v --cov-config pyproject.toml --cov=dynaconf -l --tb=short --maxfail=1 tests/
-	coverage xml
-
-test_integration:
-	py.test -m integration -v --cov-config pyproject.toml --cov=dynaconf --cov-append -l --tb=short --maxfail=1 tests/
-	coverage xml
-
-coverage-report:
-	coverage report
-
-mypy:
-	mypy dynaconf/ --exclude '^dynaconf/vendor*'
-
-test: mypy test_only
-
-citest:
-	py.test -v --cov-config pyproject.toml --cov=dynaconf -l tests/ --junitxml=junit/test-results.xml
-	coverage xml
-	make coverage-report
-
-ciinstall:
-	uv export --no-hashes --group ci > /tmp/requirements-ci.txt  # lets move all uv soon
-	python -m pip install --upgrade pip
-	python -m pip install -r /tmp/requirements-ci.txt
-
-test_all: test_functional test_integration test_redis test_vault test
-	@coverage html
-
-install:
-	uv export --no-hashes --group dev > /tmp/requirements-dev.txt  # lets move all uv soon
-	python -m pip install -r /tmp/requirements-dev.txt
-
-run-pre-commit:
-	rm -rf .tox/
-	rm -rf build/
-	pre-commit run --all-files
-
-dist: clean
-	@make minify_vendor
-	@python -m build
-	@make source_vendor
-
-check-releases:
-	uv run --isolated --with-editable .github/scripts/ release-utility check
-
-# Bump X.Y.Z.dev to X.Y+1.0.dev
-bump-minor:
-	uv run bump-my-version bump minor --commit
-
+#: Remove build artifacts, caches, and generated files
 clean:
 	@find ./ -name '*.pyc' -exec rm -f {} \;
 	@find ./ -name '__pycache__' -prune -exec rm -rf {} \;
@@ -98,23 +77,131 @@ clean:
 	rm -rf .tox/
 	rm -rf site
 	rm -rf tmp-bench
+	rm -rf .venv
 
-docs:
-	rm -rf site
-	uv run --group docs mkdocs build --clean
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
 
-run-tox:
-	tox --recreate
-	rm -rf .tox
+.PHONY: install clean info _check-venv
 
-minify_vendor:
+_check-venv:
+	@if [ ! -d .venv ]; then \
+		echo "ERROR: No .venv found. Run 'make install' first."; \
+		exit 1; \
+	fi
+
+#: Create .venv and install project | [WHEEL=<path>] [GROUP=<group>] [PYTHON=<version>] [ARGS=<uv-args>]
+install:
+	uv venv --clear $(PYTHON_FLAG)
+	uv pip install \
+		$(if $(WHEEL),$(WHEEL),--editable .) \
+		--group $(if $(GROUP),$(GROUP),dev) \
+		$(ARGS)
+	@[ -n "$$GITHUB_PATH" ] && echo "$(CURDIR)/$(VENV_BIN)" >> "$$GITHUB_PATH" || true
+	@[ -n "$$GITHUB_ENV" ] && echo "VIRTUAL_ENV=$(CURDIR)/$(VENV_DIR)" >> $$GITHUB_ENV || true
+
+#: Show info of local venv (.venv) | [VERBOSE=1] full pip list
+info:
+	@if [ ! -d .venv ]; then \
+		echo "No .venv found. Run 'make install' first."; \
+	else \
+		echo "Path:   $(CURDIR)/.venv"; \
+		echo "Python: $$($(VENV_BIN)/python --version 2>&1)"; \
+		echo; \
+		$(if $(VERBOSE), \
+			uv pip list, \
+			uv pip show dynaconf dynaconf-release-utility; \
+			echo -e "\n---\nFor full package list:\nmake info VERBOSE=1" \
+		); \
+	fi
+
+#: Show quick usage tips
+tips:
+	@echo "- Behavior can differ when the CI env var is set: some targets (test, install, lint) adapt automatically."
+	@echo "- Auto re-run tests on change: find . -name '*.py' | entr make test"
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+.PHONY: test test-integration test-functional test-redis test-vault test-all bench
+
+#: Run the unit test suite with coverage | [k=<expr>] run tests matching <expr>
+test: _check-venv
+	$(RUN) pytest tests/ \
+		-m "not integration" \
+		-v -l --color=yes $(SHORT_TB) $(K_FILTER) \
+		$(if $(k),--disable-warnings,$(PYTEST_COV)) \
+		$(if $(CITEST_FULL),$(call OUTCOME_REPORT,test))
+	$(if $(k),,$(if $(CITEST_FULL),$(RUN) coverage xml))
+
+#: Run integration-marked tests only | [k=<expr>] run tests matching <expr>
+test-integration: _check-venv
+	$(RUN) pytest tests/ \
+		-m "integration" \
+		-v -l --color=yes $(SHORT_TB) $(K_FILTER) \
+		$(if $(k),--disable-warnings,$(PYTEST_COV) --cov-append) \
+		$(if $(CITEST_FULL),$(call OUTCOME_REPORT,integration))
+	$(if $(k),,$(if $(CITEST_FULL),$(RUN) coverage xml))
+
+#: Run the functional test suite | [k=<expr>] run tests matching <expr>
+test-functional: _check-venv
+	$(RUN) python tests_functional/runtests.py $(if $(k),--filter "$(k)")
+
+#: Run functional tests against a local Redis
+test-redis: _check-venv
+	$(RUN) ./tests_functional/test_redis.sh
+
+#: Run functional tests against a local Vault
+test-vault: _check-venv
+	$(RUN) ./tests_functional/test_vault.sh
+	$(RUN) ./tests_functional/test_vault_userpass.sh
+
+#: Run every test suite and generate an HTML coverage report
+test-all: test-functional test-integration test-redis test-vault test
+	$(RUN) coverage html
+
+#: Run performance benchmarks
+bench:
+	rm -rf tmp-bench
+	@scripts/bench.sh depth2_getitem
+	@scripts/bench.sh depth2_getattr
+	@scripts/bench.sh depth1_getattr
+	@scripts/bench.sh depth1_setattr
+
+# ---------------------------------------------------------------------------
+# Build & Release
+# ---------------------------------------------------------------------------
+
+.PHONY: build check-releases release-notes bump-minor
+
+#: Build the sdist and wheel
+build: clean
 	# create a new dynaconf/vendor folder with minified files
-	./minify.sh
+	$(call RUN_TOOL,release) --python $(PYTHON_LOWERBOUND) ./scripts/minify.sh
+	@uv build
+	# restore dynaconf/vendor_src folder as dynaconf/vendor
+	@./scripts/source_vendor.sh
+	.github/scripts/dist-health-check.sh
+	ls -la dist
 
+#: Check for pending releases | Release via https://github.com/dynaconf/dynaconf/actions)
+check-releases:
+	$(call RUN_TOOL,release) release-utility check
 
-source_vendor:
-	# Ensure dynaconf/vendor_src is source and cleanup vendor folder
-	ls dynaconf/vendor_src/source && rm -rf dynaconf/vendor
+#: Preview release notes
+release-notes:
+	$(call RUN_TOOL,release) git-changelog --release-notes
 
-	# Restore dynaconf/vendor_src folder as dynaconf/vendor
-	mv dynaconf/vendor_src dynaconf/vendor
+#: Bump X.Y.Z.dev to X.(Y+1).0.dev | [YES=1] create the bump commit (DEFAULT=dry-run)
+bump-minor:
+	$(if $(YES), \
+		@$(call RUN_TOOL,release) bump-my-version bump minor --commit && \
+		echo -e "Bump commit created!\n" && \
+		git log -1 --stat, \
+		@NEXT=$$($(call RUN_TOOL,release) bump-my-version show --increment minor new_version); \
+		echo "Next version would be: $$NEXT"; \
+		echo -e "To create the bump commit, run:\n"; \
+		echo "make bump-minor YES=1" \
+	)

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -4,6 +4,7 @@ Dynaconf provides a drop in replacement for `app.config`.
 
 As Flask encourages the composition by overriding the `config_class` attribute this extension follows the [patterns of Flask](https://flask.palletsprojects.com/en/2.3.x/patterns/subclassing/) and turns your Flask's `app.config` in to a `dynaconf` instance.
 
+
 ## Initialize the extension
 
 Initialize the **FlaskDynaconf** extension in your `app`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,11 +303,7 @@ docs = [
     "pymdown-extensions>=10.16.1",
 ]
 lint = [
-    "mypy>=1.19.1",
     "pre-commit>=4.3.0",
-    "radon>=6.0.1",
-    "ruff>=0.14.14",
-    "typos>=1.42.3",
 ]
 test = [
     "dynaconf-release-utility",
@@ -335,7 +331,7 @@ test = [
     "pdbr[ipython]>=0.9.2",
 ]
 release = [
-    "build>=1.3.0",
+    "dynaconf-release-utility",
     "bump-my-version>=1.2.4",
     "git-changelog>=2.6.3",
     "python-minifier>=3.1.0",
@@ -344,4 +340,4 @@ release = [
 ]
 
 [tool.uv.sources]
-dynaconf-release-utility = { path = ".github/scripts/", editable = true }
+dynaconf-release-utility = { path = ".github/scripts/" }

--- a/scripts/makefile_doc.py
+++ b/scripts/makefile_doc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Print `target  description` help lines from a Makefile, grouped by section header.
+
+A target is documented by a `#:` comment line immediately above it, e.g.:
+
+    #: Install WHEEL and/or GROUP (uv dependency group) into ./.venv
+    install:
+        ...
+
+A `|` in the docstring separates the description (left) from a note about
+optional args (right), which is printed dimmed, e.g.:
+
+    #: Install into ./.venv | WHEEL=dist/*.whl GROUP=test PYTHON=3.11
+    install:
+        ...
+
+Set NO_COLOR (https://no-color.org/) to any non-empty value to disable colors.
+"""
+# ruff: noqa: T201  # this CLI script's whole purpose is printing to stdout
+
+import os
+import re
+import sys
+
+RULE_RE = re.compile(r"^#\s*-{10,}\s*$")
+SECTION_RE = re.compile(r"^#\s*(.+?)\s*$")
+DOC_RE = re.compile(r"^#:\s*(.*)$")
+TARGET_RE = re.compile(r"^([a-zA-Z_-]+):")
+
+NO_COLOR = bool(os.environ.get("NO_COLOR"))
+CYAN = "" if NO_COLOR else "\033[36m"
+BOLD = "" if NO_COLOR else "\033[1m"
+DIM = "" if NO_COLOR else "\033[2;90m"
+RESET = "" if NO_COLOR else "\033[0m"
+
+
+def parse(lines):
+    sections = {}
+    section = "Other"
+    prev_was_rule = False
+    pending_doc = None
+    for line in lines:
+        if RULE_RE.match(line):
+            prev_was_rule = True
+            continue
+        if prev_was_rule:
+            match = SECTION_RE.match(line)
+            if match:
+                section = match.group(1)
+            prev_was_rule = False
+            continue
+
+        doc_match = DOC_RE.match(line)
+        if doc_match:
+            pending_doc = doc_match.group(1)
+            continue
+
+        target_match = TARGET_RE.match(line)
+        if target_match and pending_doc is not None:
+            sections.setdefault(section, {})[target_match.group(1)] = (
+                pending_doc
+            )
+
+        pending_doc = None
+    return sections
+
+
+def main():
+    sections = parse(sys.stdin)
+    width = (
+        max(len(name) for targets in sections.values() for name in targets) + 2
+    )
+    for section, targets in sections.items():
+        if not targets:
+            continue
+        print(f"{BOLD}{section}{RESET}")
+        for name in sorted(targets):
+            padded_name = f"{name:<{width}}"
+            desc, sep, note = targets[name].partition("|")
+            desc = desc.strip()
+            note = f" {DIM}{sep} {note.strip()}{RESET}" if note else ""
+            print(f"    {CYAN}{padded_name}{RESET}{desc}{note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/minify.sh
+++ b/scripts/minify.sh
@@ -2,26 +2,6 @@
 
 set -euo pipefail
 
-# Ensure we are using a python lowerbound version
-PYTHON_LOWERBOUND=$(python -c \
-   'import toml; \
-   data=toml.load("pyproject.toml"); \
-   version=data["project"]["requires-python"].split(",")[0].split("=")[-1]; \
-   print(version)' \
-)
-
-PYTHON_ERR_MSG="$(cat <<EOF
-ERROR: Must use python ${PYTHON_LOWERBOUND}
-Minification creates code compatible with the current python version in use.
-For greater compatibility, the build should be done with the lower python we support.\n
-EOF
-)"
-
-if ! python --version | grep $PYTHON_LOWERBOUND; then
-   printf "$PYTHON_ERR_MSG"
-   exit 1
-fi
-
 # Ensure vendor is source and cleanup vendor_src backup folder
 ls dynaconf/vendor/source && rm -rf dynaconf/vendor_src
 
@@ -47,7 +27,7 @@ do
    touch dynaconf/vendor/$direc/__init__.py
 
    # for each .py file in the vendor_srx directory
-   # NOTE: vendor_src is created when make minify_vendor is run
+   # NOTE: vendor_src is created when make build runs ./scripts/minify.sh
    for eachfile in `ls dynaconf/vendor_src/$direc/*.py`
    do
       # minify each file pasting resilts to the dynaconf/vendor directory

--- a/scripts/source_vendor.sh
+++ b/scripts/source_vendor.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Ensure dynaconf/vendor_src is source and cleanup vendor folder
+ls dynaconf/vendor_src/source && rm -rf dynaconf/vendor
+
+# Restore dynaconf/vendor_src folder as dynaconf/vendor
+mv dynaconf/vendor_src dynaconf/vendor

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -5,6 +5,8 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import pytest
+import redis
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from dynaconf import LazySettings
 from dynaconf.loaders.redis_loader import delete
@@ -16,11 +18,13 @@ if TYPE_CHECKING:
     from pytest_docker.plugin import Service
 
 
-def is_responsive(url):
-    # This function should be check if the redis server is online and ready
-    # write(settings, {"SECRET": "redis_works"})
-    # return load(settings, key="SECRET")
-    return True
+def is_responsive(host, port):
+    try:
+        return redis.Redis(
+            host=host, port=port, socket_connect_timeout=2
+        ).ping()
+    except RedisConnectionError:
+        return False
 
 
 DYNACONF_TEST_REDIS_URL = os.environ.get("DYNACONF_TEST_REDIS_URL", None)
@@ -37,7 +41,9 @@ else:
         port = docker_services.port_for("redis", 6379)
         url = f"http://{docker_ip}:{port}"
         docker_services.wait_until_responsive(
-            timeout=15.0, pause=0.1, check=lambda: is_responsive(url)
+            timeout=15.0,
+            pause=0.1,
+            check=lambda: is_responsive(docker_ip, port),
         )
         return url
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import pytest
+import requests
 
 from dynaconf import LazySettings
 from dynaconf.loaders.vault_loader import list_envs
@@ -17,10 +18,11 @@ if TYPE_CHECKING:
 
 
 def is_responsive(url):
-    # This function should be check if the redis server is online and ready
-    # write(settings, {"SECRET": "redis_works"})
-    # return load(settings, key="SECRET")
-    return True
+    try:
+        response = requests.get(f"{url}/v1/sys/health", timeout=2)
+    except requests.exceptions.ConnectionError:
+        return False
+    return response.status_code == 200
 
 
 @pytest.fixture(scope="module")

--- a/tests_functional/legacy/django_pytest/Makefile
+++ b/tests_functional/legacy/django_pytest/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 
 test:
-	pip install pytest-django
+	uv pip install pytest-django
 	DJANGO_SETTINGS_MODULE=project.settings DJANGO_ENVIRONMENT=default pytest
-	pip uninstall -y pytest-django
+	uv pip uninstall pytest-django

--- a/tests_functional/legacy/django_pytest_pure/Makefile
+++ b/tests_functional/legacy/django_pytest_pure/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 
 test:
-	pip install pytest-django
+	uv pip install pytest-django
 	DJANGO_SETTINGS_MODULE=project.settings DJANGO_ENVIRONMENT=default pytest
-	pip uninstall -y pytest-django
+	uv pip uninstall pytest-django

--- a/tests_functional/test_redis.sh
+++ b/tests_functional/test_redis.sh
@@ -1,13 +1,50 @@
 #!/bin/bash
-docker run --rm --name dynaconf_with_redis -d -p 6379:6379 redis:alpine || true
-sleep 2
-cd tests_functional/legacy/redis_example
-pwd
-dynaconf -i dynaconf.settings write redis -s FOO=foo_is_default
-dynaconf -i dynaconf.settings write redis -s SECRET=redis_works_in_default
-dynaconf -i dynaconf.settings write redis -e development -s SECRET=redis_works_in_development
-dynaconf -i dynaconf.settings write redis -e production -s SECRET=redis_works_in_production
-sleep 2
-python redis_example.py
-docker stop dynaconf_with_redis || true
-cd ../../../
+set -euo pipefail
+
+CONTAINER_NAME="dynaconf_with_redis"
+
+cleanup() {
+    docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+start_redis() {
+    docker run --rm \
+        --name "$CONTAINER_NAME" -d \
+        -p 6379:6379 \
+        redis:alpine
+}
+
+wait_for_redis() {
+    echo "Waiting for redis to be ready..."
+    for _ in $(seq 1 15); do
+        if docker exec "$CONTAINER_NAME" redis-cli ping 2>/dev/null | grep -q PONG; then
+            echo
+            echo "Redis is ready"
+            return 0
+        fi
+        printf "."
+        sleep 1
+    done
+    echo
+    echo "Timed out waiting for redis" >&2
+    exit 1
+}
+
+run_test() (
+    cd tests_functional/legacy/redis_example
+    pwd
+    dynaconf -i dynaconf.settings write redis -s FOO=foo_is_default
+    dynaconf -i dynaconf.settings write redis -s SECRET=redis_works_in_default
+    dynaconf -i dynaconf.settings write redis -e development -s SECRET=redis_works_in_development
+    dynaconf -i dynaconf.settings write redis -e production -s SECRET=redis_works_in_production
+    python redis_example.py
+)
+
+main() {
+    start_redis
+    wait_for_redis
+    run_test
+}
+
+main

--- a/tests_functional/test_vault.sh
+++ b/tests_functional/test_vault.sh
@@ -1,17 +1,50 @@
 #!/bin/bash
-docker run --rm \
-    --name dynaconf_with_vault -d \
-    -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
-    -p 8200:8200 \
-    hashicorp/vault:1.21 \
-    || true
-sleep 5
-cd tests_functional/legacy/vault
-pwd
-dynaconf -i dynaconf.settings write vault -s SECRET=vault_works_in_default -s FOO=foo_is_default
-dynaconf -i dynaconf.settings write vault -e dev -s SECRET=vault_works_in_dev
-dynaconf -i dynaconf.settings write vault -e prod -s SECRET=vault_works_in_prod
-sleep 2
-python vault_example.py
-docker stop dynaconf_with_vault  || true
-cd ../../../
+set -euo pipefail
+
+CONTAINER_NAME="dynaconf_with_vault"
+
+cleanup() {
+    docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+start_vault() {
+    docker run --rm \
+        --name "$CONTAINER_NAME" -d \
+        -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
+        -p 8200:8200 \
+        hashicorp/vault:1.21
+}
+
+wait_for_vault() {
+    echo "Waiting for vault to be ready..."
+    for _ in $(seq 1 15); do
+        if curl -sf -o /dev/null http://127.0.0.1:8200/v1/sys/health; then
+            echo
+            echo "Vault is ready"
+            return 0
+        fi
+        printf "."
+        sleep 1
+    done
+    echo
+    echo "Timed out waiting for vault" >&2
+    exit 1
+}
+
+run_test() (
+    cd tests_functional/legacy/vault
+    pwd
+    dynaconf -i dynaconf.settings write vault -s SECRET=vault_works_in_default -s FOO=foo_is_default
+    dynaconf -i dynaconf.settings write vault -e dev -s SECRET=vault_works_in_dev
+    dynaconf -i dynaconf.settings write vault -e prod -s SECRET=vault_works_in_prod
+    python vault_example.py
+)
+
+main() {
+    start_vault
+    wait_for_vault
+    run_test
+}
+
+main

--- a/tests_functional/test_vault_userpass.sh
+++ b/tests_functional/test_vault_userpass.sh
@@ -1,28 +1,66 @@
 #!/bin/bash
-docker run --rm \
-    --name dynaconf_with_vault -d \
-    -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
-    -p 8200:8200 \
-    hashicorp/vault:1.21 \
-    || true
-sleep 5
-cd tests_functional/vault_userpass
-pwd
-curl --header "X-Vault-Token: myroot" --request PUT --data '{"type": "userpass"}' http://127.0.0.1:8200/v1/sys/auth/userpass
-curl \
-    --header "X-Vault-Token: myroot" \
-    --request POST \
-    --data @admin.hcl \
-    http://localhost:8200/v1/sys/policy/admin
-curl \
-    --header "X-Vault-Token: myroot" \
-    --request POST \
-    --data @payload.json \
-    http://127.0.0.1:8200/v1/auth/userpass/users/user
-dynaconf -i dynaconf.settings write vault -s SECRET=vault_works_in_default -s FOO=foo_is_default
-dynaconf -i dynaconf.settings write vault -e dev -s SECRET=vault_works_in_dev
-dynaconf -i dynaconf.settings write vault -e prod -s SECRET=vault_works_in_prod
-sleep 2
-python vault_userpass_example.py
-docker stop dynaconf_with_vault  || true
-cd ../../
+set -euo pipefail
+
+CONTAINER_NAME="dynaconf_with_vault_userpass"
+
+cleanup() {
+    docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+start_vault() {
+    docker run --rm \
+        --name "$CONTAINER_NAME" -d \
+        -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
+        -p 8200:8200 \
+        hashicorp/vault:1.21
+}
+
+wait_for_vault() {
+    echo "Waiting for vault to be ready..."
+    for _ in $(seq 1 15); do
+        if curl -sf -o /dev/null http://127.0.0.1:8200/v1/sys/health; then
+            echo
+            echo "Vault is ready"
+            return 0
+        fi
+        printf "."
+        sleep 1
+    done
+    echo
+    echo "Timed out waiting for vault" >&2
+    exit 1
+}
+
+setup_userpass_auth() (
+    cd tests_functional/legacy/vault_userpass
+    curl --header "X-Vault-Token: myroot" --request PUT --data '{"type": "userpass"}' http://127.0.0.1:8200/v1/sys/auth/userpass
+    curl \
+        --header "X-Vault-Token: myroot" \
+        --request POST \
+        --data @admin.hcl \
+        http://localhost:8200/v1/sys/policy/admin
+    curl \
+        --header "X-Vault-Token: myroot" \
+        --request POST \
+        --data @payload.json \
+        http://127.0.0.1:8200/v1/auth/userpass/users/user
+)
+
+run_test() (
+    cd tests_functional/legacy/vault_userpass
+    pwd
+    dynaconf -i dynaconf.settings write vault -s SECRET=vault_works_in_default -s FOO=foo_is_default
+    dynaconf -i dynaconf.settings write vault -e dev -s SECRET=vault_works_in_dev
+    dynaconf -i dynaconf.settings write vault -e prod -s SECRET=vault_works_in_prod
+    python vault_userpass_example.py
+)
+
+main() {
+    start_vault
+    wait_for_vault
+    setup_userpass_auth
+    run_test
+}
+
+main


### PR DESCRIPTION
This changes the makefile in significant ways, dropping some commands and merging others.
Here is how different the help looks.

The main motivation was to standardize CI with local development when using UV.
Besides that, I've added some conveniences for the development workflow and changed some some names with my optionated opinions hehe

Some highlights:

* In the dev machine, `make install` manages a `.venv`, which can be easily destroyed, replaced and configured with different python and extra options. E.g, we can very easily do `make build && make install WHELL=dist/*.whl` to install from the built wheel, as CI does,
* Commands such as `test` will use that, so it's easy to test different envs manually
* Added [actionlint](https://github.com/rhysd/actionlint) pre-commit hook, just because
* Fxed functional tests that used ephemeral `pip install/uninstall` (TODO: rethink venv isolation in the functional tests)
* Fixed integrations tests (redis and vault). They where silently failing because of some some conflict between the script `docker run` and the worklfow `services:` section.
* Re-structure test jobs grouping into test types (unit, functional, integration, and paralellize.
    * Each job/test-type has a matrix of python versions and OS (os-specific tasks are skipped/selected explicitly)
    * parallelize jobs:
        * test-install + test-unit
        * test-functional + test-integration

It also fixed a bug in CI where we were not really running against different python versions.

See the changes in the Make help:


```
=== make help: BEFORE (commit 85e501a) ===
all
bench
bump-minor
check-releases
ciinstall
citest
clean
coverage-report
dist
docs
install
minify_vendor
mypy
publish
run-pre-commit
run-tox
setup-pre-commit
source_vendor
test
test_all
test_functional
test_integration
test_only
test_redis
test_vault
watch
watch_coverage
watch_django
watch_test

=== make help: AFTER (current working tree) ===
General
    all               Clean, install dev deps, lint, and run the full test suite
    clean             Remove build artifacts, caches, and generated files
    docs              Serve the documentation site locally with live-reload
    docs-build        Build the documentation site
    lint              Lint and format the code
Setup
    info              Show info of local venv (.venv) | [VERBOSE=1] full pip list
    install           Create .venv and install project | [WHEEL=<path>] [GROUP=<group>] [PYTHON=<version>] [ARGS=<uv-args>]
    tips              Show quick usage tips
Tests
    bench             Run performance benchmarks
    test              Run the unit test suite with coverage | [k=<expr>] run tests matching <expr>
    test-all          Run every test suite and generate an HTML coverage report
    test-functional   Run the functional test suite | [k=<expr>] run tests matching <expr>
    test-integration  Run integration-marked tests only | [k=<expr>] run tests matching <expr>
    test-redis        Run functional tests against a local Redis
    test-vault        Run functional tests against a local Vault
Build & Release
    build             Build the sdist and wheel
    bump-minor        Bump X.Y.Z.dev to X.(Y+1).0.dev | [YES=1] create the bump commit (DEFAULT=dry-run)
    check-releases    Check for pending releases | Release via https://github.com/dynaconf/dynaconf/actions)
    release-notes     Preview release notes
```

Closes #1401 
Closes #1276 