### PR TITLE
fix: keep redis defaults when REDIS_FOR_DYNACONF is a partial dict

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -476,6 +476,10 @@ default = {
 
 ```
 
+A custom `REDIS_FOR_DYNACONF` is merged over these defaults, so passing a
+partial dict (e.g. just `host` and `port`) keeps the remaining keys such as
+`decode_responses`.
+
 ---
 
 ### **root_path**

--- a/dynaconf/loaders/redis_loader.py
+++ b/dynaconf/loaders/redis_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dynaconf.default_settings import default_redis
 from dynaconf.loaders.base import SourceMetadata
 from dynaconf.utils import build_env_list
 from dynaconf.utils import upperfy
@@ -34,7 +35,11 @@ def _get_redis_client(obj):
     redis_url = obj.get("REDIS_URL_FOR_DYNACONF")
     if redis_url:
         return StrictRedis.from_url(redis_url)
-    return StrictRedis(**obj.get("REDIS_FOR_DYNACONF"))
+    # A user supplied REDIS_FOR_DYNACONF may only override a few keys, so
+    # merge it over the internal defaults to keep decode_responses (and the
+    # rest) instead of silently dropping them and getting bytes back.
+    kwargs = {**default_redis, **(obj.get("REDIS_FOR_DYNACONF") or {})}
+    return StrictRedis(**kwargs)
 
 
 def load(obj, env=None, silent=True, key=None, validate=False):

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -9,6 +9,7 @@ import redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from dynaconf import LazySettings
+from dynaconf.loaders.redis_loader import _get_redis_client
 from dynaconf.loaders.redis_loader import delete
 from dynaconf.loaders.redis_loader import load
 from dynaconf.loaders.redis_loader import write
@@ -133,3 +134,24 @@ def test_redis_has_proper_source_metadata(docker_redis):
     )
     assert history[0]["env"] == "development"  # default when environments=True
     assert history[0]["value"]["SECRET"] == "redis_works_perfectly"
+
+
+def test_partial_redis_config_keeps_defaults():
+    # A partial REDIS_FOR_DYNACONF used to drop the internal defaults, so
+    # decode_responses fell back to False and values came back as bytes.
+    settings = LazySettings(
+        REDIS_FOR_DYNACONF={"host": "irrelevant", "port": 1111}
+    )
+    kwargs = _get_redis_client(settings).connection_pool.connection_kwargs
+    assert kwargs["decode_responses"] is True
+    assert kwargs["host"] == "irrelevant"
+    assert kwargs["port"] == 1111
+    assert kwargs["db"] == 0
+
+
+def test_partial_redis_config_user_value_wins():
+    settings = LazySettings(
+        REDIS_FOR_DYNACONF={"host": "irrelevant", "decode_responses": False}
+    )
+    kwargs = _get_redis_client(settings).connection_pool.connection_kwargs
+    assert kwargs["decode_responses"] is False


### PR DESCRIPTION
Closes #702

When `REDIS_FOR_DYNACONF` is passed as a partial dict (just `host` and `port`, say) it replaced the whole internal default, so `decode_responses` was no longer set. Redis then returned bytes and the loader failed with a `TypeError` that gets swallowed by `silent=True`, which is exactly what the reporter hit.

`_get_redis_client` now merges the user dict over `default_redis`, so the keys you leave out keep their defaults and anything you set explicitly still wins.

Added two unit tests in `tests/test_redis.py`. They don't need a redis server since the client connects lazily, so they run in the normal (non integration) lane.
