### PR TITLE
Add a `dynaconf generate` command to scaffold sample settings from validators

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,6 +317,70 @@ When using `py` you may want a flat output (without being nested inside the env 
 dynaconf list -o path/to/file.py --output-flat
 ```
 
+### dynaconf generate
+
+Generate a sample settings file from the validators registered on the instance.
+
+Each registered `Validator` becomes an entry, using its `default` value, and its
+`description` (when set) is written as a leading comment. This is handy to
+bootstrap a documented `settings.toml` (or the equivalent for another format)
+that lists every configuration key the application expects.
+
+```
+Usage: dynaconf generate [OPTIONS]
+
+  Generate a sample settings file from the registered validators.
+
+  Each registered ``Validator`` becomes an entry using its default value, and
+  its ``description`` (when set) is written as a leading comment.
+
+Options:
+  -f, --format [toml|yaml|json|env]
+                                  Output format for the sample settings.
+  -o, --output FILE               Write the sample to this file instead of
+                                  stdout.
+  -e, --env TEXT                  Filters the env used to read the registered
+                                  validators.
+  --help                          Show this message and exit.
+```
+
+Given an instance registering the following validators:
+
+```python
+# config.py
+from dynaconf import Dynaconf, Validator
+
+settings = Dynaconf(
+    validators=[
+        Validator("PORT", default=8080, description="The port to bind to"),
+        Validator("HOST", default="localhost", description="Server host name"),
+    ]
+)
+```
+
+The command prints a documented sample to stdout, which you can redirect to a
+file:
+
+```console
+$ dynaconf -i config.settings generate -f yaml > settings.sample.yaml
+```
+
+```yaml
+# The port to bind to
+PORT: 8080
+
+# Server host name
+HOST: "localhost"
+```
+
+The default format is `toml`. The `json` format does not support comments, so
+the descriptions are omitted for that one. You can also write directly to a file
+with `-o`:
+
+```console
+$ dynaconf -i config.settings generate -f toml -o settings.sample.toml
+```
+
 ### dynaconf write
 
 ```

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -61,6 +61,7 @@ def set_settings(ctx, instance=None):
 
     _echo_enabled = ctx.invoked_subcommand not in [
         "get",
+        "generate",
         "inspect",
         "debug-info",
         None,
@@ -662,6 +663,140 @@ def _list(
             click.echo(
                 json.dumps(prepare_json({key: value}), default=repr), nl=True
             )
+
+    if env:
+        settings.setenv()
+
+
+GENERATE_FORMATS = ["toml", "yaml", "json", "env"]
+
+
+def _generate_toml_literal(value):
+    """Render *value* as a TOML literal (scalars, lists and inline tables)."""
+    if value is None:
+        return '""'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return json.dumps(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_generate_toml_literal(v) for v in value) + "]"
+    if isinstance(value, dict):
+        inner = ", ".join(
+            f"{k} = {_generate_toml_literal(v)}" for k, v in value.items()
+        )
+        return "{" + inner + "}"
+    return json.dumps(str(value))
+
+
+def _generate_render_value(fileformat, value):
+    """Render a single validator default as a literal for *fileformat*."""
+    if value is empty:
+        value = None
+    if fileformat in ("yaml", "json"):
+        # JSON scalars and flow collections are also valid YAML.
+        return json.dumps(prepare_json(value), default=repr)
+    if fileformat == "toml":
+        return _generate_toml_literal(value)
+    # env
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, tuple, dict)):
+        return json.dumps(prepare_json(value), default=repr)
+    return str(value)
+
+
+def _iter_validator_specs(settings):
+    """Yield (name, default, description) for each registered validator name."""
+    seen = set()
+    for validator in settings.validators:
+        names = getattr(validator, "names", ()) or ()
+        default = getattr(validator, "default", empty)
+        description = getattr(validator, "description", None)
+        for name in names:
+            if isinstance(name, tuple) and name:
+                name = name[0]
+            if name in seen:
+                continue
+            seen.add(name)
+            yield name, default, description
+
+
+def _generate_sample(settings, fileformat):
+    """Build a sample settings file from the instance's validators."""
+    specs = list(_iter_validator_specs(settings))
+    if fileformat == "json":
+        data = {
+            str(name): (None if default is empty else default)
+            for name, default, _ in specs
+        }
+        return json.dumps(prepare_json(data), indent=2, default=repr) + "\n"
+
+    if not specs:
+        return "# No validators are registered for this instance.\n"
+
+    lines = []
+    for name, default, description in specs:
+        key = str(name)
+        if description:
+            for line in str(description).splitlines():
+                lines.append(f"# {line}")
+        value = _generate_render_value(fileformat, default)
+        if fileformat == "yaml":
+            lines.append(f"{key}: {value}")
+        elif fileformat == "env":
+            lines.append(f"{key.upper()}={value}")
+        else:  # toml
+            lines.append(f"{key} = {value}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+@main.command()
+@click.option(
+    "--format",
+    "fileformat",
+    "-f",
+    default="toml",
+    type=click.Choice(GENERATE_FORMATS),
+    help="Output format for the sample settings.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(writable=True, dir_okay=False),
+    default=None,
+    help="Write the sample to this file instead of stdout.",
+)
+@click.option(
+    "--env",
+    "-e",
+    default=None,
+    help="Filters the env used to read the registered validators.",
+)
+def generate(fileformat, output, env):
+    """Generate a sample settings file from the registered validators.
+
+    Each registered ``Validator`` becomes an entry using its default value,
+    and its ``description`` (when set) is written as a leading comment.
+
+    Example:
+
+        dynaconf -i config.settings generate -f yaml > settings.sample.yaml
+    """
+    if env:
+        settings.setenv(env.strip())
+
+    content = _generate_sample(settings, fileformat)
+
+    if output:
+        with open(output, "w", encoding=ENC) as sample_file:
+            sample_file.write(content)
+        click.echo(f"Sample settings written to {output}")
+    else:
+        click.echo(content, nl=False)
 
     if env:
         settings.setenv()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 from dynaconf import default_settings
 from dynaconf import LazySettings
+from dynaconf import Validator
 from dynaconf.cli import EXTS
 from dynaconf.cli import main
 from dynaconf.cli import read_file_in_root_directory
@@ -18,6 +19,16 @@ from dynaconf.utils.files import read_file
 from dynaconf.vendor.click.testing import CliRunner
 
 settings = LazySettings(OPTION_FOR_TESTS=True, environments=True)
+
+generate_settings = LazySettings(
+    validators=[
+        Validator("PORT", default=8080, description="The port to bind to"),
+        Validator("HOST", default="localhost", description="Server host name"),
+        Validator("DEBUG", default=False, description="Enable debug mode"),
+        Validator("TAGS", default=["web", "api"], description="Default tags"),
+        Validator("SECRET_KEY", description="Secret key (no default)"),
+    ]
+)
 
 
 def run(cmd, env=None, attr="output"):
@@ -947,3 +958,65 @@ def test_inspect_invalid_format(tmp_path):
     )
 
     assert expected in result
+
+
+GENERATE_INSTANCE = "tests.test_cli.generate_settings"
+
+
+def test_generate_toml_is_the_default_format():
+    result = run(["-i", GENERATE_INSTANCE, "generate"])
+    assert "# The port to bind to" in result
+    assert "PORT = 8080" in result
+    assert 'HOST = "localhost"' in result
+    assert "DEBUG = false" in result
+    # a validator without a default still shows up with its description
+    assert "# Secret key (no default)" in result
+    assert 'SECRET_KEY = ""' in result
+
+
+def test_generate_yaml_format():
+    result = run(["-i", GENERATE_INSTANCE, "generate", "-f", "yaml"])
+    assert "# The port to bind to" in result
+    assert "PORT: 8080" in result
+    assert "SECRET_KEY: null" in result
+
+
+def test_generate_env_format():
+    result = run(["-i", GENERATE_INSTANCE, "generate", "-f", "env"])
+    assert "# Enable debug mode" in result
+    assert "PORT=8080" in result
+    assert "DEBUG=false" in result
+
+
+def test_generate_json_format_is_parseable():
+    result = run(["-i", GENERATE_INSTANCE, "generate", "-f", "json"])
+    data = json.loads(result)
+    assert data["PORT"] == 8080
+    assert data["HOST"] == "localhost"
+    assert data["DEBUG"] is False
+    assert data["TAGS"] == ["web", "api"]
+    assert data["SECRET_KEY"] is None
+
+
+def test_generate_writes_to_output_file(tmp_path):
+    output = tmp_path / "settings.sample.toml"
+    result = run(
+        [
+            "-i",
+            GENERATE_INSTANCE,
+            "generate",
+            "-f",
+            "toml",
+            "-o",
+            str(output),
+        ]
+    )
+    assert f"Sample settings written to {output}" in result
+    content = read_file(str(output))
+    assert "# The port to bind to" in content
+    assert "PORT = 8080" in content
+
+
+def test_generate_without_validators_reports_it():
+    result = run(["-i", "tests.test_cli.settings", "generate"])
+    assert "No validators are registered" in result


### PR DESCRIPTION
This implements the `dynaconf generate` command described in #1272.

It walks the validators registered on an instance and writes a sample settings file where each validator becomes an entry with its default value, and its `description` (when set) is written as a leading comment. The result is a documented template listing every key the app expects.

For example, with:

```python
# config.py
from dynaconf import Dynaconf, Validator

settings = Dynaconf(validators=[
    Validator("PORT", default=8080, description="The port to bind to"),
    Validator("HOST", default="localhost", description="Server host name"),
])
```

`dynaconf -i config.settings generate -f yaml` prints:

```yaml
# The port to bind to
PORT: 8080

# Server host name
HOST: "localhost"
```

The default format is `toml`, and `yaml`, `json` and `env` are supported too. `json` has no comments so descriptions are omitted there. Output goes to stdout by default (so it can be redirected like the RFC example), or to a file with `-o`. Validators without a default still show up with their description and an empty placeholder value.

I added tests in `tests/test_cli.py` for each format plus the `-o` file path and the empty-validators case, and a `dynaconf generate` section in `docs/cli.md`. The full `test_cli` suite passes locally, and ruff/mypy are clean on the changed files.

One thing I intentionally left out for now is the typed (`Annotated`) validators mentioned in the issue note — this covers the classic `Validator(...)` registration. Happy to extend it to typed settings in a follow-up (or here) if you would prefer.