### PR TITLE
chore(python): add support for python 3.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     with:
       dist-artifact: ${{ needs.build.outputs.dist-artifact }}
       python_minimal: '["3.10", "3.14"]'
-      python_full: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]'
+      python_full: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       python_latest: '3.14'
     secrets: inherit
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     with:
       dist-artifact: ${{ needs.build.outputs.dist-artifact }}
       python_minimal: '["3.10", "3.14"]'
-      python_full: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python_full: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]'
       python_latest: '3.14'
     secrets: inherit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
         description: 'Full set of Python versions to test'
         required: false
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       python_latest:
         description: 'Latest Python version'
         required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Bruno Rocha", email = "rochacbruno@gmail.com"},
 ]
 license = {text = "MIT"}
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Utilities",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Python 3.15.0 candidate 1 is out. "candidate" means that there will be no more ABI changes, and the API over all is now stable. It is now pretty much safe to test against and to specify support for it.

This PR adds Python 3.15 support to Dynaconf:
- version and classifier in `pyproject.toml`
- `3.15-dev` (to be replaced with `3.15` in October) in GitHub Actions

I have ran the tests locally, and all of them pass.

This PR _keeps_ the upper bound on `requires-python`, but as stated in #1452, I highly recommend you remove it :)