### PR TITLE
Do not pin a when-validator to the env of the first validate call

### DIFF
--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -278,17 +278,20 @@ class Validator:
         current_env = getattr(settings, "current_env", "main")
         envs = self.envs or [current_env]
 
-        # NOTE: Smells bad, must not mutate a validator
         if self.when is not None:
+            # inherit env if not defined, without pinning it on `when`
+            inherited_envs = self.when.envs is None
             try:
-                # inherit env if not defined
-                if self.when.envs is None:
+                if inherited_envs:
                     self.when.envs = envs
 
                 self.when.validate(settings, only=only, exclude=exclude)
             except ValidationError:
                 # if when is invalid, return canceling validation flow
                 return
+            finally:
+                if inherited_envs:
+                    self.when.envs = None
 
         if only_current_env:
             if current_env.upper() in [s.upper() for s in envs]:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -132,6 +132,27 @@ def test_validators_on_init(tmpdir):
         settings.HOSTNAME
 
 
+def test_when_validator_does_not_retain_inherited_env(tmpdir):
+    # `when` inherits the caller's envs; it must not keep them for later calls.
+    tmpfile = tmpdir.join("settings.toml")
+    tmpfile.write(
+        "[development]\nFEATURE_ON = false\n\n[production]\nFEATURE_ON = true\n"
+    )
+    settings = Dynaconf(environments=True, settings_files=[str(tmpfile)])
+    guard = Validator("FEATURE_ON", eq=True)
+    settings.validators.register(
+        Validator("FEATURE_KEY", must_exist=True, when=guard)
+    )
+
+    settings.setenv("development")
+    settings.validators.validate()
+    assert guard.envs is None
+
+    settings.setenv("production")
+    with pytest.raises(ValidationError):
+        settings.validators.validate()
+
+
 def test_validators_register(tmpdir):
     tmpfile = tmpdir.join("settings.toml")
     tmpfile.write(TOML)


### PR DESCRIPTION
`Validator(when=...)` pins the nested validator to the env of the first `validate()` call, so after
an env switch the guarded check is silently skipped.

The source already flags the smell at `dynaconf/validator.py:281`; this is the consequence:

```python
# NOTE: Smells bad, must not mutate a validator
if self.when is not None:
    try:
        # inherit env if not defined
        if self.when.envs is None:
            self.when.envs = envs          # written, never restored

        self.when.validate(settings, only=only, exclude=exclude)
    except ValidationError:
        return
```

`self.when.envs` stays set. On the next call it is no longer `None`, so it does not re-inherit;
`validate` takes the `for env in envs:` branch at `validator.py:314` and evaluates the guard
against `settings.from_env("development")` — the env from the *first* call. The guard fails there,
the outer validator returns early, and a required key goes unchecked.

### Reproduction

```toml
[development]
FEATURE_ON = false

[production]
FEATURE_ON = true
```

```python
settings = Dynaconf(environments=True, settings_files=["settings.toml"])
guard = Validator("FEATURE_ON", eq=True)
settings.validators.register(Validator("FEATURE_KEY", must_exist=True, when=guard))
```

```
A) fresh object, straight to production        -> ValidationError   (correct)

B) same object, development first, then production
   when.envs after the dev validate = ['DEVELOPMENT']
   env=PRODUCTION  FEATURE_ON=True  FEATURE_KEY exists=False
   -> validate() PASSED                        *** required key never checked ***
```

A is the control: the same config raises when nothing has pinned `when` yet, so the difference is
the earlier `validate()` call, not the settings. Clearing only `guard.envs` restores B to raising,
which isolates that field as the cause.

It needs genuinely per-env values to show up — with `settings.set(...)` the value is visible from
both envs, so the guard passes either way and nothing looks wrong. That is probably why it has gone
unnoticed.

The corrupted validator is not discarded: `ValidatorList` holds registered validators for the
lifetime of the `Settings` object and iterates them on every `validate()`.

### Change

Restore the inherited value in a `finally`, and only when we were the ones who set it — an
explicitly-configured `when.envs` is left alone.

Test added next to the other `when` tests. Verified red/green by reverting only `validator.py`:
it fails on `assert guard.envs is None`. `pytest tests/test_validators.py` goes 50 → 51 passed with
no other change; `ruff format --check` and `ruff check` are clean.

`tests/test_validators.py` exercises `when=` at lines 162, 171, 179, 301 and 304, but never
combines it with an env switch, which is why the seam was uncovered.

---

Disclosure: prepared with AI assistance; I verified the reproduction, the control case, the
red/green runs and the test suite myself.
