### PR TITLE
fix(utils): handle escaped quotes and backslashes in _parse_quoted_string

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -75,12 +75,31 @@ def _parse_quoted_string(value: str) -> tuple[str, str]:
     # Check for quotes at start
     if value[0] in ('"', "'"):
         quote = value[0]
-        try:
-            end_idx = value.index(quote, 1)
-            return value[1:end_idx], value[end_idx + 1 :].strip()
-        except ValueError:
-            # Unclosed quote - treat as error
-            raise DynaconfFormatError(f"Unclosed quote in: {value}")
+        idx = 1
+        length = len(value)
+        chars = []
+        while idx < length:
+            char = value[idx]
+            if char == "\\":
+                if idx + 1 < length:
+                    next_char = value[idx + 1]
+                    if next_char in (quote, "\\"):
+                        chars.append(next_char)
+                        idx += 2
+                        continue
+                    chars.append("\\")
+                    chars.append(next_char)
+                    idx += 2
+                    continue
+                chars.append("\\")
+                idx += 1
+                continue
+            if char == quote:
+                return "".join(chars), value[idx + 1 :].strip()
+            chars.append(char)
+            idx += 1
+
+        raise DynaconfFormatError(f"Unclosed quote in: {value}")
     else:
         # Not quoted - split on whitespace
         parts = value.split(maxsplit=1)
@@ -326,19 +345,23 @@ def _get_formatter(value, **context):
     cast group will match anything provided after @
     the default group will match single-word or quoted multi-word values
     """
-    tokens = value.strip().split()
-    if not tokens:
+    parts = value.strip().split(maxsplit=1)
+    if not parts:
         raise DynaconfFormatError(f"Error parsing {value}: no key specified")
 
-    key = tokens[0]
+    key = parts[0]
     cast = None
     default = None
-    remainder = " ".join(tokens[1:])
+    remainder = parts[1] if len(parts) > 1 else ""
 
     while remainder:
         remainder = remainder.strip()
         if not remainder:
             break
+
+        if remainder.startswith("default="):
+            remainder = remainder[8:].strip()
+            continue
 
         if remainder[0] in ('"', "'"):
             # Quoted value (default)
@@ -404,7 +427,13 @@ def _read_file_formatter(value, **context):
 
     # Parse path (may be quoted)
     path, remainder = _parse_quoted_string(value)
-    default = remainder.strip() if remainder else None
+    if remainder:
+        if remainder[0] in ('"', "'"):
+            default, _ = _parse_quoted_string(remainder)
+        else:
+            default = remainder.strip()
+    else:
+        default = None
 
     # Validate path is not empty after parsing
     if not path:
@@ -705,12 +734,14 @@ def add_converter(converter_key, func):
         converter_key = f"@{converter_key}"
 
     converters[converter_key] = wraps(func)(
-        lambda value: value.set_casting(func)
-        if isinstance(value, Lazy)
-        else Lazy(
-            value,
-            casting=func,
-            formatter=BaseFormatter(lambda x, **_: x, converter_key),
+        lambda value: (
+            value.set_casting(func)
+            if isinstance(value, Lazy)
+            else Lazy(
+                value,
+                casting=func,
+                formatter=BaseFormatter(lambda x, **_: x, converter_key),
+            )
         )
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1343,6 +1343,47 @@ def test_parse_quoted_string_empty(settings):
     assert remainder == ""
 
 
+def test_parse_quoted_string_escaped_quotes(settings):
+    """Test _parse_quoted_string with escaped quotes and backslashes"""
+    from dynaconf.utils.parse_conf import _parse_quoted_string
+
+    result, remainder = _parse_quoted_string(r'"with \"escaped\" quotes" rest')
+    assert result == 'with "escaped" quotes'
+    assert remainder == "rest"
+
+    result, remainder = _parse_quoted_string(r"'with \'escaped\' quotes' rest")
+    assert result == "with 'escaped' quotes"
+    assert remainder == "rest"
+
+    result, remainder = _parse_quoted_string(
+        r'"with \\ double backslash" rest'
+    )
+    assert result == "with \\ double backslash"
+    assert remainder == "rest"
+
+
+def test_get_formatter_with_escaped_quotes(settings):
+    """Test @get default value containing escaped quotes"""
+    settings.set("MSG", r'@get NONEXISTENT_XYZ default="fallback \"quoted\""')
+    assert settings.MSG == 'fallback "quoted"'
+
+
+def test_insert_with_escaped_quotes(settings):
+    """Test @insert value containing escaped quotes"""
+    settings.set("LIST_ITEMS", ["first", "third"])
+    settings.set("LIST_ITEMS", r'@insert 1 "second with \"quoted\""')
+    assert settings.LIST_ITEMS == ["first", 'second with "quoted"', "third"]
+
+
+def test_read_file_quoted_default(settings):
+    """Test @read_file with quoted default value when file does not exist"""
+    settings.set(
+        "NON_EXISTENT_FILE",
+        r'@read_file /path/does/not/exist.txt "my default value"',
+    )
+    assert settings.NON_EXISTENT_FILE == "my default value"
+
+
 def test_merge_kv_pattern_fallback(settings):
     """Test @merge using old KV_PATTERN (no quotes)"""
     # Pattern starting with '=' matches KV_PATTERN but not KV_PATTERN_QUOTED


### PR DESCRIPTION
### Summary

Fixes parsing of quoted strings containing escaped quotes (e.g. `\"` or `\'`) and backslashes in `_parse_quoted_string`, and ensures quoted default values in `@read_file` are properly unquoted.

### Problem

Previously, `_parse_quoted_string` used `value.index(quote, 1)` to locate the closing quote. When parsing values with escaped quotes (for instance `@insert 1 "item with \"quoted\" text"`, `@get KEY default="val with \"quotes\""`, or `@read_file "/path/with \"spaces\"/file.txt"`):
- The parser would split on the escaped quote (`\"`), cutting the string prematurely.
- The remainder of the string was incorrectly parsed as remaining arguments.
- In `_read_file_formatter`, a quoted fallback default value was returned with surrounding quotes intact instead of being unquoted.

### Solution

- Updated `_parse_quoted_string` to scan characters sequentially, respecting backslash escape sequences for quotes and backslashes (`\"`, `\'`, `\\`).
- Updated `_read_file_formatter` to parse and unquote default fallback strings if they are quoted.
- Maintained exact compatibility with existing unquoted tokens, whitespace splitting, and error handling for unclosed quotes.

### Tests

- Added `test_parse_quoted_string_escaped_quotes` in `tests/test_utils.py` covering escaped single quotes, double quotes, and backslashes.
- Added `test_get_formatter_with_escaped_quotes`.
- Added `test_insert_with_escaped_quotes`.
- Added `test_read_file_quoted_default`.
- Ran full test suite with `pytest` and verified with `ruff check` and `ruff format`.
